### PR TITLE
Bytecode instrumentation cache

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
@@ -30,9 +30,13 @@ abstract class Runner protected constructor(
 ) : Closeable {
     protected var scenario = strategy.scenario // `strategy.scenario` will be transformed in `initialize`
     protected lateinit var testClass: Class<*> // not available before `initialize` call
+
     @Suppress("LeakingThis")
-    val classLoader: ExecutionClassLoader = if (needsTransformation() || strategy.needsTransformation()) TransformationClassLoader(strategy, this)
-                                            else ExecutionClassLoader()
+    val classLoader: ExecutionClassLoader =
+        if (needsTransformation() || strategy.needsTransformation())
+            TransformationClassLoader(strategy, this)
+        else ExecutionClassLoader()
+
     protected val completedOrSuspendedThreads = AtomicInteger(0)
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -126,8 +126,7 @@ abstract class ManagedStrategy(
     override fun needsTransformation(): Boolean = true
 
     fun useBytecodeCache(): Boolean =
-        (!collectTrace) && testCfg.eliminateLocalObjects
-                && (testCfg.guarantees == ManagedCTestConfiguration.DEFAULT_GUARANTEES)
+        !collectTrace && testCfg.eliminateLocalObjects && (testCfg.guarantees == ManagedCTestConfiguration.DEFAULT_GUARANTEES)
 
     override fun run(): LincheckFailure? = runImpl().also { close() }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -43,9 +43,13 @@ abstract class ManagedStrategy(
     // Runner for scenario invocations,
     // can be replaced with a new one for trace construction.
     private var runner: ManagedStrategyRunner
-    // Shares location ids between class transformers in order
-    // to keep them different in different code locations.
-    private val codeLocationIdProvider = CodeLocationIdProvider()
+
+    companion object {
+        // Shares location ids between class transformers in order
+        // to keep them different in different code locations.
+        // TODO: global code location ID counter can potentially overflow --- handle this situation
+        private val codeLocationIdProvider = CodeLocationIdProvider()
+    }
 
     // == EXECUTION CONTROL FIELDS ==
 
@@ -120,6 +124,10 @@ abstract class ManagedStrategy(
     )
 
     override fun needsTransformation(): Boolean = true
+
+    fun useBytecodeCache(): Boolean =
+        (!collectTrace) && testCfg.eliminateLocalObjects
+                && (testCfg.guarantees == ManagedCTestConfiguration.DEFAULT_GUARANTEES)
 
     override fun run(): LincheckFailure? = runImpl().also { close() }
 


### PR DESCRIPTION
Currently bytecode instrumentation can take significant time. Moreover, it is performed for each scenario even when testing the same data structure. 

In the context of the adaptive planning feature #158, instrumentation time can interfere with the invocations time, thus making it harder to get reliable prediction for the average invocation time. 

This PR provides simple instrumented bytecode caching, thus mitigating the performance overhead of instrumentation. 