### PR TITLE
ParameterGenerator Formal Contract

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/BooleanGen.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/BooleanGen.kt
@@ -23,7 +23,7 @@ package org.jetbrains.kotlinx.lincheck.paramgen
 import org.jetbrains.kotlinx.lincheck.RandomProvider
 
 
-class BooleanGen(randomProvider: RandomProvider, configuration: String) : ParameterGenerator<Boolean> {
+class BooleanGen(randomProvider: RandomProvider, configuration: String) : ParameterGenerator<Boolean>(randomProvider, configuration) {
     private val random = randomProvider.createRandom()
 
     override fun generate() = random.nextBoolean()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ByteGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ByteGen.java
@@ -24,11 +24,12 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class ByteGen implements ParameterGenerator<Byte> {
+public class ByteGen extends ParameterGenerator<Byte> {
 
     private final ExpandingRangeIntGenerator generator;
 
     public ByteGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         generator = ExpandingRangeIntGenerator.create(randomProvider.createRandom(), configuration, Byte.MIN_VALUE, Byte.MAX_VALUE, "byte");
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/DoubleGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/DoubleGen.java
@@ -24,7 +24,7 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class DoubleGen implements ParameterGenerator<Double> {
+public class DoubleGen extends ParameterGenerator<Double> {
     private static final float DEFAULT_STEP = 0.1f;
     private static final float DEFAULT_BEGIN = -10f;
     private static final float DEFAULT_END = 10f;
@@ -34,6 +34,7 @@ public class DoubleGen implements ParameterGenerator<Double> {
     private final double begin;
 
     public DoubleGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         double begin;
         double end;
         double step = 0.0;

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/FloatGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/FloatGen.java
@@ -24,10 +24,11 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class FloatGen implements ParameterGenerator<Float> {
+public class FloatGen extends ParameterGenerator<Float> {
     private final DoubleGen doubleGen;
 
     public FloatGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         doubleGen = new DoubleGen(randomProvider, configuration);
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/IntGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/IntGen.java
@@ -25,11 +25,12 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class IntGen implements ParameterGenerator<Integer> {
+public class IntGen extends ParameterGenerator<Integer> {
 
     private final ExpandingRangeIntGenerator generator;
 
     public IntGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         generator = ExpandingRangeIntGenerator.create(randomProvider.createRandom(), configuration, Integer.MIN_VALUE, Integer.MAX_VALUE, "int");
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/LongGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/LongGen.java
@@ -24,10 +24,11 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class LongGen implements ParameterGenerator<Long> {
+public class LongGen extends ParameterGenerator<Long> {
     private final IntGen intGen;
 
     public LongGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         intGen = new IntGen(randomProvider, configuration);
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ParameterGenerator.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ParameterGenerator.java
@@ -22,16 +22,29 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
  * #L%
  */
 
+import org.jetbrains.kotlinx.lincheck.RandomProvider;
 import org.jetbrains.kotlinx.lincheck.annotations.Operation;
 
 /**
  * The implementation of this interface is used to generate parameters
  * for {@link Operation operation}.
   */
-public interface ParameterGenerator<T> {
-    T generate();
+public abstract class ParameterGenerator<T> {
+    protected final RandomProvider randomProvider;
+    protected final String configuration;
 
-    final class Dummy implements ParameterGenerator<Object> {
+    public ParameterGenerator(RandomProvider randomProvider, String configuration) {
+        this.randomProvider = randomProvider;
+        this.configuration = configuration;
+    }
+
+    public abstract T generate();
+
+    public static final class Dummy extends ParameterGenerator<Object> {
+        public Dummy(RandomProvider randomProvider, String configuration) {
+            super(randomProvider, configuration);
+        }
+
         @Override
         public Object generate() {
             throw new UnsupportedOperationException();

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ShortGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ShortGen.java
@@ -24,10 +24,11 @@ package org.jetbrains.kotlinx.lincheck.paramgen;
 
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-public class ShortGen implements ParameterGenerator<Short> {
+public class ShortGen extends ParameterGenerator<Short> {
     private final ExpandingRangeIntGenerator generator;
 
     public ShortGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         generator = ExpandingRangeIntGenerator.create(randomProvider.createRandom(), configuration, Byte.MIN_VALUE, Byte.MAX_VALUE, "byte");
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/StringGen.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/StringGen.java
@@ -26,7 +26,7 @@ import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
 import java.util.Random;
 
-public class StringGen implements ParameterGenerator<String> {
+public class StringGen extends ParameterGenerator<String> {
     private static final int DEFAULT_MAX_WORD_LENGTH = 15;
     private static final String DEFAULT_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ";
 
@@ -36,6 +36,7 @@ public class StringGen implements ParameterGenerator<String> {
     private int currentWordLength = 1;
 
     public StringGen(RandomProvider randomProvider, String configuration) {
+        super(randomProvider, configuration);
         random = randomProvider.createRandom();
         if (configuration.isEmpty()) { // use default configuration
             maxWordLength = DEFAULT_MAX_WORD_LENGTH;

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ThreadIdGen.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/paramgen/ThreadIdGen.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlinx.lincheck.RandomProvider
  *
  * Note, that this API is unstable and is subject to change.
  */
-class ThreadIdGen(randomProvider: RandomProvider, configuration: String) : ParameterGenerator<Any> {
+class ThreadIdGen(randomProvider: RandomProvider, configuration: String) : ParameterGenerator<Any>(randomProvider, configuration) {
     override fun generate() = THREAD_ID_TOKEN
 }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/SerializableValueTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/SerializableValueTests.kt
@@ -128,7 +128,7 @@ class SerializableParameterIncorrectTest : AbstractLincheckTest(IncorrectResults
     }
 }
 
-class ValueHolderGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<ValueHolder> {
+class ValueHolderGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<ValueHolder>(randomProvider, conf) {
     override fun generate(): ValueHolder {
         return listOf(ValueHolder(1), ValueHolder(2)).random()
     }
@@ -148,7 +148,7 @@ class SerializableJavaUtilParameterTest : AbstractLincheckTest() {
     }
 }
 
-class JavaUtilGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<List<Int>> {
+class JavaUtilGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<List<Int>>(randomProvider, conf) {
     override fun generate() = listOf(1, 2)
 }
 
@@ -168,6 +168,6 @@ class SerializableNullParameterTest : AbstractLincheckTest() {
     }
 }
 
-class NullGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<List<Int>?> {
+class NullGen(randomProvider: RandomProvider, conf: String) : ParameterGenerator<List<Int>?>(randomProvider, conf) {
     override fun generate() = null
 }


### PR DESCRIPTION
Makes the implicit constructor contract for implementations of ParameterGenerator explicit. This addresses issue #176