### PR TITLE
Bugfix for wait-notify support in presence of lock re-entrance

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -276,7 +276,7 @@ abstract class ManagedStrategy(
             failIfObstructionFreedomIsRequired {
                 // Log the last event that caused obstruction freedom violation
                 traceCollector?.passCodeLocation(tracePoint)
-                "Obstruction-freedom is required but an active lock has been found"
+                ObstructionFreedomSpinLockViolationMessage
             }
             checkLiveLockHappened(loopDetector.totalOperations)
             isLoop = true
@@ -440,7 +440,7 @@ abstract class ManagedStrategy(
         // Try to acquire the monitor
         while (!monitorTracker.acquireMonitor(iThread, monitor)) {
             failIfObstructionFreedomIsRequired {
-                "Obstruction-freedom is required but a lock has been found"
+                ObstructionFreedomLockViolationMessage
             }
             // Switch to another thread and wait for a moment when the monitor can be acquired
             switchCurrentThread(iThread, SwitchReason.LOCK_WAIT, true)
@@ -495,7 +495,7 @@ abstract class ManagedStrategy(
         if (inIgnoredSection(iThread)) return false
         newSwitchPoint(iThread, codeLocation, tracePoint)
         failIfObstructionFreedomIsRequired {
-            "Obstruction-freedom is required but a waiting on a monitor block has been found"
+            ObstructionFreedomWaitViolationMessage
         }
         if (withTimeout) return false // timeouts occur instantly
         while (monitorTracker.waitOnMonitor(iThread, monitor)) {
@@ -941,3 +941,12 @@ internal object ForcibleExecutionFinishException : RuntimeException() {
 }
 
 private const val COROUTINE_SUSPENSION_CODE_LOCATION = -1 // currently the exact place of coroutine suspension is not known
+
+private const val ObstructionFreedomSpinLockViolationMessage =
+    "Obstruction-freedom is required but an active lock has been found"
+
+private const val ObstructionFreedomLockViolationMessage =
+    "Obstruction-freedom is required but a lock has been found"
+
+private const val ObstructionFreedomWaitViolationMessage =
+    "Obstruction-freedom is required but a waiting on a monitor block has been found"

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTest.kt
@@ -32,10 +32,31 @@ class WaitNotifyLockTest : VerifierState() {
     }
 }
 
-private class WaitNotifyLock {
+@ModelCheckingCTest(iterations = 30)
+class NestedWaitNotifyLockTest : VerifierState() {
+    private var counter = 0
+    private val lock = NestedWaitNotifyLock()
+
+    override fun extractState() = counter
+
+    @Operation
+    fun getAndIncrement() = lock.withLock { counter++ }
+
+    @Test
+    fun test() {
+        LinChecker.check(this::class.java)
+    }
+}
+
+private interface SimpleLock {
+    fun lock()
+    fun unlock()
+}
+
+private class WaitNotifyLock : SimpleLock {
     private var owner: Thread? = null
 
-    fun lock() {
+    override fun lock() {
         val thread = Thread.currentThread()
         synchronized(this) {
             while (owner != null) {
@@ -45,7 +66,7 @@ private class WaitNotifyLock {
         }
     }
 
-    fun unlock() {
+    override fun unlock() {
         synchronized(this) {
             owner = null
             (this as Object).notify()
@@ -53,7 +74,32 @@ private class WaitNotifyLock {
     }
 }
 
-private inline fun <T> WaitNotifyLock.withLock(body: () -> T): T {
+private class NestedWaitNotifyLock : SimpleLock {
+    private var owner: Thread? = null
+
+    override fun lock() {
+        val thread = Thread.currentThread()
+        synchronized(this) {
+            synchronized(this) {
+                while (owner != null) {
+                    (this as Object).wait()
+                }
+                owner = thread
+            }
+        }
+    }
+
+    override fun unlock() {
+        synchronized(this) {
+            synchronized(this) {
+                owner = null
+                (this as Object).notify()
+            }
+        }
+    }
+}
+
+private inline fun <T> SimpleLock.withLock(body: () -> T): T {
     try {
         lock()
         return body()

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTests.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelChecki
 import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
 import org.junit.Test
 
+// tests wait/notify support in model checking strategy
 @ModelCheckingCTest(iterations = 30)
 class WaitNotifyLockTest : VerifierState() {
     private var counter = 0
@@ -32,6 +33,7 @@ class WaitNotifyLockTest : VerifierState() {
     }
 }
 
+// tests wait/notify support under lock re-entrance in model checking strategy
 @ModelCheckingCTest(iterations = 30)
 class NestedWaitNotifyLockTest : VerifierState() {
     private var counter = 0

--- a/src/jvm/test/resources/expected_logs/obstruction_freedom_synchronized.txt
+++ b/src/jvm/test/resources/expected_logs/obstruction_freedom_synchronized.txt
@@ -1,4 +1,4 @@
-= Obstruction-freedom is required but a lock has been found =
+= The algorithm should be non-blocking, but a lock is detected =
 Execution scenario (parallel part):
 | operation() | operation() |
 


### PR DESCRIPTION
In current implementation of `MonitorTracker` in model checking strategy, the monitor re-entrance information is lost when thread performs `wait` operation on some object. Thus upon wake-up the model checker just re-acquires a monitor once, but does not restore previous monitor re-entrance counter. This leads to a bug (see the new test added in this PR).

This PR fixes this problem by saving the information about lock re-entrance and then correctly restoring it.   