### PR TITLE
Specialized collections with package remapping 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     kotlin("multiplatform")
     id("maven-publish")
     id("kotlinx.team.infra") version "0.3.0-dev-64"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 repositories {
@@ -44,6 +45,8 @@ kotlin {
             val kotlinxCoroutinesVersion: String by project
             val asmVersion: String by project
             val reflectionsVersion: String by project
+            val fastUtilVersion: String by project
+
             dependencies {
                 api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
                 api("org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion")
@@ -52,6 +55,7 @@ kotlin {
                 api("org.ow2.asm:asm-commons:$asmVersion")
                 api("org.ow2.asm:asm-util:$asmVersion")
                 api("org.reflections:reflections:$reflectionsVersion")
+                api("it.unimi.dsi:fastutil:$fastUtilVersion")
             }
         }
 
@@ -73,6 +77,10 @@ kotlin {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.shadowJar {
+    relocate("it.unimi.dsi.fastutil", "org.jetbrains.kotlinx.lincheck.collections")
 }
 
 sourceSets.main {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ kotlinxCoroutinesVersion=1.6.4
 asmVersion=9.4
 atomicfuVersion=0.17.3
 reflectionsVersion=0.9.12
+fastUtilVersion=8.5.12
 
 junitVersion=4.13.1
 jctoolsVersion=3.3.0

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
@@ -10,7 +10,6 @@
 
 package org.jetbrains.kotlinx.lincheck;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.kotlinx.lincheck.annotations.*;
 import org.jetbrains.kotlinx.lincheck.execution.*;
@@ -22,6 +21,8 @@ import java.util.*;
 import java.util.stream.*;
 
 import static org.jetbrains.kotlinx.lincheck.ActorKt.*;
+import static org.jetbrains.kotlinx.lincheck.CollectionsUtilsKt.lincheckListOf;
+import static org.jetbrains.kotlinx.lincheck.CollectionsUtilsKt.lincheckMapOf;
 
 /**
  * Contains information about the provided operations (see {@link Operation}).
@@ -51,13 +52,13 @@ public class CTestStructure {
      * Constructs {@link CTestStructure} for the specified test class.
      */
     public static CTestStructure getFromTestClass(Class<?> testClass) {
-        Map<String, OperationGroup> groupConfigs = new Object2ObjectOpenHashMap<>();
-        List<ActorGenerator> actorGenerators = new ObjectArrayList<>();
-        List<Method> validationFunctions = new ObjectArrayList<>();
-        List<Method> stateRepresentations = new ObjectArrayList<>();
+        Map<String, OperationGroup> groupConfigs = lincheckMapOf();
+        List<ActorGenerator> actorGenerators = lincheckListOf();
+        List<Method> validationFunctions = lincheckListOf();
+        List<Method> stateRepresentations = lincheckListOf();
         Class<?> clazz = testClass;
         RandomProvider randomProvider = new RandomProvider();
-        Map<Class<?>, ParameterGenerator<?>> parameterGeneratorsMap = new Object2ObjectOpenHashMap<>();
+        Map<Class<?>, ParameterGenerator<?>> parameterGeneratorsMap = lincheckMapOf();
 
         while (clazz != null) {
             readTestStructureFromClass(clazz, groupConfigs, actorGenerators, parameterGeneratorsMap, validationFunctions, stateRepresentations, randomProvider);
@@ -150,7 +151,7 @@ public class CTestStructure {
     }
 
     private static Map<String, ParameterGenerator<?>> createNamedGens(Class<?> clazz, RandomProvider randomProvider) {
-        Map<String, ParameterGenerator<?>> namedGens = new Object2ObjectOpenHashMap<>();
+        Map<String, ParameterGenerator<?>> namedGens = lincheckMapOf();
         // Traverse all operations to determine named EnumGens types
         // or throw if one named enum gen is associated with many types
         Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = collectNamedEnumGeneratorToClassMap(clazz);
@@ -183,7 +184,7 @@ public class CTestStructure {
      *                               which violates the uniqueness principle of enum generator to enum class mapping.
      */
     private static Map<String, Class<? extends Enum<?>>> collectNamedEnumGeneratorToClassMap(Class<?> clazz) {
-        Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = new Object2ObjectOpenHashMap<>();
+        Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = lincheckMapOf();
 
         Arrays.stream(clazz.getDeclaredMethods()) // get all methods of the class
                 .filter(method -> method.isAnnotationPresent(Operation.class)) // take methods, annotated as @Operation
@@ -283,7 +284,7 @@ public class CTestStructure {
     }
 
     private static Map<Class<?>, ParameterGenerator<?>> createDefaultGenerators(RandomProvider randomProvider) {
-        Map<Class<?>, ParameterGenerator<?>> defaultGens = new Object2ObjectOpenHashMap<>();
+        Map<Class<?>, ParameterGenerator<?>> defaultGens = lincheckMapOf();
         defaultGens.put(boolean.class, new BooleanGen(randomProvider, ""));
         defaultGens.put(Boolean.class, defaultGens.get(boolean.class));
         defaultGens.put(byte.class, new ByteGen(randomProvider, ""));

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
@@ -10,6 +10,8 @@
 
 package org.jetbrains.kotlinx.lincheck;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.kotlinx.lincheck.annotations.*;
 import org.jetbrains.kotlinx.lincheck.execution.*;
 import org.jetbrains.kotlinx.lincheck.paramgen.*;
@@ -49,13 +51,13 @@ public class CTestStructure {
      * Constructs {@link CTestStructure} for the specified test class.
      */
     public static CTestStructure getFromTestClass(Class<?> testClass) {
-        Map<String, OperationGroup> groupConfigs = new HashMap<>();
-        List<ActorGenerator> actorGenerators = new ArrayList<>();
-        List<Method> validationFunctions = new ArrayList<>();
-        List<Method> stateRepresentations = new ArrayList<>();
+        Map<String, OperationGroup> groupConfigs = new Object2ObjectOpenHashMap<>();
+        List<ActorGenerator> actorGenerators = new ObjectArrayList<>();
+        List<Method> validationFunctions = new ObjectArrayList<>();
+        List<Method> stateRepresentations = new ObjectArrayList<>();
         Class<?> clazz = testClass;
         RandomProvider randomProvider = new RandomProvider();
-        Map<Class<?>, ParameterGenerator<?>> parameterGeneratorsMap = new HashMap<>();
+        Map<Class<?>, ParameterGenerator<?>> parameterGeneratorsMap = new Object2ObjectOpenHashMap<>();
 
         while (clazz != null) {
             readTestStructureFromClass(clazz, groupConfigs, actorGenerators, parameterGeneratorsMap, validationFunctions, stateRepresentations, randomProvider);
@@ -70,9 +72,9 @@ public class CTestStructure {
         if (!stateRepresentations.isEmpty())
             stateRepresentation = stateRepresentations.get(0);
         // Create StressCTest class configuration
-        List<ParameterGenerator<?>> parameterGenerators = new ArrayList<>(parameterGeneratorsMap.values());
+        List<ParameterGenerator<?>> parameterGenerators = new ObjectArrayList<>(parameterGeneratorsMap.values());
 
-        return new CTestStructure(actorGenerators, parameterGenerators, new ArrayList<>(groupConfigs.values()), validationFunctions, stateRepresentation, randomProvider);
+        return new CTestStructure(actorGenerators, parameterGenerators, new ObjectArrayList<>(groupConfigs.values()), validationFunctions, stateRepresentation, randomProvider);
     }
 
     private static void readTestStructureFromClass(
@@ -104,7 +106,7 @@ public class CTestStructure {
                     throw new IllegalArgumentException("Invalid count of parameter generators for " + m);
                 }
                 // Construct a list of parameter generators
-                final List<ParameterGenerator<?>> gens = new ArrayList<>();
+                final List<ParameterGenerator<?>> gens = new ObjectArrayList<>();
                 int nParameters = m.getParameterCount() - (isSuspendableMethod ? 1 : 0);
                 for (int i = 0; i < nParameters; i++) {
                     String nameInOperation = opAnn.params().length > 0 ? opAnn.params()[i] : null;
@@ -148,7 +150,7 @@ public class CTestStructure {
     }
 
     private static Map<String, ParameterGenerator<?>> createNamedGens(Class<?> clazz, RandomProvider randomProvider) {
-        Map<String, ParameterGenerator<?>> namedGens = new HashMap<>();
+        Map<String, ParameterGenerator<?>> namedGens = new Object2ObjectOpenHashMap<>();
         // Traverse all operations to determine named EnumGens types
         // or throw if one named enum gen is associated with many types
         Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = collectNamedEnumGeneratorToClassMap(clazz);
@@ -181,7 +183,7 @@ public class CTestStructure {
      *                               which violates the uniqueness principle of enum generator to enum class mapping.
      */
     private static Map<String, Class<? extends Enum<?>>> collectNamedEnumGeneratorToClassMap(Class<?> clazz) {
-        Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = new HashMap<>();
+        Map<String, Class<? extends Enum<?>>> enumGeneratorNameToClassMap = new Object2ObjectOpenHashMap<>();
 
         Arrays.stream(clazz.getDeclaredMethods()) // get all methods of the class
                 .filter(method -> method.isAnnotationPresent(Operation.class)) // take methods, annotated as @Operation
@@ -281,7 +283,7 @@ public class CTestStructure {
     }
 
     private static Map<Class<?>, ParameterGenerator<?>> createDefaultGenerators(RandomProvider randomProvider) {
-        Map<Class<?>, ParameterGenerator<?>> defaultGens = new HashMap<>();
+        Map<Class<?>, ParameterGenerator<?>> defaultGens = new Object2ObjectOpenHashMap<>();
         defaultGens.put(boolean.class, new BooleanGen(randomProvider, ""));
         defaultGens.put(Boolean.class, defaultGens.get(boolean.class));
         defaultGens.put(byte.class, new ByteGen(randomProvider, ""));
@@ -313,7 +315,7 @@ public class CTestStructure {
         public OperationGroup(String name, boolean nonParallel) {
             this.name = name;
             this.nonParallel = nonParallel;
-            this.actors = new ArrayList<>();
+            this.actors = new ObjectArrayList<>();
         }
 
         @Override

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CollectionsUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CollectionsUtils.kt
@@ -1,0 +1,128 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2023 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck
+
+import it.unimi.dsi.fastutil.Hash
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
+import it.unimi.dsi.fastutil.ints.IntArrayList
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.function.Function
+
+internal typealias MutableIntList = IntArrayList
+internal typealias MutableObjectList<T> = ObjectArrayList<T>
+internal typealias MutableIntToObjectMap<V> = Int2ObjectOpenHashMap<V>
+internal typealias MutableObjectToObjectMap<K, V> = Object2ObjectOpenHashMap<K, V>
+internal typealias MutableIntToIntMap = Int2IntOpenHashMap
+internal typealias MutableIntSet = IntOpenHashSet
+
+internal fun mutableIntSetOf(vararg ints: Int): MutableIntSet = MutableIntSet(ints)
+
+internal fun mutableIntListOf(vararg ints: Int): MutableIntList = MutableIntList(ints)
+
+internal fun <T> mutableObjectListOf(vararg ints: T): MutableObjectList<T> = MutableObjectList(ints)
+
+internal fun <K, V> mutableObjectToObjectMapOf(vararg pairs: Pair<K, V>): MutableObjectToObjectMap<K, V> {
+    val result = MutableObjectToObjectMap<K, V>()
+    pairs.forEach { (key, value) -> result[key] = value }
+    return result
+}
+
+
+internal fun <V> mutableIntToObjectMapOf(vararg pairs: Pair<Int, V>): MutableIntToObjectMap<V> {
+    val result = MutableIntToObjectMap<V>()
+    pairs.forEach { (key, value) -> result[key] = value }
+    return result
+}
+
+internal fun mutableIntToIntMapOf(vararg pairs: Pair<Int, Int>): MutableIntToIntMap {
+    val result = MutableIntToIntMap()
+    pairs.forEach { (key, value) -> result[key] = value }
+    return result
+}
+
+/**
+ * Does the same as [java.util.Map.computeIfAbsent].
+ *
+ * Exists as there is an ambiguity when using [java.util.Map.computeIfAbsent] in Kotlin, because Fastutil
+ * library provides [it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap.computeIfAbsent] method with the same name.
+ */
+internal fun <K, V> MutableMap<K, V>.getOrComputeIfAbsent(key: K, mappingFunction: Function<K, V>): V = computeIfAbsent(key, mappingFunction)
+
+internal class ObjectToObjectIdentityHashMap<K, V> : Object2ObjectOpenCustomHashMap<K, V>(IdentityStrategy<K>())
+
+private class IdentityStrategy<T> : Hash.Strategy<T> {
+    override fun hashCode(o: T): Int {
+        return System.identityHashCode(o)
+    }
+
+    override fun equals(a: T, b: T): Boolean {
+        return a === b
+    }
+}
+
+internal class ObjectToObjectWeakHashMap<K, V: Any> {
+    private val queue = ReferenceQueue<K>()
+    private val internalMap = Object2ObjectOpenHashMap<WeakKey<K>, V>()
+
+    val size: Int get() = internalMap.size
+    operator fun get(key: K): V? {
+        cleanUp()
+        return internalMap[WeakKey(key)]
+    }
+
+    operator fun set(key: K, value: V): V? {
+        cleanUp()
+        return internalMap.put(WeakKey(key, queue), value)
+    }
+
+    fun computeIfAbsent(key: K, mappingFunction: (K) -> V): V {
+        cleanUp()
+        val weakKey = WeakKey(key, queue)
+        var value = internalMap[weakKey]
+        if (value == null) {
+            value = mappingFunction(key)
+            internalMap[weakKey] = value
+        }
+        return value
+    }
+
+    @Suppress("ControlFlowWithEmptyBody")
+    fun clear() {
+        internalMap.clear()
+        while (queue.poll() != null) {
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun cleanUp() {
+        val key = queue.poll() as? WeakKey<K> ?: return
+        internalMap.remove(key)
+    }
+
+    private class WeakKey<T>(key: T, queue: ReferenceQueue<T>? = null) : WeakReference<T>(key, queue) {
+        private val hash = key.hashCode()
+
+        override fun hashCode() = hash
+
+        override fun equals(other: Any?) = when {
+            this === other -> true
+            other !is WeakKey<*> -> false
+            get() == other.get() -> true
+            else -> false
+        }
+    }
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CollectionsUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CollectionsUtils.kt
@@ -22,34 +22,30 @@ import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
 import java.util.function.Function
 
-internal typealias MutableIntList = IntArrayList
-internal typealias MutableObjectList<T> = ObjectArrayList<T>
-internal typealias MutableIntToObjectMap<V> = Int2ObjectOpenHashMap<V>
-internal typealias MutableObjectToObjectMap<K, V> = Object2ObjectOpenHashMap<K, V>
-internal typealias MutableIntToIntMap = Int2IntOpenHashMap
-internal typealias MutableIntSet = IntOpenHashSet
+internal fun lincheckIntSetOf(vararg ints: Int): IntOpenHashSet = IntOpenHashSet(ints)
 
-internal fun mutableIntSetOf(vararg ints: Int): MutableIntSet = MutableIntSet(ints)
+internal fun lincheckIntListOf(vararg ints: Int): IntArrayList = IntArrayList(ints)
 
-internal fun mutableIntListOf(vararg ints: Int): MutableIntList = MutableIntList(ints)
+internal fun <T> lincheckListOf(vararg ints: T): ObjectArrayList<T> =
+    ObjectArrayList<T>(ints)
 
-internal fun <T> mutableObjectListOf(vararg ints: T): MutableObjectList<T> = MutableObjectList(ints)
+internal fun <K, V> lincheckMapOf(): Object2ObjectOpenHashMap<K, V> = Object2ObjectOpenHashMap<K, V>()
 
-internal fun <K, V> mutableObjectToObjectMapOf(vararg pairs: Pair<K, V>): MutableObjectToObjectMap<K, V> {
-    val result = MutableObjectToObjectMap<K, V>()
+internal fun <K, V> lincheckMapOf(vararg pairs: Pair<K, V>): Object2ObjectOpenHashMap<K, V> {
+    val result = Object2ObjectOpenHashMap<K, V>()
     pairs.forEach { (key, value) -> result[key] = value }
     return result
 }
 
 
-internal fun <V> mutableIntToObjectMapOf(vararg pairs: Pair<Int, V>): MutableIntToObjectMap<V> {
-    val result = MutableIntToObjectMap<V>()
+internal fun <V> lincheckIntToObjectMapOf(vararg pairs: Pair<Int, V>): Int2ObjectOpenHashMap<V> {
+    val result = Int2ObjectOpenHashMap<V>()
     pairs.forEach { (key, value) -> result[key] = value }
     return result
 }
 
-internal fun mutableIntToIntMapOf(vararg pairs: Pair<Int, Int>): MutableIntToIntMap {
-    val result = MutableIntToIntMap()
+internal fun lincheckIntToIntMapOf(vararg pairs: Pair<Int, Int>): Int2IntOpenHashMap {
+    val result = Int2IntOpenHashMap()
     pairs.forEach { (key, value) -> result[key] = value }
     return result
 }
@@ -60,7 +56,8 @@ internal fun mutableIntToIntMapOf(vararg pairs: Pair<Int, Int>): MutableIntToInt
  * Exists as there is an ambiguity when using [java.util.Map.computeIfAbsent] in Kotlin, because Fastutil
  * library provides [it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap.computeIfAbsent] method with the same name.
  */
-internal fun <K, V> MutableMap<K, V>.getOrComputeIfAbsent(key: K, mappingFunction: Function<K, V>): V = computeIfAbsent(key, mappingFunction)
+internal fun <K, V> MutableMap<K, V>.getOrComputeIfAbsent(key: K, mappingFunction: Function<K, V>): V =
+    computeIfAbsent(key, mappingFunction)
 
 internal class ObjectToObjectIdentityHashMap<K, V> : Object2ObjectOpenCustomHashMap<K, V>(IdentityStrategy<K>())
 
@@ -74,7 +71,7 @@ private class IdentityStrategy<T> : Hash.Strategy<T> {
     }
 }
 
-internal class ObjectToObjectWeakHashMap<K, V: Any> {
+internal class ObjectToObjectWeakHashMap<K, V : Any> {
     private val queue = ReferenceQueue<K>()
     private val internalMap = Object2ObjectOpenHashMap<WeakKey<K>, V>()
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CustomScenarioDSL.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CustomScenarioDSL.kt
@@ -52,7 +52,7 @@ internal fun actor(f: KFunction<*>, vararg args: Any?, cancelOnSuspension: Boole
 }
 
 @ScenarioDSLMarker
-class DSLThreadScenario : ArrayList<Actor>() {
+class DSLThreadScenario : MutableObjectList<Actor>() {
     /**
      * An actor to be executed
      */
@@ -62,7 +62,7 @@ class DSLThreadScenario : ArrayList<Actor>() {
 }
 
 @ScenarioDSLMarker
-class DSLParallelScenario : ArrayList<DSLThreadScenario>() {
+class DSLParallelScenario : MutableObjectList<DSLThreadScenario>() {
     /**
      * Define a sequence of actors to be executed in a separate thread
      */
@@ -73,9 +73,9 @@ class DSLParallelScenario : ArrayList<DSLThreadScenario>() {
 
 @ScenarioDSLMarker
 class DSLScenarioBuilder {
-    private val initial = mutableListOf<Actor>()
-    private var parallel = mutableListOf<MutableList<Actor>>()
-    private val post = mutableListOf<Actor>()
+    private val initial = mutableObjectListOf<Actor>()
+    private var parallel = mutableObjectListOf<MutableList<Actor>>()
+    private val post = mutableObjectListOf<Actor>()
     private var initialSpecified = false
     private var parallelSpecified = false
     private var postSpecified = false

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CustomScenarioDSL.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CustomScenarioDSL.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.jetbrains.kotlinx.lincheck.execution.*
 import java.lang.IllegalStateException
 import kotlin.reflect.KFunction
@@ -52,7 +53,7 @@ internal fun actor(f: KFunction<*>, vararg args: Any?, cancelOnSuspension: Boole
 }
 
 @ScenarioDSLMarker
-class DSLThreadScenario : MutableObjectList<Actor>() {
+class DSLThreadScenario : ObjectArrayList<Actor>() {
     /**
      * An actor to be executed
      */
@@ -62,7 +63,8 @@ class DSLThreadScenario : MutableObjectList<Actor>() {
 }
 
 @ScenarioDSLMarker
-class DSLParallelScenario : MutableObjectList<DSLThreadScenario>() {
+class DSLParallelScenario :
+    ObjectArrayList<DSLThreadScenario>() {
     /**
      * Define a sequence of actors to be executed in a separate thread
      */
@@ -73,9 +75,9 @@ class DSLParallelScenario : MutableObjectList<DSLThreadScenario>() {
 
 @ScenarioDSLMarker
 class DSLScenarioBuilder {
-    private val initial = mutableObjectListOf<Actor>()
-    private var parallel = mutableObjectListOf<MutableList<Actor>>()
-    private val post = mutableObjectListOf<Actor>()
+    private val initial = lincheckListOf<Actor>()
+    private var parallel = lincheckListOf<MutableList<Actor>>()
+    private val post = lincheckListOf<Actor>()
     private var initialSpecified = false
     private var parallelSpecified = false
     private var postSpecified = false

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -28,7 +28,7 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
     protected var minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR
     protected var sequentialSpecification: Class<*>? = null
     protected var timeoutMs: Long = CTestConfiguration.DEFAULT_TIMEOUT_MS
-    protected var customScenarios: MutableList<ExecutionScenario> = mutableListOf()
+    protected var customScenarios: MutableList<ExecutionScenario> = mutableObjectListOf()
 
     /**
      * Number of different test scenarios to be executed

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -28,7 +28,7 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
     protected var minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR
     protected var sequentialSpecification: Class<*>? = null
     protected var timeoutMs: Long = CTestConfiguration.DEFAULT_TIMEOUT_MS
-    protected var customScenarios: MutableList<ExecutionScenario> = mutableObjectListOf()
+    protected var customScenarios: MutableList<ExecutionScenario> = lincheckListOf()
 
     /**
      * Number of different test scenarios to be executed

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -321,7 +321,7 @@ internal fun StringBuilder.appendExecutionScenarioWithResults(
             appendSeparatorLine()
         }
     }
-    val hints = mutableListOf<String>()
+    val hints = mutableObjectListOf<String>()
     if (scenario.initExecution.isNotEmpty() || scenario.postExecution.isNotEmpty()) {
         hints.add(
             """
@@ -487,7 +487,7 @@ private data class ExceptionStackTracesResult(val exceptionStackTraces: Map<Thro
  * if some exception occurred due a bug in Lincheck itself
  */
 private fun collectExceptionStackTraces(executionResult: ExecutionResult): ExceptionsProcessingResult {
-    val exceptionStackTraces = mutableMapOf<Throwable, ExceptionNumberAndStacktrace>()
+    val exceptionStackTraces = mutableObjectToObjectMapOf<Throwable, ExceptionNumberAndStacktrace>()
 
     (executionResult.initResults.asSequence()
             + executionResult.parallelResults.asSequence().flatten()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -321,7 +321,7 @@ internal fun StringBuilder.appendExecutionScenarioWithResults(
             appendSeparatorLine()
         }
     }
-    val hints = mutableObjectListOf<String>()
+    val hints = lincheckListOf<String>()
     if (scenario.initExecution.isNotEmpty() || scenario.postExecution.isNotEmpty()) {
         hints.add(
             """
@@ -487,7 +487,7 @@ private data class ExceptionStackTracesResult(val exceptionStackTraces: Map<Thro
  * if some exception occurred due a bug in Lincheck itself
  */
 private fun collectExceptionStackTraces(executionResult: ExecutionResult): ExceptionsProcessingResult {
-    val exceptionStackTraces = mutableObjectToObjectMapOf<Throwable, ExceptionNumberAndStacktrace>()
+    val exceptionStackTraces = lincheckMapOf<Throwable, ExceptionNumberAndStacktrace>()
 
     (executionResult.initResults.asSequence()
             + executionResult.parallelResults.asSequence().flatten()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/TransformationClassLoader.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/TransformationClassLoader.java
@@ -10,6 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.kotlinx.lincheck.runner.*;
 import org.jetbrains.kotlinx.lincheck.strategy.*;
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*;
@@ -50,7 +51,7 @@ public class TransformationClassLoader extends ExecutionClassLoader {
     private static final Map<String, byte[]> modelCheckingStrategyBytecodeCache = new ConcurrentHashMap<>();
 
     public TransformationClassLoader(Strategy strategy, Runner runner) {
-        classTransformers = new ArrayList<>();
+        classTransformers = new ObjectArrayList<>();
         // Apply the strategy's transformer at first, then the runner's one.
         if (strategy.needsTransformation()) classTransformers.add(strategy::createTransformer);
         if (runner.needsTransformation()) classTransformers.add(runner::createTransformer);

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -20,7 +20,6 @@ import java.io.*
 import java.lang.ref.*
 import java.lang.reflect.*
 import java.lang.reflect.Method
-import java.util.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 
@@ -105,14 +104,14 @@ private fun executeValidationFunction(instance: Any, validationFunction: Method)
 @Suppress("UNCHECKED_CAST")
 internal fun <T> Class<T>.normalize() = LinChecker::class.java.classLoader.loadClass(name) as Class<T>
 
-private val methodsCache = WeakHashMap<Class<*>, WeakHashMap<Method, WeakReference<Method>>>()
+private val methodsCache = ObjectToObjectWeakHashMap<Class<*>, ObjectToObjectWeakHashMap<Method, WeakReference<Method>>>()
 
 /**
  * Get the same [method] for [instance] solving the different class loaders problem.
  */
 @Synchronized
 internal fun getMethod(instance: Any, method: Method): Method {
-    val methods = methodsCache.computeIfAbsent(instance.javaClass) { WeakHashMap() }
+    val methods = methodsCache.computeIfAbsent(instance.javaClass) { ObjectToObjectWeakHashMap() }
     return methods[method]?.get() ?: run {
         val m = instance.javaClass.getMethod(method.name, method.parameterTypes)
         methods[method] = WeakReference(m)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionScenario.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionScenario.kt
@@ -9,6 +9,7 @@
  */
 package org.jetbrains.kotlinx.lincheck.execution
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.jetbrains.kotlinx.lincheck.*
 
 /**
@@ -124,9 +125,9 @@ fun ExecutionScenario.validate() {
  * Creates a copy of the scenario.
  */
 fun ExecutionScenario.copy() = ExecutionScenario(
-    MutableObjectList(initExecution),
-    parallelExecution.map { MutableObjectList(it) },
-    MutableObjectList(postExecution)
+    ObjectArrayList(initExecution),
+    parallelExecution.map { ObjectArrayList(it) },
+    ObjectArrayList(postExecution)
 )
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionScenario.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionScenario.kt
@@ -124,9 +124,9 @@ fun ExecutionScenario.validate() {
  * Creates a copy of the scenario.
  */
 fun ExecutionScenario.copy() = ExecutionScenario(
-    ArrayList(initExecution),
-    parallelExecution.map { ArrayList(it) },
-    ArrayList(postExecution)
+    MutableObjectList(initExecution),
+    parallelExecution.map { MutableObjectList(it) },
+    MutableObjectList(postExecution)
 )
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/RandomExecutionGenerator.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/RandomExecutionGenerator.java
@@ -10,12 +10,12 @@
 
 package org.jetbrains.kotlinx.lincheck.execution;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.kotlinx.lincheck.Actor;
 import org.jetbrains.kotlinx.lincheck.CTestConfiguration;
 import org.jetbrains.kotlinx.lincheck.CTestStructure;
 import org.jetbrains.kotlinx.lincheck.RandomProvider;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -35,7 +35,7 @@ public class RandomExecutionGenerator extends ExecutionGenerator {
         // Create init execution part
         List<ActorGenerator> validActorGeneratorsForInit = testStructure.actorGenerators.stream()
             .filter(ag -> !ag.getUseOnce() && !ag.isSuspendable()).collect(Collectors.toList());
-        List<Actor> initExecution = new ArrayList<>();
+        List<Actor> initExecution = new ObjectArrayList<>();
         for (int i = 0; i < testConfiguration.getActorsBefore() && !validActorGeneratorsForInit.isEmpty(); i++) {
             ActorGenerator ag = validActorGeneratorsForInit.get(random.nextInt(validActorGeneratorsForInit.size()));
             initExecution.add(ag.generate(0, random));
@@ -46,20 +46,20 @@ public class RandomExecutionGenerator extends ExecutionGenerator {
             .filter(g -> g.nonParallel)
             .collect(Collectors.toList());
         Collections.shuffle(nonParallelGroups, random);
-        List<ActorGenerator> parallelGroup = new ArrayList<>(testStructure.actorGenerators);
+        List<ActorGenerator> parallelGroup = new ObjectArrayList<>(testStructure.actorGenerators);
         nonParallelGroups.forEach(g -> parallelGroup.removeAll(g.actors));
 
-        List<List<Actor>> parallelExecution = new ArrayList<>();
-        List<ThreadGen> threadGens = new ArrayList<>();
+        List<List<Actor>> parallelExecution = new ObjectArrayList<>();
+        List<ThreadGen> threadGens = new ObjectArrayList<>();
         for (int t = 0; t < testConfiguration.getThreads(); t++) {
-            parallelExecution.add(new ArrayList<>());
+            parallelExecution.add(new ObjectArrayList<>());
             threadGens.add(new ThreadGen(t, testConfiguration.getActorsPerThread()));
         }
         for (int i = 0; i < nonParallelGroups.size(); i++) {
             threadGens.get(i % threadGens.size()).nonParallelActorGenerators
                 .addAll(nonParallelGroups.get(i).actors);
         }
-        List<ThreadGen> tgs2 = new ArrayList<>(threadGens);
+        List<ThreadGen> tgs2 = new ObjectArrayList<>(threadGens);
         while (!threadGens.isEmpty()) {
             for (Iterator<ThreadGen> it = threadGens.iterator(); it.hasNext(); ) {
                 ThreadGen threadGen = it.next();
@@ -85,8 +85,8 @@ public class RandomExecutionGenerator extends ExecutionGenerator {
         // Create post execution part if the parallel part does not have suspendable actors
         List<Actor> postExecution;
         if (parallelExecution.stream().noneMatch(actors -> actors.stream().anyMatch(Actor::isSuspendable))) {
-            postExecution = new ArrayList<>();
-            List<ActorGenerator> leftActorGenerators = new ArrayList<>(parallelGroup);
+            postExecution = new ObjectArrayList<>();
+            List<ActorGenerator> leftActorGenerators = new ObjectArrayList<>(parallelGroup);
             for (ThreadGen threadGen : tgs2)
                 leftActorGenerators.addAll(threadGen.nonParallelActorGenerators);
             for (int i = 0; i < testConfiguration.getActorsAfter() && !leftActorGenerators.isEmpty(); i++) {
@@ -107,7 +107,7 @@ public class RandomExecutionGenerator extends ExecutionGenerator {
     }
 
     private static class ThreadGen {
-        final List<ActorGenerator> nonParallelActorGenerators = new ArrayList<>();
+        final List<ActorGenerator> nonParallelActorGenerators = new ObjectArrayList<>();
         int iThread;
         int left;
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/TestThreadExecutionGenerator.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/TestThreadExecutionGenerator.java
@@ -10,6 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck.runner;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.kotlinx.lincheck.*;
 import org.jetbrains.kotlinx.lincheck.runner.ParallelThreadsRunner.*;
@@ -19,7 +20,6 @@ import org.objectweb.asm.commons.Method;
 import org.objectweb.asm.commons.TryCatchBlockSorter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.objectweb.asm.Opcodes.*;
@@ -95,7 +95,7 @@ public class TestThreadExecutionGenerator {
     ) {
         String className = TestThreadExecution.class.getCanonicalName() + generatedClassNumber++;
         String internalClassName = className.replace('.', '/');
-        List<Object> objArgs = new ArrayList<>();
+        List<Object> objArgs = new ObjectArrayList<>();
         Class<? extends TestThreadExecution> clz = runner.getClassLoader().defineClass(className,
                 generateClass(internalClassName, getType(runner.getTestClass()), iThread, actors, objArgs, completions, scenarioContainsSuspendableActors));
         try {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_GUARANTEES
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_HANGING_DETECTION_THRESHOLD
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_INVOCATIONS
-import java.util.*
 
 /**
  * Common options for all managed strategies.
@@ -24,7 +23,7 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     protected var invocationsPerIteration = DEFAULT_INVOCATIONS
     protected var checkObstructionFreedom = DEFAULT_CHECK_OBSTRUCTION_FREEDOM
     protected var hangingDetectionThreshold = DEFAULT_HANGING_DETECTION_THRESHOLD
-    protected val guarantees: MutableList<ManagedStrategyGuarantee> = ArrayList(DEFAULT_GUARANTEES)
+    protected val guarantees: MutableList<ManagedStrategyGuarantee> = MutableObjectList(DEFAULT_GUARANTEES)
     protected var eliminateLocalObjects: Boolean = DEFAULT_ELIMINATE_LOCAL_OBJECTS
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
@@ -9,6 +9,7 @@
  */
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_CHECK_OBSTRUCTION_FREEDOM
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_ELIMINATE_LOCAL_OBJECTS
@@ -23,7 +24,7 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     protected var invocationsPerIteration = DEFAULT_INVOCATIONS
     protected var checkObstructionFreedom = DEFAULT_CHECK_OBSTRUCTION_FREEDOM
     protected var hangingDetectionThreshold = DEFAULT_HANGING_DETECTION_THRESHOLD
-    protected val guarantees: MutableList<ManagedStrategyGuarantee> = MutableObjectList(DEFAULT_GUARANTEES)
+    protected val guarantees: MutableList<ManagedStrategyGuarantee> = ObjectArrayList(DEFAULT_GUARANTEES)
     protected var eliminateLocalObjects: Boolean = DEFAULT_ELIMINATE_LOCAL_OBJECTS
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -9,6 +9,7 @@
  */
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import kotlinx.coroutines.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.CancellationResult.*
@@ -81,18 +82,18 @@ abstract class ManagedStrategy(
     private val collectStateRepresentation get() = collectTrace && stateRepresentationFunction != null
     // Trace point constructors, where `tracePointConstructors[id]`
     // stores a constructor for the corresponding code location.
-    private val tracePointConstructors: MutableList<TracePointConstructor> = MutableObjectList()
+    private val tracePointConstructors: MutableList<TracePointConstructor> = ObjectArrayList()
     // Collector of all events in the execution such as thread switches.
     private var traceCollector: TraceCollector? = null // null when `collectTrace` is false
     // Stores the currently executing methods call stack for each thread.
-    private val callStackTrace = Array(nThreads) { mutableObjectListOf<CallStackTraceElement>() }
+    private val callStackTrace = Array(nThreads) { lincheckListOf<CallStackTraceElement>() }
     // Stores the global number of method calls.
     private var methodCallNumber = 0
     // In case of suspension, the call stack of the corresponding `suspend`
     // methods is stored here, so that the same method call identifiers are
     // used on resumption, and the trace point before and after the suspension
     // correspond to the same method call in the trace.
-    private val suspendedFunctionsStack = Array(nThreads) { mutableIntListOf() }
+    private val suspendedFunctionsStack = Array(nThreads) { lincheckIntListOf() }
     // Current execution part
     protected lateinit var executionPart: ExecutionPart
 
@@ -774,7 +775,7 @@ abstract class ManagedStrategy(
      * Logs thread events such as thread switches and passed code locations.
      */
     private inner class TraceCollector {
-        private val _trace = mutableObjectListOf<TracePoint>()
+        private val _trace = lincheckListOf<TracePoint>()
         val trace: List<TracePoint> = _trace
 
         fun newSwitch(iThread: Int, reason: SwitchReason) {
@@ -852,17 +853,17 @@ abstract class ManagedStrategy(
         /**
          * Map, which helps us to determine how many times current thread visits some code location.
          */
-        private val currentThreadCodeLocationVisitCountMap = mutableIntToIntMapOf()
+        private val currentThreadCodeLocationVisitCountMap = lincheckIntToIntMapOf()
 
         /**
          * Is used to find a cycle period inside exact thread execution if it has hung
          */
-        private val currentThreadCodeLocationsHistory = mutableIntListOf()
+        private val currentThreadCodeLocationsHistory = lincheckIntListOf()
 
         /**
          *  Threads switches and executions history to store sequences lead to loops
          */
-        private val currentInterleavingHistory = MutableObjectList<InterleavingHistoryNode>()
+        private val currentInterleavingHistory = ObjectArrayList<InterleavingHistoryNode>()
 
         /**
          * When we're back to some thread, newSwitchPoint won't be called before the first event in the current
@@ -1148,7 +1149,7 @@ abstract class ManagedStrategy(
          * [onNextExecution] won't be called before the first execution,
          * so we have to start [executionsPerformedInCurrentThread] from 1.
          */
-        private val threadsRan = mutableIntSetOf()
+        private val threadsRan = lincheckIntSetOf()
 
         fun initialize() {
             currentInterleavingNodeIndex = 0

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectManager.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectManager.kt
@@ -9,7 +9,8 @@
  */
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
-import java.util.*
+import org.jetbrains.kotlinx.lincheck.ObjectToObjectIdentityHashMap
+import org.jetbrains.kotlinx.lincheck.mutableObjectListOf
 
 /**
  * First of all, the object manager keeps information of locally accessible objects
@@ -25,16 +26,16 @@ import java.util.*
 internal class ObjectManager(private val testClass: Class<out Any>) {
     // For each local object store all objects that depend on it (e.g, are referenced by it).
     // Non-local objects are not presented in this map.
-    private val localObjects = IdentityHashMap<Any, MutableList<Any>>()
+    private val localObjects = ObjectToObjectIdentityHashMap<Any, MutableList<Any>>()
     // Stores object names (typically, the corresponding field names where they are uniquely stored).
-    private val objectNames = IdentityHashMap<Any, String>()
+    private val objectNames = ObjectToObjectIdentityHashMap<Any, String>()
 
     fun newLocalObject(o: Any) {
         // a test instance can not be local object.
         // check by name to ignore difference in loaders
         if (o::class.java.name == testClass.name) return
         // add o to list of local object with no dependencies
-        localObjects[o] = mutableListOf()
+        localObjects[o] = mutableObjectListOf()
     }
 
     fun deleteLocalObject(o: Any?) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectManager.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectManager.kt
@@ -10,7 +10,7 @@
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
 import org.jetbrains.kotlinx.lincheck.ObjectToObjectIdentityHashMap
-import org.jetbrains.kotlinx.lincheck.mutableObjectListOf
+import org.jetbrains.kotlinx.lincheck.lincheckListOf
 
 /**
  * First of all, the object manager keeps information of locally accessible objects
@@ -35,7 +35,7 @@ internal class ObjectManager(private val testClass: Class<out Any>) {
         // check by name to ignore difference in loaders
         if (o::class.java.name == testClass.name) return
         // add o to list of local object with no dependencies
-        localObjects[o] = mutableObjectListOf()
+        localObjects[o] = lincheckListOf()
     }
 
     fun deleteLocalObject(o: Any?) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -74,7 +74,7 @@ private fun StringBuilder.appendTraceRepresentation(
  * Convert trace events to the final form of a matrix of strings.
  */
 private fun splitToColumns(nThreads: Int, traceRepresentation: List<TraceEventRepresentation>): List<List<String>> {
-    val result = List(nThreads) { mutableObjectListOf<String>() }
+    val result = List(nThreads) { lincheckListOf<String>() }
     for (event in traceRepresentation) {
         val columnId = event.iThread
         // write message in an appropriate column
@@ -109,9 +109,9 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
         Array<ActorNode?>(scenario.threads[i].size) { null }
     }
     // call nodes for each method call
-    val callNodes = mutableIntToObjectMapOf<CallNode>()
+    val callNodes = lincheckIntToObjectMapOf<CallNode>()
     // all trace nodes in order corresponding to `tracePoints`
-    val traceGraphNodes = mutableObjectListOf<TraceNode>()
+    val traceGraphNodes = lincheckListOf<TraceNode>()
 
     for (eventId in tracePoints.indices) {
         val event = tracePoints[eventId]
@@ -204,7 +204,7 @@ private fun traceGraphToRepresentationList(
     verboseTrace: Boolean
 ): List<TraceEventRepresentation> {
     var curNode: TraceNode? = startNode
-    val traceRepresentation = mutableObjectListOf<TraceEventRepresentation>()
+    val traceRepresentation = lincheckListOf<TraceEventRepresentation>()
     while (curNode != null) {
         curNode = curNode.addRepresentationTo(traceRepresentation, verboseTrace)
     }
@@ -290,7 +290,7 @@ private abstract class TraceInnerNode(iThread: Int, last: TraceNode?, callDepth:
             it.shouldBeExpanded(verboseTrace)
         }
 
-    private val internalEvents = mutableObjectListOf<TraceNode>()
+    private val internalEvents = lincheckListOf<TraceNode>()
 
     fun addInternalEvent(node: TraceNode) {
         internalEvents.add(node)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -10,6 +10,8 @@
 package org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking
 
 import org.jetbrains.kotlinx.lincheck.execution.*
+import org.jetbrains.kotlinx.lincheck.mutableIntListOf
+import org.jetbrains.kotlinx.lincheck.mutableObjectListOf
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
@@ -244,7 +246,7 @@ internal class ModelCheckingStrategy(
             lastNotInitializedNodeChoices = null
             lastNotInitializedNode?.let {
                 // Create a mutable list for the initialization of the not initialized node choices.
-                lastNotInitializedNodeChoices = mutableListOf<Choice>().also { choices ->
+                lastNotInitializedNodeChoices = mutableObjectListOf<Choice>().also { choices ->
                     it.choices = choices
                 }
                 lastNotInitializedNode = null
@@ -286,8 +288,8 @@ internal class ModelCheckingStrategy(
     }
 
     private inner class InterleavingBuilder {
-        private val switchPositions = mutableListOf<Int>()
-        private val threadSwitchChoices = mutableListOf<Int>()
+        private val switchPositions = mutableIntListOf()
+        private val threadSwitchChoices = mutableIntListOf()
         private var lastNoninitializedNode: SwitchChoosingNode? = null
 
         val numberOfSwitches get() = switchPositions.size

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -10,8 +10,8 @@
 package org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking
 
 import org.jetbrains.kotlinx.lincheck.execution.*
-import org.jetbrains.kotlinx.lincheck.mutableIntListOf
-import org.jetbrains.kotlinx.lincheck.mutableObjectListOf
+import org.jetbrains.kotlinx.lincheck.lincheckIntListOf
+import org.jetbrains.kotlinx.lincheck.lincheckListOf
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
@@ -246,7 +246,7 @@ internal class ModelCheckingStrategy(
             lastNotInitializedNodeChoices = null
             lastNotInitializedNode?.let {
                 // Create a mutable list for the initialization of the not initialized node choices.
-                lastNotInitializedNodeChoices = mutableObjectListOf<Choice>().also { choices ->
+                lastNotInitializedNodeChoices = lincheckListOf<Choice>().also { choices ->
                     it.choices = choices
                 }
                 lastNotInitializedNode = null
@@ -288,8 +288,8 @@ internal class ModelCheckingStrategy(
     }
 
     private inner class InterleavingBuilder {
-        private val switchPositions = mutableIntListOf()
-        private val threadSwitchChoices = mutableIntListOf()
+        private val switchPositions = lincheckIntListOf()
+        private val threadSwitchChoices = lincheckIntListOf()
         private var lastNoninitializedNode: SwitchChoosingNode? = null
 
         val numberOfSwitches get() = switchPositions.size

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/CachedVerifier.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/CachedVerifier.java
@@ -10,6 +10,8 @@
 
 package org.jetbrains.kotlinx.lincheck.verifier;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.jetbrains.kotlinx.lincheck.ObjectToObjectWeakHashMap;
 import org.jetbrains.kotlinx.lincheck.execution.*;
 
 import java.util.*;
@@ -21,11 +23,11 @@ import java.util.*;
  * phase significantly.
  */
 public abstract class CachedVerifier implements Verifier {
-    private final Map<ExecutionScenario, Set<ExecutionResult>> previousResults = new WeakHashMap<>();
+    private final ObjectToObjectWeakHashMap<ExecutionScenario, Set<ExecutionResult>> previousResults = new ObjectToObjectWeakHashMap<>();
 
     @Override
     public boolean verifyResults(ExecutionScenario scenario, ExecutionResult results) {
-        boolean newResult = previousResults.computeIfAbsent(scenario, s -> new HashSet<>()).add(results);
+        boolean newResult = previousResults.computeIfAbsent(scenario, s -> new ObjectOpenHashSet<>()).add(results);
         if (!newResult) return true;
         return verifyResultsImpl(scenario, results);
     }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/ObjectToObjectWeakHashMapTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/ObjectToObjectWeakHashMapTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2023 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test
+
+import org.jetbrains.kotlinx.lincheck.ObjectToObjectWeakHashMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ObjectToObjectWeakHashMapTest {
+
+    /**
+     * Checks that map don't persist keys with no strong references.
+     *
+     * Here supposed that if this map is a regular [HashMap] - this test will fail.
+     */
+    @Test
+    fun `should not fail with out of memory error`() {
+        val map = ObjectToObjectWeakHashMap<Int, List<Int>>()
+        for (i in 0 until 10_000) {
+            map[i] = List(10_000) { it }
+        }
+    }
+
+    @Test
+    fun `should have the same behaviour as a regular hash map`() {
+        val list1 = listOf(1, 2, 3)
+        val list2 = listOf(1, 2, 3)
+        val list3 = listOf(1, 2, 3)
+
+        val map = ObjectToObjectWeakHashMap<Int, List<Int>>()
+        map[1] = list1
+        map[2] = list2
+        map[3] = list3
+        map.computeIfAbsent(4) { listOf(4, 5, 6) }
+
+        assertEquals(map[1], list1)
+        assertEquals(map[2], list2)
+        assertEquals(map[3], list3)
+        assertEquals(map[4], listOf(4, 5, 6))
+    }
+
+}


### PR DESCRIPTION
1. Standart java collections replaced with Fastutils collections
2. Remapping `Fastutil` package to `Lincheck` package using Gradle shadow plugin