### PR TITLE
Clocks representation fix when initial executions are present

### DIFF
--- a/src/jvm/test/resources/expected_logs/clocks_and_exceptions.txt
+++ b/src/jvm/test/resources/expected_logs/clocks_and_exceptions.txt
@@ -8,8 +8,8 @@
 | operation2(): void       |                                              |
 | operation2(): void       |                                              |
 | ----------------------------------------------------------------------- |
-| operation1(): void       | operation2(): IllegalStateException #1 [1,0] |
-| operation1(): void [1,0] | operation1(): void [1,1]                     |
+| operation1(): void [5,0] | operation2(): IllegalStateException #1 [6,0] |
+| operation1(): void [6,0] | operation1(): void [6,1]                     |
 | ----------------------------------------------------------------------- |
 | operation1(): void       |                                              |
 | operation1(): void       |                                              |

--- a/src/jvm/test/resources/expected_logs/trace_reporting_init_post_parts.txt
+++ b/src/jvm/test/resources/expected_logs/trace_reporting_init_post_parts.txt
@@ -1,16 +1,19 @@
 = Invalid execution results =
-| ------------------------------- |
-|     Thread 1      |  Thread 2   |
-| ------------------------------- |
-| enterInit(): void |             |
-| ------------------------------- |
-| foo(): 1          | bar(): void |
-| ------------------------------- |
-| enterPost(): void |             |
-| ------------------------------- |
+| ------------------------------------- |
+|     Thread 1      |     Thread 2      |
+| ------------------------------------- |
+| enterInit(): void |                   |
+| ------------------------------------- |
+| foo(): 1 [1,0]    | bar(): void [1,0] |
+| ------------------------------------- |
+| enterPost(): void |                   |
+| ------------------------------------- |
 
 ---
 All operations above the horizontal line | ----- | happen before those below the line
+---
+Values in "[..]" brackets indicate the number of completed operations
+in each of the parallel threads seen at the beginning of the current operation
 ---
 
 The following interleaving leads to the error:


### PR DESCRIPTION
When scenario has initial part, clocks doesn't reflect them, considering only operations in the parallel part.