### PR TITLE
Execute `init` and `post` parts via the same mechanism as for the `parallel` one.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -218,25 +218,33 @@ fun storeCancellableContinuation(cont: CancellableContinuation<*>) {
 }
 
 internal fun ExecutionScenario.convertForLoader(loader: ClassLoader) = ExecutionScenario(
-    initExecution,
+    initExecution.map {
+         it.convertForLoader(loader)
+    },
     parallelExecution.map { actors ->
         actors.map { a ->
-            val args = a.arguments.map { it.convertForLoader(loader) }
-            // the original `isSuspendable` is used here since `KFunction.isSuspend` fails on transformed classes
-            Actor(
-                method = a.method.convertForLoader(loader),
-                arguments = args,
-                cancelOnSuspension = a.cancelOnSuspension,
-                allowExtraSuspension = a.allowExtraSuspension,
-                blocking = a.blocking,
-                causesBlocking = a.causesBlocking,
-                promptCancellation = a.promptCancellation,
-                isSuspendable = a.isSuspendable
-            )
+            a.convertForLoader(loader)
         }
     },
-    postExecution
+    postExecution.map {
+        it.convertForLoader(loader)
+    }
 )
+
+private fun Actor.convertForLoader(loader: ClassLoader): Actor {
+    val args = arguments.map { it.convertForLoader(loader) }
+    // the original `isSuspendable` is used here since `KFunction.isSuspend` fails on transformed classes
+    return Actor(
+        method = method.convertForLoader(loader),
+        arguments = args,
+        cancelOnSuspension = cancelOnSuspension,
+        allowExtraSuspension = allowExtraSuspension,
+        blocking = blocking,
+        causesBlocking = causesBlocking,
+        promptCancellation = promptCancellation,
+        isSuspendable = isSuspendable
+    )
+}
 
 internal fun ExecutionResult.convertForLoader(loader: ClassLoader) = ExecutionResult(
         initResults.map { it.convertForLoader(loader) },

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.CancellationResult.*
 import org.jetbrains.kotlinx.lincheck.execution.*
+import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.*
 import org.jetbrains.kotlinx.lincheck.runner.ParallelThreadsRunner.Completion.*
 import org.jetbrains.kotlinx.lincheck.runner.UseClocks.*
@@ -67,12 +68,9 @@ internal open class ParallelThreadsRunner(
     private val uninitializedThreads = AtomicInteger(scenario.nThreads) // for threads synchronization
     private var yieldInvokedInOnStart = false
 
-    var currentExecutionPart: ExecutionPart? = null
-        private set
-
-    private var initialPartExecution: InitTestThreadExecution? = null
+    private var initialPartExecution: TestThreadExecution? = null
     private var parallelPartExecutions: Array<TestThreadExecution> = arrayOf()
-    private var postPartExecution: PostTestThreadExecution? = null
+    private var postPartExecution: TestThreadExecution? = null
 
     private var testThreadExecutions: List<TestThreadExecution> = listOf()
 
@@ -154,8 +152,6 @@ internal open class ParallelThreadsRunner(
         uninitializedThreads.set(scenario.nThreads)
         // reset stored continuations
         executor.threads.forEach { it.cont = null }
-        // reset phase
-        currentExecutionPart = null
         // reset thread executions
         testThreadExecutions.forEach { it.reset() }
     }
@@ -204,7 +200,7 @@ internal open class ParallelThreadsRunner(
         var i = 1
         while (!isCoroutineResumed(iThread, actorId)) {
             // Check whether the scenario is completed and the current suspended operation cannot be resumed.
-            if (completedOrSuspendedThreads.get() == scenario.nThreads) {
+            if (currentExecutionPart == POST || completedOrSuspendedThreads.get() == scenario.nThreads) {
                 suspensionPointResults[iThread][actorId] = NoResult
                 return Suspended
             }
@@ -228,7 +224,7 @@ internal open class ParallelThreadsRunner(
 
     /**
      * This method is used for communication between `ParallelThreadsRunner` and `ManagedStrategy` via overriding,
-     * so that runner do not know about managed strategy details.
+     * so that runner does not know about managed strategy details.
      */
     internal open fun <T> cancelByLincheck(cont: CancellableContinuation<T>, promptCancellation: Boolean): CancellationResult =
         cont.cancelByLincheck(promptCancellation)
@@ -247,27 +243,30 @@ internal open class ParallelThreadsRunner(
     override fun run(): InvocationResult {
         try {
             var timeout = timeoutMs * 1_000_000
-            // create new tested class instance
+            // Create a new testing class instance.
             createTestInstance()
-            // execute initial part
-            initialPartExecution?.run {
-                currentExecutionPart = ExecutionPart.INIT
-                beforePart(ExecutionPart.INIT)
-                timeout -= executor.submitAndAwait(arrayOf(this), timeout)
+            // Execute the initial part.
+            initialPartExecution?.let {
+                beforePart(INIT)
+                timeout -= executor.submitAndAwait(arrayOf(it), timeout)
             }
-            // execute parallel part
-            currentExecutionPart = ExecutionPart.PARALLEL
-            beforePart(ExecutionPart.PARALLEL)
+            val afterInitStateRepresentation = constructStateRepresentation()
+            // Execute the parallel part.
+            beforePart(PARALLEL)
             timeout -= executor.submitAndAwait(parallelPartExecutions, timeout)
-            // execute post part
-            postPartExecution?.run {
-                currentExecutionPart = ExecutionPart.POST
-                beforePart(ExecutionPart.POST)
-                timeout -= executor.submitAndAwait(arrayOf(this), timeout)
-                validationFailure?.let { return it }
+            val afterParallelStateRepresentation: String? = constructStateRepresentation()
+            // Execute the post part.
+            postPartExecution?.let {
+                beforePart(POST)
+                timeout -= executor.submitAndAwait(arrayOf(it), timeout)
             }
-            // Combine the results and convert them for the standard class loader (if of non-primitive types).
-            // We do not want the byte-code transformation to be known outside of runner and strategy classes.
+            val afterPostStateRepresentation = constructStateRepresentation()
+            // Execute validation functions
+            executeValidationFunctions(testInstance, validationFunctions) { functionName, exception ->
+                return ValidationFailureInvocationResult(scenario, functionName, exception)
+            }
+            // Combine the results and convert them for the standard class loader (if they are of non-primitive types).
+            // We do not want the transformed code to be reachable outside of the runner and strategy classes.
             return CompletedInvocationResult(
                 ExecutionResult(
                     initResults = initialPartExecution?.results?.toList().orEmpty(),
@@ -277,9 +276,9 @@ internal open class ParallelThreadsRunner(
                         }
                     },
                     postResults = postPartExecution?.results?.toList().orEmpty(),
-                    afterInitStateRepresentation = initialPartExecution?.stateRepresentation,
-                    afterParallelStateRepresentation = postPartExecution?.afterParallelStateRepresentation,
-                    afterPostStateRepresentation = postPartExecution?.afterPostStateRepresentation
+                    afterInitStateRepresentation = afterInitStateRepresentation,
+                    afterParallelStateRepresentation = afterParallelStateRepresentation,
+                    afterPostStateRepresentation = afterPostStateRepresentation
                 ).convertForLoader(LinChecker::class.java.classLoader)
             )
         } catch (e: TimeoutException) {
@@ -292,73 +291,41 @@ internal open class ParallelThreadsRunner(
         }
     }
 
-    private val hasNonTrivialInitialPart: Boolean =
-        scenario.initExecution.isNotEmpty() ||
-        validationFunctions.isNotEmpty() ||
-        stateRepresentationFunction != null
 
     private fun createInitialPartExecution() =
-        if (hasNonTrivialInitialPart) InitTestThreadExecution() else null
-
-    inner class InitTestThreadExecution : TestThreadExecution(INIT_THREAD_ID) {
-        var stateRepresentation: String? = null
-
-        init {
-            initialize(nActors = scenario.initExecution.size, nThreads = 0)
-        }
-
-        override fun run() {
-            scenario.initExecution.mapIndexed { i, actor ->
-                onActorStart(INIT_THREAD_ID)
-                results[i] = executeActor(testInstance, actor)
+        if (scenario.initExecution.isNotEmpty()) {
+            TestThreadExecutionGenerator.create(this, INIT_THREAD_ID,
+                scenario.initExecution,
+                emptyList(),
+                false
+            ).apply {
+                initialize(
+                    nActors = scenario.initExecution.size,
+                    nThreads = 1,
+                )
+                allThreadExecutions = arrayOf(this)
             }
-            stateRepresentation = constructStateRepresentation()
+        } else {
+            null
         }
-    }
-
-    private val hasNonTrivialPostPart: Boolean =
-        scenario.postExecution.isNotEmpty() ||
-        validationFunctions.isNotEmpty() ||
-        stateRepresentationFunction != null
 
     private fun createPostPartExecution() =
-        if (hasNonTrivialPostPart) PostTestThreadExecution() else null
-
-    inner class PostTestThreadExecution : TestThreadExecution(POST_THREAD_ID) {
-
-        var validationFailure: ValidationFailureInvocationResult? = null
-
-        var afterParallelStateRepresentation: String? = null
-        var afterPostStateRepresentation: String? = null
-
-        init {
-            initialize(nActors = scenario.postExecution.size, nThreads = 0)
-        }
-
-        override fun run() {
-            afterParallelStateRepresentation = constructStateRepresentation()
+        if (scenario.postExecution.isNotEmpty()) {
             val dummyCompletion = Continuation<Any?>(EmptyCoroutineContext) {}
-            var suspended = false
-            scenario.postExecution.mapIndexed { i, actor ->
-                results[i] = if (suspended) {
-                    NoResult
-                } else {
-                    // post part may contain suspendable actors if there aren't any in the parallel part,
-                    // invoke with dummy continuation
-                    onActorStart(POST_THREAD_ID)
-                    executeActor(testInstance, actor, dummyCompletion).also {
-                        suspended = it === Suspended
-                    }
-                }
+            TestThreadExecutionGenerator.create(this, POST_THREAD_ID,
+                scenario.postExecution,
+                Array(scenario.postExecution.size) { dummyCompletion }.toList(),
+                scenario.hasSuspendableActors
+            ).apply {
+                initialize(
+                    nActors = scenario.postExecution.size,
+                    nThreads = 1,
+                )
+                allThreadExecutions = arrayOf(this)
             }
-            afterPostStateRepresentation = constructStateRepresentation()
-            executeInIgnoredSection {
-                executeValidationFunctions(testInstance, validationFunctions) { functionName, exception ->
-                    validationFailure = ValidationFailureInvocationResult(scenario, functionName, exception)
-                }
-            }
+        } else {
+            null
         }
-    }
 
     private fun createParallelPartExecutions(): Array<TestThreadExecution> = Array(scenario.nThreads) { iThread ->
         TestThreadExecutionGenerator.create(this, iThread,
@@ -388,6 +355,7 @@ internal open class ParallelThreadsRunner(
     }
 
     override fun onStart(iThread: Int) {
+        if (currentExecutionPart !== PARALLEL) return
         super.onStart(iThread)
         uninitializedThreads.decrementAndGet() // this thread has finished initialization
         // wait for other threads to start
@@ -410,17 +378,6 @@ internal open class ParallelThreadsRunner(
     override fun close() {
         super.close()
         executor.close()
-    }
-
-    private inline fun executeInIgnoredSection(action: () -> Unit) {
-        if (strategy is ManagedStrategy) {
-            strategy.enterIgnoredSection()
-            action()
-            strategy.leaveIgnoredSection()
-        }
-        else {
-            action()
-        }
     }
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
@@ -39,6 +39,9 @@ abstract class Runner protected constructor(
 
     protected val completedOrSuspendedThreads = AtomicInteger(0)
 
+    var currentExecutionPart: ExecutionPart? = null
+        private set
+
     /**
      * This method is a part of `Runner` initialization and should be invoked after this runner
      * creation. It is separated from the constructor to perform the strategy initialization at first.
@@ -135,6 +138,8 @@ abstract class Runner protected constructor(
     }
 
     fun beforePart(part: ExecutionPart) {
+        completedOrSuspendedThreads.set(0)
+        currentExecutionPart = part
         strategy.beforePart(part)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/TestThreadExecutionGenerator.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/TestThreadExecutionGenerator.java
@@ -90,7 +90,7 @@ public class TestThreadExecutionGenerator {
      * Creates a {@link TestThreadExecution} instance with specified {@link TestThreadExecution#run()} implementation.
      */
     public static TestThreadExecution create(Runner runner, int iThread, List<Actor> actors,
-                                             List<ParallelThreadsRunner.Completion> completions,
+                                             List<Continuation> completions,
                                              boolean scenarioContainsSuspendableActors
     ) {
         String className = TestThreadExecution.class.getCanonicalName() + generatedClassNumber++;
@@ -110,7 +110,7 @@ public class TestThreadExecutionGenerator {
     }
 
     private static byte[] generateClass(String internalClassName, Type testClassType, int iThread, List<Actor> actors,
-                                        List<Object> objArgs, List<ParallelThreadsRunner.Completion> completions,
+                                        List<Object> objArgs, List<Continuation> completions,
                                         boolean scenarioContainsSuspendableActors)
     {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
@@ -133,7 +133,7 @@ public class TestThreadExecutionGenerator {
     }
 
     private static void generateRun(ClassVisitor cv, Type testType, int iThread, List<Actor> actors,
-                                    List<Object> objArgs, List<Completion> completions,
+                                    List<Object> objArgs, List<Continuation> completions,
                                     boolean scenarioContainsSuspendableActors)
     {
         int access = ACC_PUBLIC;
@@ -341,7 +341,7 @@ public class TestThreadExecutionGenerator {
         mv.arrayStore(RESULT_TYPE);
     }
 
-    private static void loadArguments(GeneratorAdapter mv, Actor actor, List<Object> objArgs, Completion completion) {
+    private static void loadArguments(GeneratorAdapter mv, Actor actor, List<Object> objArgs, Continuation completion) {
         int nArguments = actor.getArguments().size();
         for (int j = 0; j < nArguments; j++) {
             pushArgumentOnStack(mv, objArgs, actor.getArguments().toArray()[j], actor.getMethod().getParameterTypes()[j]);

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.CancellationResult.*
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.runner.*
+import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.objectweb.asm.*
@@ -94,8 +95,6 @@ abstract class ManagedStrategy(
     // used on resumption, and the trace point before and after the suspension
     // correspond to the same method call in the trace.
     private val suspendedFunctionsStack = Array(nThreads) { mutableListOf<Int>() }
-    // Current execution part
-    protected lateinit var executionPart: ExecutionPart
 
     init {
         runner = createRunner()
@@ -316,7 +315,8 @@ abstract class ManagedStrategy(
         iThread: Int,
         codeLocation: Int
     ) {
-        val shouldSwitchDueToStrategy = shouldSwitch(iThread)
+        // Switch in the parallel part if the strategy decides so.
+        val shouldSwitchDueToStrategy = runner.currentExecutionPart == PARALLEL && shouldSwitch(iThread)
         val spinLockDetected = loopDetector.visitCodeLocation(iThread, codeLocation)
 
         if (spinLockDetected) {
@@ -468,9 +468,11 @@ abstract class ManagedStrategy(
      * Threads to which an execution can be switched from thread [iThread].
      */
     protected fun switchableThreads(iThread: Int) =
-        if (runner.currentExecutionPart == ExecutionPart.PARALLEL)
+        if (runner.currentExecutionPart == PARALLEL) {
             (0 until nThreads).filter { it != iThread && isActive(it) }
-        else listOf()
+        } else {
+            emptyList()
+        }
 
     private fun isTestThread(iThread: Int) = iThread < nThreads
 
@@ -1210,11 +1212,13 @@ private class ManagedStrategyRunner(
     stateRepresentationMethod: Method?, timeoutMs: Long, useClocks: UseClocks
 ) : ParallelThreadsRunner(managedStrategy, testClass, validationFunctions, stateRepresentationMethod, timeoutMs, useClocks) {
     override fun onStart(iThread: Int) {
+        if (currentExecutionPart !== PARALLEL) return
         super.onStart(iThread)
         managedStrategy.onStart(iThread)
     }
 
     override fun onFinish(iThread: Int) {
+        if (currentExecutionPart !== PARALLEL) return
         managedStrategy.onFinish(iThread)
         super.onFinish(iThread)
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -100,7 +100,6 @@ internal class ModelCheckingStrategy(
             ExecutionPart.PARALLEL -> currentInterleaving.chooseThread(0)
             ExecutionPart.POST -> 0
         }
-        executionPart = part
         loopDetector.beforePart(nextThread)
         currentThread = nextThread
     }


### PR DESCRIPTION
We need to unify the init, post, and parallel scenario parts running. Otherwise, it's hard to proceed with #136.