### PR TITLE
Fix representation of empty traces

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -743,10 +743,6 @@ abstract class ManagedStrategy(
             _trace.add(spinCycleStartPosition, spinCycleStartTracePoint)
         }
 
-        fun finishThread(iThread: Int) {
-            _trace += FinishThreadTracePoint(iThread)
-        }
-
         fun passCodeLocation(tracePoint: TracePoint?) {
             // tracePoint can be null here if trace is not available, e.g. in case of suspension
             if (tracePoint != null) _trace += tracePoint

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -67,10 +67,6 @@ internal class StateRepresentationTracePoint(
     override fun toStringImpl(): String = "STATE: $stateRepresentation"
 }
 
-internal class FinishThreadTracePoint(iThread: Int) : TracePoint(iThread, Int.MAX_VALUE, emptyList()) {
-    override fun toStringImpl(): String = "thread is finished"
-}
-
 /**
  * This TracePoint is added only at the end of an execution when obstruction freedom is violated
  */

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -123,17 +123,16 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
             val nextActor = ++lastHandledActor[iThread]
             // create new actor node actor
             val actorNode = traceGraphNodes.createAndAppend { lastNode ->
-                val result = results[iThread, nextActor]
                 ActorNode(
                     iThread = iThread,
                     last = lastNode,
                     callDepth = 0,
                     actor = scenario.threads[iThread][nextActor],
-                    resultRepresentation = result?.let { actorNodeResultRepresentation(result, exceptionStackTraces) }
+                    resultRepresentation = results[iThread, nextActor]
+                        ?.let { actorNodeResultRepresentation(it, exceptionStackTraces) }
                 )
             }
             actorNodes[iThread][nextActor] = actorNode
-            traceGraphNodes.add(actorNode)
         }
         // add the event
         var innerNode: TraceInnerNode = actorNodes[iThread][actorId]!!
@@ -159,19 +158,36 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
         innerNode.addInternalEvent(node)
     }
     // add an ActorResultNode to each actor, because did not know where actor ends before
-    for (iThread in actorNodes.indices)
+    for (iThread in actorNodes.indices) {
         for (actorId in actorNodes[iThread].indices) {
-            actorNodes[iThread][actorId]?.let {
-                // insert an ActorResultNode between the last actor event and the next event after it
-                val lastEvent = it.lastInternalEvent
-                val lastEventNext = lastEvent.next
-                val result = results[iThread, actorId]
-                val resultRepresentation = result?.let { resultRepresentation(result, exceptionStackTraces) }
-                val resultNode = ActorResultNode(iThread, lastEvent, it.callDepth + 1, resultRepresentation)
-                it.addInternalEvent(resultNode)
-                resultNode.next = lastEventNext
+            var actorNode = actorNodes[iThread][actorId]
+            val actorResult = results[iThread, actorId]
+            // in case of empty trace, we want to show at least the actor nodes themselves;
+            // however, no actor nodes will be created by the code above, so we need to create them explicitly here.
+            if (actorNode == null && actorResult != null) {
+                val lastNode = actorNodes[iThread].getOrNull(actorId - 1)?.lastInternalEvent
+                actorNode = ActorNode(
+                    iThread = iThread,
+                    last = lastNode,
+                    callDepth = 0,
+                    actor = scenario.threads[iThread][actorId],
+                    resultRepresentation = actorNodeResultRepresentation(actorResult, exceptionStackTraces)
+                )
+                actorNodes[iThread][actorId] = actorNode
+                traceGraphNodes.add(actorNode)
             }
+            if (actorNode == null)
+                continue
+            // insert an ActorResultNode between the last actor event and the next event after it
+            val lastEvent = actorNode.lastInternalEvent
+            val lastEventNext = lastEvent.next
+            val result = results[iThread, actorId]
+            val resultRepresentation = result?.let { resultRepresentation(result, exceptionStackTraces) }
+            val resultNode = ActorResultNode(iThread, lastEvent, actorNode.callDepth + 1, resultRepresentation)
+            actorNode.addInternalEvent(resultNode)
+            resultNode.next = lastEventNext
         }
+    }
     return traceGraphNodes.firstOrNull()
 }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/TraceReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/TraceReportingTest.kt
@@ -117,4 +117,30 @@ class TraceReportingTest {
         failure.checkLincheckOutput("trace_reporting_init_post_parts.txt")
         checkTraceHasNoLincheckEvents(failure.toString())
     }
+
+    @Operation
+    fun notImplemented() {
+        TODO()
+    }
+
+    @Test
+    fun testEmptyTrace() {
+        val failure = ModelCheckingOptions()
+            .iterations(0)
+            .addCustomScenario {
+                parallel {
+                    thread {
+                        actor(::notImplemented)
+                    }
+                }
+            }
+            .sequentialSpecification(EmptySequentialImplementation::class.java)
+            .checkImpl(this::class.java)
+        failure.checkLincheckOutput("trace_reporting_empty.txt")
+    }
+
+    class EmptySequentialImplementation {
+        fun notImplemented() {}
+    }
+
 }

--- a/src/jvm/test/resources/expected_logs/spin_lock_in_incorrect_results_failure.txt
+++ b/src/jvm/test/resources/expected_logs/spin_lock_in_incorrect_results_failure.txt
@@ -23,6 +23,7 @@ The following interleaving leads to the error:
 | b()      |                                                                                                     |
 |          |   bStarted.READ: true at SpinlockInIncorrectResultsWithClocksTest.c(SpinlockEventsCutTests.kt:190)  |
 |          |   result: void                                                                                      |
+|          | d(): 0                                                                                              |
 | -------------------------------------------------------------------------------------------------------------- |
 
 Detailed trace:
@@ -39,4 +40,5 @@ Detailed trace:
 |   result: void                                                                                      |                                                                                                     |
 |                                                                                                     |   bStarted.READ: true at SpinlockInIncorrectResultsWithClocksTest.c(SpinlockEventsCutTests.kt:190)  |
 |                                                                                                     |   result: void                                                                                      |
+|                                                                                                     | d(): 0                                                                                              |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/jvm/test/resources/expected_logs/trace_reporting_empty.txt
+++ b/src/jvm/test/resources/expected_logs/trace_reporting_empty.txt
@@ -1,0 +1,28 @@
+= Invalid execution results =
+| ---------------------------------------- |
+|                 Thread 1                 |
+| ---------------------------------------- |
+| notImplemented(): NotImplementedError #1 |
+| ---------------------------------------- |
+
+---
+The number next to an exception name helps you find its stack trace provided after the interleaving section
+---
+
+The following interleaving leads to the error:
+| ---------------------------------------- |
+|                 Thread 1                 |
+| ---------------------------------------- |
+| notImplemented(): NotImplementedError #1 |
+| ---------------------------------------- |
+
+Exception stack traces:
+#1: kotlin.NotImplementedError
+	at org.jetbrains.kotlinx.lincheck_test.representation.TraceReportingTest.notImplemented(TraceReportingTest.kt:123)
+
+Detailed trace:
+| ---------------------------------------- |
+|                 Thread 1                 |
+| ---------------------------------------- |
+| notImplemented(): NotImplementedError #1 |
+| ---------------------------------------- |


### PR DESCRIPTION
Currently, empty execution trace is printed incorrectly by the tool as an empty string. 
This PR fixes this. It ensures that at least the executed actors (with their results) are always printed, event if the execution trace does not have any interesting trace points. 