### PR TITLE
Optimize synchronization when the number of threads exceeds the number of cores

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -207,7 +207,11 @@ internal open class ParallelThreadsRunner(
                 suspensionPointResults[iThread][actorId] = NoResult
                 return Suspended
             }
-            if (i++ % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0) Thread.yield()
+            // Do not call `yield()` until necessary. However, if the number of threads
+            // exceed the number of cores, it is better to call `yield` immediately to avoid starvation.
+            if (i++ % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0 || executor.numberOfThreadsExceedAvailableProcessors){
+                Thread.yield()
+            }
         }
         // Coroutine will be resumed. Call method so that strategy can learn it.
         afterCoroutineResumed(iThread)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/IllegalModuleAccessOutputMessageTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/IllegalModuleAccessOutputMessageTest.kt
@@ -11,12 +11,12 @@
 package org.jetbrains.kotlinx.lincheck_test.representation
 
 import kotlinx.atomicfu.*
-import org.jetbrains.kotlinx.lincheck.annotations.Operation
-import org.jetbrains.kotlinx.lincheck.checkImpl
-import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.annotations.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.util.InternalLincheckExceptionEmulator.throwException
 import org.jetbrains.kotlinx.lincheck_test.util.*
-import org.junit.Test
+import org.junit.*
 
 /**
  * This test checks that hint about classes not accessible from unnamed modules
@@ -43,8 +43,5 @@ class IllegalModuleAccessOutputMessageTest {
     @Test
     fun test() = ModelCheckingOptions()
         .checkImpl(this::class.java)
-        .checkLincheckOutput("illegal_module_access.txt",
-            linesToRemoveRegex = TEST_EXECUTION_TRACE_ELEMENT_REGEX
-        )
-
+        .checkLincheckOutput("illegal_module_access.txt")
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InternalLincheckBugTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InternalLincheckBugTest.kt
@@ -10,12 +10,12 @@
 
 package org.jetbrains.kotlinx.lincheck_test.representation
 
-import org.jetbrains.kotlinx.lincheck.annotations.Operation
-import org.jetbrains.kotlinx.lincheck.checkImpl
-import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.annotations.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.util.InternalLincheckExceptionEmulator.throwException
 import org.jetbrains.kotlinx.lincheck_test.util.*
-import org.junit.Test
+import org.junit.*
 
 /**
  * This test checks that if exception is thrown from the Lincheck itself, it will be reported properly.
@@ -43,8 +43,5 @@ class InternalLincheckBugTest {
         actorsPerThread(2)
     }
         .checkImpl(this::class.java)
-        .checkLincheckOutput("internal_bug_report.txt",
-            linesToRemoveRegex = TEST_EXECUTION_TRACE_ELEMENT_REGEX,
-        )
-
+        .checkLincheckOutput("internal_bug_report.txt")
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
@@ -11,48 +11,45 @@
 package org.jetbrains.kotlinx.lincheck_test.util
 
 import org.jetbrains.kotlinx.lincheck.*
-import org.jetbrains.kotlinx.lincheck.strategy.LincheckFailure
-import org.jetbrains.kotlinx.lincheck.verifier.LTS
+import org.jetbrains.kotlinx.lincheck.strategy.*
+import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.Assert.*
 
 /**
  * Checks that failure output matches the expected one stored in a file.
  *
- * @receiver checked failure.
  * @param expectedOutputFile name of file stored in resources/expected_logs, storing the expected lincheck output.
- * @param linesToRemoveRegex regex to filter expected and actual output to remove test suite-dependent lines
  */
-internal fun LincheckFailure?.checkLincheckOutput(expectedOutputFile: String, linesToRemoveRegex: Regex? = null) {
-    // val modelCheckingOptions = ModelCheckingOptions()
-    // testConfiguration(modelCheckingOptions)
-    // val failure = modelCheckingOptions.checkImpl(this::class.java)
+internal fun LincheckFailure?.checkLincheckOutput(expectedOutputFile: String) {
     check(this != null) { "The test should fail" }
 
     val actualOutput = StringBuilder().appendFailure(this).toString()
-    val actualOutputLines = actualOutput.getLines(linesToRemoveRegex)
     val expectedOutput = getExpectedLogFromResources(expectedOutputFile)
-    val expectedOutputLines = expectedOutput.getLines(linesToRemoveRegex)
 
-    expectedOutputLines.zip(actualOutputLines).forEachIndexed { index, (expectedLine, actualLine) ->
-        assertValuesEqualsAndPrintAllOutputsIfFailed(
-            expectedValue = expectedLine,
-            actualValue = actualLine,
-            expectedOutput = expectedOutput,
-            actualOutput = actualOutput
-        ) { "Expected output doesn't match actual at line number: ${index + 1}" }
+    if (actualOutput.filtered != expectedOutput.filtered) {
+        assertEquals(actualOutput, expectedOutput)
     }
-
-    assertValuesEqualsAndPrintAllOutputsIfFailed(
-        expectedValue = expectedOutputLines.size,
-        actualValue = actualOutputLines.size,
-        expectedOutput = expectedOutput,
-        actualOutput = actualOutput
-    ) { "Expected output size doesn't match actual" }
 }
 
-private fun String.getLines(filterRegex: Regex?): List<String> {
-    return filterRegex?.let {  lines().filter { !it.matches(filterRegex) } } ?: lines()
+private val String.filtered: String get() {
+    // Remove platform-specific lines
+    var filtered = lines().filter {
+        !it.matches(TEST_EXECUTION_TRACE_ELEMENT_REGEX)
+    }.joinToString("\n")
+    // Remove line numbers
+    filtered = filtered.replace(LINE_NUMBER_REGEX, "")
+    return filtered
 }
+
+// removing the following lines from the trace (because they may vary):
+// - pattern `org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution(\d+)` (the number of thread may vary)
+// - everything from `java.base/` (because code locations may vary between different versions of JVM)
+private val TEST_EXECUTION_TRACE_ELEMENT_REGEX = listOf(
+    "(\\W*)at org\\.jetbrains\\.kotlinx\\.lincheck\\.runner\\.TestThreadExecution(\\d+)\\.run\\(Unknown Source\\)",
+    "(\\W*)at java.base\\/(.*)"
+).joinToString(separator = ")|(", prefix = "(", postfix = ")").toRegex()
+
+private val LINE_NUMBER_REGEX = Regex(":(\\d+)\\)")
 
 private fun assertValuesEqualsAndPrintAllOutputsIfFailed(
     expectedValue: Any,
@@ -91,14 +88,6 @@ internal fun getExpectedLogFromResources(testFileName: String): String {
 
     return expectedLogResource.reader().readText()
 }
-
-// removing the following lines from the trace (because they may vary):
-// - pattern `org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution(\d+)` (the number of thread may vary)
-// - everything from `java.base/` (because code locations may vary between different versions of JVM)
-internal val TEST_EXECUTION_TRACE_ELEMENT_REGEX = listOf(
-    "(\\W*)at org\\.jetbrains\\.kotlinx\\.lincheck\\.runner\\.TestThreadExecution(\\d+)\\.run\\(Unknown Source\\)",
-    "(\\W*)at java.base\\/(.*)"
-).joinToString(separator = ")|(", prefix = "(", postfix = ")").toRegex()
 
 fun checkTraceHasNoLincheckEvents(trace: String) {
     val testPackageOccurrences = trace.split("org.jetbrains.kotlinx.lincheck_test.").size - 1

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
@@ -51,36 +51,6 @@ private val TEST_EXECUTION_TRACE_ELEMENT_REGEX = listOf(
 
 private val LINE_NUMBER_REGEX = Regex(":(\\d+)\\)")
 
-private fun assertValuesEqualsAndPrintAllOutputsIfFailed(
-    expectedValue: Any,
-    actualValue: Any,
-    expectedOutput: String,
-    actualOutput: String,
-    messageSupplier: () -> String
-) {
-    if (expectedValue != actualValue) {
-        fail(
-            // Multiline string is not used here as to .trimIndent function considers lincheck indents and makes ugly output
-            buildString {
-                appendLine(messageSupplier())
-
-                appendLine()
-                appendLine("Expected:")
-                appendLine(expectedValue)
-                appendLine("Actual:")
-                appendLine(actualValue)
-
-                appendLine()
-                appendLine("Expected full output:")
-                appendLine(expectedOutput)
-                appendLine()
-                appendLine("Actual full output:")
-                appendLine(actualOutput)
-            }
-        )
-    }
-}
-
 internal fun getExpectedLogFromResources(testFileName: String): String {
     val resourceName = "expected_logs/$testFileName"
     val expectedLogResource = LTS::class.java.classLoader.getResourceAsStream(resourceName)


### PR DESCRIPTION
After #173, `Thread.yield()` and `park()` are called after spinning for a long time. However, this strategy may lead to starvation when the number of parallel threads exceeds the number of cores. As this is a rare case, we can call `yield()` and `park()` immediately on such hardware. 