### PR TITLE
Fix a race in FixedActiveThreadsExecutor

### DIFF
--- a/src/jvm/test/resources/expected_logs/illegal_module_access.txt
+++ b/src/jvm/test/resources/expected_logs/illegal_module_access.txt
@@ -12,7 +12,7 @@ Please add the following lines to your test running configuration:
 	at org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategyRunner.onFailure(ManagedStrategy.kt:736)
 	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution.failOnExceptionIsUnexpected(TestThreadExecution.java:52)
 	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution229.run(Unknown Source)
-	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda-4(FixedActiveThreadsExecutor.kt:125)
+	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda-4(FixedActiveThreadsExecutor.kt:129)
 	at java.base/java.lang.Thread.run(Thread.java:829)
 Caused by: java.lang.IllegalAccessException: module java.base does not "opens java.io" to unnamed module
 	at org.jetbrains.kotlinx.lincheck_test.representation.IllegalModuleAccessOutputMessageTest$operation$1.invoke(IllegalModuleAccessOutputMessageTest.kt:37)

--- a/src/jvm/test/resources/expected_logs/internal_bug_report.txt
+++ b/src/jvm/test/resources/expected_logs/internal_bug_report.txt
@@ -7,5 +7,5 @@ java.lang.IllegalStateException: Internal bug
 	at org.jetbrains.kotlinx.lincheck.util.InternalLincheckExceptionEmulator.throwException(InternalLincheckExceptionEmulator.kt:23)
 	at org.jetbrains.kotlinx.lincheck_test.representation.InternalLincheckBugTest.operation2(InternalLincheckBugTest.kt:36)
 	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution304.run(Unknown Source)
-	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda-4(FixedActiveThreadsExecutor.kt:125)
+	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda-4(FixedActiveThreadsExecutor.kt:129)
 	at java.base/java.lang.Thread.run(Thread.java:829)


### PR DESCRIPTION
There is a race in `FixedActuveThreadsExecutor` that may lead to a hang. This PR fixes the race and, hopefully, should also fix #194.