### PR TITLE
Strategy run API refactoring

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -45,7 +45,7 @@ abstract class CTestConfiguration(
 
     abstract fun createStrategy(
         testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-        stateRepresentationMethod: Method?, verifier: Verifier
+        stateRepresentationMethod: Method?
     ): Strategy
 
     companion object {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -37,7 +37,7 @@ private typealias SuspensionPointResultWithContinuation = AtomicReference<Pair<k
  *
  * It is pretty useful for stress testing or if you do not care about context switch expenses.
  */
-internal open class ParallelThreadsRunner(
+open class ParallelThreadsRunner(
     strategy: Strategy,
     testClass: Class<*>,
     validationFunction: Actor?,
@@ -445,6 +445,6 @@ internal open class ParallelThreadsRunner(
     override fun onFailure(iThread: Int, e: Throwable) {}
 }
 
-internal enum class UseClocks { ALWAYS, RANDOM }
+enum class UseClocks { ALWAYS, RANDOM }
 
 internal enum class CompletionStatus { CANCELLED, RESUMED }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -37,7 +37,7 @@ private typealias SuspensionPointResultWithContinuation = AtomicReference<Pair<k
  *
  * It is pretty useful for stress testing or if you do not care about context switch expenses.
  */
-open class ParallelThreadsRunner(
+internal open class ParallelThreadsRunner(
     strategy: Strategy,
     testClass: Class<*>,
     validationFunction: Actor?,
@@ -445,6 +445,6 @@ open class ParallelThreadsRunner(
     override fun onFailure(iThread: Int, e: Throwable) {}
 }
 
-enum class UseClocks { ALWAYS, RANDOM }
+internal enum class UseClocks { ALWAYS, RANDOM }
 
 internal enum class CompletionStatus { CANCELLED, RESUMED }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -101,18 +101,11 @@ abstract class Strategy protected constructor(
  * @return the failure, if detected, null otherwise.
  */
 fun Strategy.runIteration(invocations: Int, verifier: Verifier): LincheckFailure? {
-    var spinning = false
     for (invocation in 0 until invocations) {
-        if (!(spinning || nextInvocation()))
+        if (!nextInvocation())
             return null
-        spinning = false
-        val failure = run {
-            val result = runInvocation()
-            spinning = (result is SpinCycleFoundAndReplayRequired)
-            if (!spinning)
-                verify(result, verifier)
-            else null
-        }
+        val result = runInvocation()
+        val failure = verify(result, verifier)
         if (failure != null)
             return failure
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -101,7 +101,7 @@ abstract class Strategy protected constructor(
  *
  * @return the failure, if detected, null otherwise.
  */
-fun Strategy.runIteration(iteration: Int, invocationsBound: Int, verifier: Verifier): LincheckFailure? {
+fun Strategy.runIteration(invocationsBound: Int, verifier: Verifier): LincheckFailure? {
     var spinning = false
     for (invocation in 0 until invocationsBound) {
         if (!(spinning || nextInvocation()))

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -27,6 +27,11 @@ abstract class Strategy protected constructor(
 ) : Closeable {
 
     /**
+     * Runner used for executing the test scenario.
+     */
+    protected abstract val runner: Runner
+
+    /**
      * Sets the internal state of strategy to run the next invocation.
      *
      * @return true if there is next invocation to run, false if all invocations have been studied.
@@ -89,7 +94,9 @@ abstract class Strategy protected constructor(
     /**
      * Closes the strategy and releases any resources associated with it.
      */
-    override fun close() {}
+    override fun close() {
+        runner.close()
+    }
 }
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -102,15 +102,14 @@ abstract class Strategy protected constructor(
 /**
  * Runs one Lincheck's test iteration with the given strategy and verifier.
  *
- * @param iteration the id of the iteration.
- * @param invocationsBound number of invocations to run.
+ * @param invocations number of invocations to run.
  * @param verifier the verifier to be used.
  *
  * @return the failure, if detected, null otherwise.
  */
-fun Strategy.runIteration(invocationsBound: Int, verifier: Verifier): LincheckFailure? {
+fun Strategy.runIteration(invocations: Int, verifier: Verifier): LincheckFailure? {
     var spinning = false
-    for (invocation in 0 until invocationsBound) {
+    for (invocation in 0 until invocations) {
         if (!(spinning || nextInvocation()))
             return null
         spinning = false

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -29,7 +29,7 @@ abstract class Strategy protected constructor(
     /**
      * Runner used for executing the test scenario.
      */
-    protected abstract val runner: Runner
+    internal abstract val runner: Runner
 
     /**
      * Sets the internal state of strategy to run the next invocation.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -39,20 +39,13 @@ abstract class Strategy protected constructor(
     open fun nextInvocation(): Boolean = true
 
     /**
-     * Initializes the invocation.
-     * Should be called before each call to [runInvocation].
-     */
-    open fun initializeInvocation() {}
-
-    /**
      * Runs the current invocation and returns its result.
      *
-     * Should be called after [initializeInvocation] and only if previous call to [nextInvocation] returned `true`:
+     * Should be called only if previous call to [nextInvocation] returned `true`:
      *
      * ```kotlin
      *  with(strategy) {
      *      if (nextInvocation()) {
-     *          initializeInvocation()
      *          runInvocation()
      *      }
      *  }
@@ -113,7 +106,6 @@ fun Strategy.runIteration(invocations: Int, verifier: Verifier): LincheckFailure
         if (!(spinning || nextInvocation()))
             return null
         spinning = false
-        initializeInvocation()
         val failure = run {
             val result = runInvocation()
             spinning = (result is SpinCycleFoundAndReplayRequired)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -134,7 +134,7 @@ abstract class ManagedStrategy(
     private lateinit var callStackContextPerThread: Array<ArrayList<CallContext>>
 
     override fun close() {
-        runner.close()
+        super.close()
         // clear object numeration at the end to avoid memory leaks
         cleanObjectNumeration()
     }
@@ -1518,7 +1518,7 @@ abstract class ManagedStrategy(
  * This class is a [ParallelThreadsRunner] with some overrides that add callbacks
  * to the strategy so that it can known about some required events.
  */
-class ManagedStrategyRunner(
+internal class ManagedStrategyRunner(
     private val managedStrategy: ManagedStrategy,
     testClass: Class<*>, validationFunction: Actor?, stateRepresentationMethod: Method?,
     timeoutMs: Long, useClocks: UseClocks

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -56,7 +56,7 @@ abstract class ManagedStrategy(
 
     // Runner for scenario invocations,
     // can be replaced with a new one for trace construction.
-    internal var runner: ManagedStrategyRunner = createRunner()
+    override var runner = createRunner()
 
     // Spin-waiters for each thread
     private val spinners = SpinnerGroup(nThreads)
@@ -1519,7 +1519,7 @@ abstract class ManagedStrategy(
  * This class is a [ParallelThreadsRunner] with some overrides that add callbacks
  * to the strategy so that it can known about some required events.
  */
-internal class ManagedStrategyRunner(
+class ManagedStrategyRunner(
     private val managedStrategy: ManagedStrategy,
     testClass: Class<*>, validationFunction: Actor?, stateRepresentationMethod: Method?,
     timeoutMs: Long, useClocks: UseClocks

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -135,6 +135,8 @@ abstract class ManagedStrategy(
 
     override fun close() {
         runner.close()
+        // clear object numeration at the end to avoid memory leaks
+        cleanObjectNumeration()
     }
 
     private fun createRunner(): ManagedStrategyRunner =
@@ -247,8 +249,11 @@ abstract class ManagedStrategy(
         // Therefore, if the runner detects deadlock, we don't even try to collect trace.
         if (loggedResults is RunnerTimeoutInvocationResult) return null
         val sameResultTypes = loggedResults.javaClass == result.javaClass
-        val sameResults =
-            loggedResults !is CompletedInvocationResult || result !is CompletedInvocationResult || loggedResults.results == failingResult.results
+        val sameResults = (
+            loggedResults !is CompletedInvocationResult ||
+            result !is CompletedInvocationResult ||
+            loggedResults.results == result.results
+        )
         check(sameResultTypes && sameResults) {
             StringBuilder().apply {
                 appendln("Non-determinism found. Probably caused by non-deterministic code (WeakHashMap, Object.hashCode, etc).")

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -280,8 +280,7 @@ abstract class ManagedStrategy(
     }
 
     private fun failDueToLivelock(lazyMessage: () -> String): Nothing {
-        suddenInvocationResult =
-            ObstructionFreedomViolationInvocationResult(lazyMessage(), runner.collectExecutionResults())
+        suddenInvocationResult = ObstructionFreedomViolationInvocationResult(lazyMessage(), runner.collectExecutionResults())
         // Forcibly finish the current execution by throwing an exception.
         throw ForcibleExecutionFinishError
     }
@@ -303,10 +302,10 @@ abstract class ManagedStrategy(
 
     private val concurrentActorCausesBlocking: Boolean
         get() = currentActorId.mapIndexed { iThread, actorId ->
-            if (iThread != currentThread && actorId >= 0 && !finished[iThread])
-                scenario.threads[iThread][actorId]
-            else null
-        }.filterNotNull().any { it.causesBlocking }
+                    if (iThread != currentThread && actorId >= 0 && !finished[iThread])
+                        scenario.threads[iThread][actorId]
+                    else null
+                }.filterNotNull().any { it.causesBlocking }
 
 
     // == EXECUTION CONTROL METHODS ==

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -173,8 +173,7 @@ abstract class ManagedStrategy(
     /**
      * Resets all internal data to the initial state and initializes current invocation to be run.
      */
-    override fun initializeInvocation() {
-        super.initializeInvocation()
+    protected open fun initializeInvocation() {
         finished.fill(false)
         isSuspended.fill(false)
         currentActorId.fill(-1)
@@ -191,7 +190,7 @@ abstract class ManagedStrategy(
      * Runs the current invocation.
      */
     override fun runInvocation(): InvocationResult {
-        // initializeInvocation()
+        initializeInvocation()
         val result = runner.run()
         // In case the runner detects a deadlock, some threads can still manipulate the current strategy,
         // so we're not interested in suddenInvocationResult in this case
@@ -241,7 +240,6 @@ abstract class ManagedStrategy(
 
         runner.close()
         runner = createRunner()
-        initializeInvocation()
 
         val loggedResults = runInvocation()
         // In case the runner detects a deadlock, some threads can still be in an active state,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -59,5 +59,5 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
         scenario: ExecutionScenario,
         validationFunction: Actor?,
         stateRepresentationMethod: Method?,
-    ): Strategy = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
+    ): Strategy = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod, isReplayModeForIdeaPluginEnabled)
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -50,11 +50,14 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
 
     private var isReplayModeForIdeaPluginEnabled = false
 
-    override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-                                stateRepresentationMethod: Method?, verifier: Verifier): Strategy
-        = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod, verifier, isReplayModeForIdeaPluginEnabled)
-
     internal fun enableReplayModeForIdeaPlugin() {
         isReplayModeForIdeaPluginEnabled = true
     }
+
+    override fun createStrategy(
+        testClass: Class<*>,
+        scenario: ExecutionScenario,
+        validationFunction: Actor?,
+        stateRepresentationMethod: Method?,
+    ): Strategy = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -63,11 +63,9 @@ internal class ModelCheckingStrategy(
         currentInterleaving.initialize()
     }
 
-    override fun runInvocation(): InvocationResult {
-        return super.runInvocation().also {
-            if (it is SpinCycleFoundAndReplayRequired)
-                currentInterleaving.rollbackAfterSpinCycleFound()
-        }
+    override fun enableSpinCycleReplay() {
+        super.enableSpinCycleReplay()
+        currentInterleaving.rollbackAfterSpinCycleFound()
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ObjectLabelFactory.cleanObjectNumeration
-import org.jetbrains.kotlinx.lincheck.verifier.*
 import java.lang.reflect.*
 import kotlin.random.*
 
@@ -41,13 +40,8 @@ internal class ModelCheckingStrategy(
     scenario: ExecutionScenario,
     validationFunction: Actor?,
     stateRepresentation: Method?,
-    verifier: Verifier,
     val replay: Boolean,
-) : ManagedStrategy(testClass, scenario, verifier, validationFunction, stateRepresentation, testCfg) {
-    // The number of invocations that the strategy is eligible to use to search for an incorrect execution.
-    private val maxInvocations = testCfg.invocationsPerIteration
-    // The number of already used invocations.
-    private var usedInvocations = 0
+) : ManagedStrategy(testClass, scenario, validationFunction, stateRepresentation, testCfg) {
     // The maximum number of thread switch choices that strategy should perform
     // (increases when all the interleavings with the current depth are studied).
     private var maxNumberOfSwitches = 0
@@ -58,26 +52,22 @@ internal class ModelCheckingStrategy(
     // The interleaving that will be studied on the next invocation.
     private lateinit var currentInterleaving: Interleaving
 
-    override fun runImpl(): LincheckFailure? {
-        currentInterleaving = root.nextInterleaving() ?: return null
-        while (usedInvocations < maxInvocations) {
-            // run invocation and check its results
-            val invocationResult = runInvocation()
-            if (suddenInvocationResult is SpinCycleFoundAndReplayRequired) {
-                // Restart the current interleaving with
-                // the collected knowledge about the detected spin loop.
+    override fun nextInvocation(): Boolean {
+        currentInterleaving = root.nextInterleaving()
+            ?: return false
+        return true
+    }
+
+    override fun initializeInvocation() {
+        super.initializeInvocation()
+        currentInterleaving.initialize()
+    }
+
+    override fun runInvocation(): InvocationResult {
+        return super.runInvocation().also {
+            if (it is SpinCycleFoundAndReplayRequired)
                 currentInterleaving.rollbackAfterSpinCycleFound()
-                continue
-            }
-            usedInvocations++
-            checkResult(invocationResult)?.let { failure ->
-                runReplayIfPluginEnabled(failure)
-                return failure
-            }
-            // get new unexplored interleaving
-            currentInterleaving = root.nextInterleaving() ?: break
         }
-        return null
     }
 
     /**
@@ -299,11 +289,6 @@ internal class ModelCheckingStrategy(
         check(iThread == currentThread)
         currentInterleaving.newExecutionPosition(iThread)
         return currentInterleaving.isSwitchPosition()
-    }
-
-    override fun initializeInvocation() {
-        currentInterleaving.initialize()
-        super.initializeInvocation()
     }
 
     override fun beforePart(part: ExecutionPart) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -72,7 +72,7 @@ internal class ModelCheckingStrategy(
      * If the plugin enabled and the failure has a trace, passes information about
      * the trace and the failure to the Plugin and run re-run execution to debug it.
      */
-    private fun runReplayIfPluginEnabled(failure: LincheckFailure) {
+    internal fun runReplayIfPluginEnabled(failure: LincheckFailure) {
         if (replay && failure.trace != null) {
             // Extract trace representation in the appropriate view.
             val trace = constructTraceForPlugin(failure, failure.trace)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -41,9 +41,12 @@ class StressCTestConfiguration(
 
     override val instrumentationMode: InstrumentationMode get() = STRESS
 
-    override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-                                stateRepresentationMethod: Method?, verifier: Verifier) =
-        StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod, verifier)
+    override fun createStrategy(
+        testClass: Class<*>,
+        scenario: ExecutionScenario,
+        validationFunction: Actor?,
+        stateRepresentationMethod: Method?
+    ) = StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
 
     companion object {
         const val DEFAULT_INVOCATIONS = 10000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -41,12 +41,9 @@ class StressCTestConfiguration(
 
     override val instrumentationMode: InstrumentationMode get() = STRESS
 
-    override fun createStrategy(
-        testClass: Class<*>,
-        scenario: ExecutionScenario,
-        validationFunction: Actor?,
-        stateRepresentationMethod: Method?
-    ) = StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
+    override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
+                                stateRepresentationMethod: Method?) =
+        StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
 
     companion object {
         const val DEFAULT_INVOCATIONS = 10000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
@@ -22,7 +22,8 @@ class StressStrategy(
     validationFunction: Actor?,
     stateRepresentationFunction: Method?,
 ) : Strategy(scenario) {
-    private val runner = ParallelThreadsRunner(
+
+    override val runner : Runner = ParallelThreadsRunner(
         strategy = this,
         testClass = testClass,
         validationFunction = validationFunction,
@@ -32,8 +33,4 @@ class StressStrategy(
     )
 
     override fun runInvocation(): InvocationResult = runner.run()
-
-    override fun close() {
-        runner.close()
-    }
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlinx.lincheck.Actor
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
-import org.jetbrains.kotlinx.lincheck.verifier.*
 import java.lang.reflect.*
 
 class StressStrategy(
@@ -22,9 +21,7 @@ class StressStrategy(
     scenario: ExecutionScenario,
     validationFunction: Actor?,
     stateRepresentationFunction: Method?,
-    private val verifier: Verifier
 ) : Strategy(scenario) {
-    private val invocations = testCfg.invocationsPerIteration
     private val runner = ParallelThreadsRunner(
         strategy = this,
         testClass = testClass,
@@ -34,19 +31,11 @@ class StressStrategy(
         useClocks = UseClocks.RANDOM
     )
 
-    override fun run(): LincheckFailure? {
-        runner.use {
-            // Run invocations
-            for (invocation in 0 until invocations) {
-                when (val ir = runner.run()) {
-                    is CompletedInvocationResult -> {
-                        if (!verifier.verifyResults(scenario, ir.results))
-                            return IncorrectResultsFailure(scenario, ir.results)
-                    }
-                    else -> return ir.toLincheckFailure(scenario)
-                }
-            }
-            return null
-        }
+    override fun runInvocation(): InvocationResult {
+        return runner.run()
+    }
+
+    override fun close() {
+        runner.close()
     }
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
@@ -31,9 +31,7 @@ class StressStrategy(
         useClocks = UseClocks.RANDOM
     )
 
-    override fun runInvocation(): InvocationResult {
-        return runner.run()
-    }
+    override fun runInvocation(): InvocationResult = runner.run()
 
     override fun close() {
         runner.close()

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
@@ -175,5 +175,6 @@ class ParallelThreadExecutionExceptionsTest {
 }
 
 fun mockStrategy(scenario: ExecutionScenario) = object : Strategy(scenario) {
+    override val runner: Runner get() = error("Not yet implemented")
     override fun runInvocation(): InvocationResult = error("Not yet implemented")
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
@@ -175,5 +175,5 @@ class ParallelThreadExecutionExceptionsTest {
 }
 
 fun mockStrategy(scenario: ExecutionScenario) = object : Strategy(scenario) {
-    override fun run(): LincheckFailure? = error("Not yet implemented")
+    override fun runInvocation(): InvocationResult = error("Not yet implemented")
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
@@ -30,7 +30,7 @@ public class TestThreadExecutionHelperTest {
         ExecutionScenario scenario = new ExecutionScenario(emptyList(), emptyList(), emptyList(), null);
         Strategy strategy = new Strategy(scenario) {
             @Override
-            public LincheckFailure run() {
+            public InvocationResult runInvocation() {
                 throw new UnsupportedOperationException();
             }
         };

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
@@ -30,6 +30,11 @@ public class TestThreadExecutionHelperTest {
         ExecutionScenario scenario = new ExecutionScenario(emptyList(), emptyList(), emptyList(), null);
         Strategy strategy = new Strategy(scenario) {
             @Override
+            public Runner getRunner$lincheck() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public InvocationResult runInvocation() {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
This PR proposes a simple refactoring of the `Strategy` class API. 

**Motivation**

Currently, the `Strategy` API provides the following method to run the scenario:

```kotlin
abstract fun run(): LincheckFailure?
```

This method should run the scenario (some) number of times and returns the failure, in case if any invocation fails. 

This API leads to code duplication in the current code base.
* Both stress and model-checking strategies in fact run the scenario fixed number of times in a loop. This loop is duplicated in both implementations. 
* Both strategies run verifier on each invocation result. Again, the implementation of verification method is duplicated in both strategies. 

This PR proposes to change the API, so that the `Strategy` instead provides the method to run single invocation:
```kotlin
abstract fun runInvocation(): InvocationResult
``` 

This change allows to implement the previously duplicated functionality in a single place, as a bunch of `Strategy` interface extension methods. 

Note that in addition, the new API adds two (optional) methods to implement:
```kotlin
    /**
     * Sets the internal state of strategy to run the next invocation.
     *
     * @return true if there is next invocation to run, false if all invocations have been studied.
     */
    open fun nextInvocation(): Boolean = true

    /**
     * Initializes the invocation.
     * Should be called before each call to [runInvocation].
     */
    open fun initializeInvocation() {}
```

Thus, the pattern to run the strategy becomes as follows:
```kotlin
// run single invocation (if available)
with(strategy) {
     if (nextInvocation()) {
        initializeInvocation()
        runInvocation()
     }
}
```

For deterministic strategies (like model checking strategy), consecutive calls of `runInvocation` withouth `nextInvocation` calls, should lead to the same results:

```kotlin
with(strategy) {
     if (nextInvocation()) {
        // first invocation run
        initializeInvocation()
        val r1 = runInvocation()
        // second invocation run
        initializeInvocation()
        val r2 = runInvocation()
        // two invocations should return the same result
        check(r1 == r2)
     }
}
```

This change also simplifies implementation of the new features. 

* In #250 we need to collect the statistics of running each invocation (e.g. its running time). With the old API, this again would require the code duplication in all `Strategy` implementers. 

* In #158 we want to implement the adaptive dynamic selection of the number of invocations to be run. This change requires to offload the decision on how many times to run the scenario from the `Strategy` class into the `Planner` class. Again, with the new API this becomes trivial.  