### PR TITLE
Trace collection in stress mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ tasks {
     withType<Test> {
         maxParallelForks = 1
         jvmArgs(
+            "-Xmx1G",
             "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
             "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED",
             "--add-exports", "java.base/sun.security.action=ALL-UNNAMED"

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -39,7 +39,7 @@ abstract class CTestConfiguration(
 ) {
     abstract fun createStrategy(
         testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-        stateRepresentationMethod: Method?, verifier: Verifier
+        stateRepresentationMethod: Method?
     ): Strategy
 
     companion object {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -9,6 +9,7 @@
  */
 package org.jetbrains.kotlinx.lincheck
 
+import org.jetbrains.kotlinx.lincheck.CTestConfiguration.Companion.DEFAULT_REPRODUCE_WITH_MODEL_CHECKING
 import org.jetbrains.kotlinx.lincheck.CTestConfiguration.Companion.DEFAULT_TIMEOUT_MS
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
@@ -33,6 +34,7 @@ abstract class CTestConfiguration(
     val generatorClass: Class<out ExecutionGenerator>,
     val verifierClass: Class<out Verifier>,
     val minimizeFailedScenario: Boolean,
+    val reproduceWithModelChecking: Boolean,
     val sequentialSpecification: Class<*>,
     val timeoutMs: Long,
     val customScenarios: List<ExecutionScenario>
@@ -51,6 +53,7 @@ abstract class CTestConfiguration(
         val DEFAULT_EXECUTION_GENERATOR: Class<out ExecutionGenerator?> = RandomExecutionGenerator::class.java
         val DEFAULT_VERIFIER: Class<out Verifier> = LinearizabilityVerifier::class.java
         const val DEFAULT_MINIMIZE_ERROR = true
+        const val DEFAULT_REPRODUCE_WITH_MODEL_CHECKING = true
         const val DEFAULT_TIMEOUT_MS: Long = 10000
     }
 }
@@ -69,6 +72,7 @@ internal fun createFromTestClassAnnotations(testClass: Class<*>): List<CTestConf
                 verifierClass = ann.verifier.java,
                 invocationsPerIteration = ann.invocationsPerIteration,
                 minimizeFailedScenario = ann.minimizeFailedScenario,
+                reproduceWithModelChecking = ann.reproduceWithModelChecking,
                 sequentialSpecification = chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
                 timeoutMs = DEFAULT_TIMEOUT_MS,
                 customScenarios = emptyList()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -13,12 +13,14 @@ import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
+import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import kotlin.reflect.*
 
 /**
  * This class runs concurrent tests.
  */
-class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
+class LinChecker(private val testClass: Class<*>, options: Options<*, *>?) {
     private val testStructure = CTestStructure.getFromTestClass(testClass)
     private val testConfigurations: List<CTestConfiguration>
     private val reporter: Reporter
@@ -50,80 +52,65 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
         check(testConfigurations.isNotEmpty()) { "No Lincheck test configuration to run" }
         for (testCfg in testConfigurations) {
             val failure = testCfg.checkImpl()
-            if (failure != null) return failure
+            if (failure != null)
+                return failure
         }
         return null
     }
 
     private fun CTestConfiguration.checkImpl(): LincheckFailure? {
-        val exGen = createExecutionGenerator(testStructure.randomProvider)
-        for (i in customScenarios.indices) {
-            val verifier = createVerifier()
-            val scenario = customScenarios[i]
-            scenario.validate()
-            reporter.logIteration(i + 1, customScenarios.size, scenario)
-            val failure = scenario.run(this, verifier)
-            if (failure != null) return failure
-        }
         var verifier = createVerifier()
-        repeat(iterations) { i ->
+        val generator = createExecutionGenerator(testStructure.randomProvider)
+        val randomScenarios = generateSequence {
+            generator.nextExecution().also {
+                // reset the parameter generator ranges to start with the same initial bounds for each scenario.
+                testStructure.parameterGenerators.forEach { it.reset() }
+            }
+        }
+        val scenarios = customScenarios.asSequence() + randomScenarios.take(iterations)
+        val scenariosSize = customScenarios.size + iterations
+        scenarios.forEachIndexed { i, scenario ->
+            val isCustomScenario = (i < customScenarios.size)
             // For performance reasons, verifier re-uses LTS from previous iterations.
-            // This behaviour is similar to a memory leak and can potentially cause OutOfMemoryError.
+            // This behavior is similar to a memory leak and can potentially cause OutOfMemoryError.
             // This is why we periodically create a new verifier to still have increased performance
             // from re-using LTS and limit the size of potential memory leak.
             // https://github.com/Kotlin/kotlinx-lincheck/issues/124
             if ((i + 1) % VERIFIER_REFRESH_CYCLE == 0)
                 verifier = createVerifier()
-            val scenario = exGen.nextExecution()
             scenario.validate()
-            reporter.logIteration(i + 1 + customScenarios.size, iterations, scenario)
-            val failure = scenario.run(this, verifier)
-            if (failure != null) {
-                val minimizedFailedIteration = if (!minimizeFailedScenario) failure else failure.minimize(this)
-                reporter.logFailedIteration(minimizedFailedIteration)
-                return minimizedFailedIteration
+            reporter.logIteration(i + 1, scenariosSize, scenario)
+            var failure = scenario.run(i, this, verifier)
+            if (failure == null)
+                return@forEachIndexed
+            if (minimizeFailedScenario && !isCustomScenario) {
+                var j = i + 1
+                reporter.logScenarioMinimization(scenario)
+                failure = failure.minimize { minimizedScenario ->
+                    minimizedScenario.run(j++, this, createVerifier())
+                }
             }
-            // Reset the parameter generator ranges to start with the same initial bounds on each scenario generation.
-            testStructure.parameterGenerators.forEach { it.reset() }
+            reporter.logFailedIteration(failure)
+            return failure
         }
         return null
     }
 
-    // Tries to minimize the specified failing scenario to make the error easier to understand.
-    // The algorithm is greedy: it tries to remove one actor from the scenario and checks
-    // whether a test with the modified one fails with error as well. If it fails,
-    // then the scenario has been successfully minimized, and the algorithm tries to minimize it again, recursively.
-    // Otherwise, if no actor can be removed so that the generated test fails, the minimization is completed.
-    // Thus, the algorithm works in the linear time of the total number of actors.
-    private fun LincheckFailure.minimize(testCfg: CTestConfiguration): LincheckFailure {
-        reporter.logScenarioMinimization(scenario)
-        var minimizedFailure = this
-        while (true) {
-            minimizedFailure = minimizedFailure.scenario.tryMinimize(testCfg) ?: break
-        }
-        return minimizedFailure
-    }
-
-    private fun ExecutionScenario.tryMinimize(testCfg: CTestConfiguration): LincheckFailure? {
-        // Reversed indices to avoid conflicts with in-loop removals
-        for (i in threads.indices.reversed()) {
-            for (j in threads[i].indices.reversed()) {
-                tryMinimize(i, j)
-                    ?.run(testCfg, testCfg.createVerifier())
-                    ?.let { return it }
-            }
-        }
-        return null
-    }
-
-    private fun ExecutionScenario.run(testCfg: CTestConfiguration, verifier: Verifier): LincheckFailure? =
-        testCfg.createStrategy(
+    private fun ExecutionScenario.run(
+        iteration: Int,
+        testCfg: CTestConfiguration,
+        verifier: Verifier,
+    ): LincheckFailure? {
+        val strategy = testCfg.createStrategy(
             testClass = testClass,
             scenario = this,
             validationFunction = testStructure.validationFunction,
             stateRepresentationMethod = testStructure.stateRepresentation,
-            verifier = verifier
-        ).run()
+        )
+        return strategy.use {
+            it.runIteration(iteration, testCfg.invocationsPerIteration, verifier)
+        }
+    }
 
     private fun CTestConfiguration.createVerifier() =
         verifierClass.getConstructor(Class::class.java).newInstance(sequentialSpecification)
@@ -134,6 +121,12 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
             CTestStructure::class.java,
             RandomProvider::class.java
         ).newInstance(this, testStructure, randomProvider)
+
+    private val CTestConfiguration.invocationsPerIteration get() = when (this) {
+        is ModelCheckingCTestConfiguration -> this.invocationsPerIteration
+        is StressCTestConfiguration -> this.invocationsPerIteration
+        else -> error("unexpected")
+    }
 
     // This companion object is used for backwards compatibility.
     companion object {
@@ -151,6 +144,33 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
 
         private const val VERIFIER_REFRESH_CYCLE = 100
     }
+}
+
+// Tries to minimize the specified failing scenario to make the error easier to understand.
+// The algorithm is greedy: it tries to remove one actor from the scenario and checks
+// whether a test with the modified one fails with error as well. If it fails,
+// then the scenario has been successfully minimized, and the algorithm tries to minimize it again, recursively.
+// Otherwise, if no actor can be removed so that the generated test fails, the minimization is completed.
+// Thus, the algorithm works in the linear time of the total number of actors.
+private fun LincheckFailure.minimize(checkScenario: (ExecutionScenario) -> LincheckFailure?): LincheckFailure {
+    var minimizedFailure = this
+    while (true) {
+        minimizedFailure = minimizedFailure.scenario.tryMinimize(checkScenario)
+            ?: break
+    }
+    return minimizedFailure
+}
+
+private fun ExecutionScenario.tryMinimize(checkScenario: (ExecutionScenario) -> LincheckFailure?): LincheckFailure? {
+    // Reversed indices to avoid conflicts with in-loop removals
+    for (i in threads.indices.reversed()) {
+        for (j in threads[i].indices.reversed()) {
+            tryMinimize(i, j)
+                ?.run(checkScenario)
+                ?.let { return it }
+        }
+    }
+    return null
 }
 
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -92,7 +92,7 @@ class LinChecker(private val testClass: Class<*>, options: Options<*, *>?) {
                 }
             }
             val isStressMode = (this is StressCTestConfiguration)
-            if (isStressMode) {
+            if (isStressMode && reproduceWithModelChecking) {
                 // stress mode does not support trace reporting, so we attempt to reproduce the failure
                 // with the model checking mode and collect the trace
                 check(failure.trace == null)
@@ -152,8 +152,10 @@ class LinChecker(private val testClass: Class<*>, options: Options<*, *>?) {
             validationFunction = testStructure.validationFunction,
             stateRepresentationMethod = testStructure.stateRepresentation,
         )
+        val invocationsPerIteration = testCfg.invocationsPerIteration
+            .coerceAtMost(MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT)
         return strategy.use {
-            it.runIteration(iteration, MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT, verifier)
+            it.runIteration(iteration, invocationsPerIteration, verifier)
         }
     }
 
@@ -239,4 +241,4 @@ fun <O : Options<O, *>> O.check(testClass: KClass<*>) = this.check(testClass.jav
 
 internal fun <O : Options<O, *>> O.checkImpl(testClass: Class<*>) = LinChecker(testClass, this).checkImpl()
 
-private const val MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT = 10_000
+private const val MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT = 5_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import kotlin.reflect.*
@@ -71,24 +72,33 @@ class LinChecker(private val testClass: Class<*>, options: Options<*, *>?) {
         val scenariosSize = customScenarios.size + iterations
         scenarios.forEachIndexed { i, scenario ->
             val isCustomScenario = (i < customScenarios.size)
+            var iteration = i
             // For performance reasons, verifier re-uses LTS from previous iterations.
             // This behavior is similar to a memory leak and can potentially cause OutOfMemoryError.
             // This is why we periodically create a new verifier to still have increased performance
             // from re-using LTS and limit the size of potential memory leak.
             // https://github.com/Kotlin/kotlinx-lincheck/issues/124
-            if ((i + 1) % VERIFIER_REFRESH_CYCLE == 0)
+            if (iteration + 1 % VERIFIER_REFRESH_CYCLE == 0)
                 verifier = createVerifier()
             scenario.validate()
-            reporter.logIteration(i + 1, scenariosSize, scenario)
-            var failure = scenario.run(i, this, verifier)
-            if (failure == null)
-                return@forEachIndexed
+            reporter.logIteration(iteration, scenariosSize, scenario)
+            var failure = scenario.run(iteration, this, verifier)
+                ?: return@forEachIndexed
             if (minimizeFailedScenario && !isCustomScenario) {
-                var j = i + 1
                 reporter.logScenarioMinimization(scenario)
+                verifier = createVerifier()
                 failure = failure.minimize { minimizedScenario ->
-                    minimizedScenario.run(j++, this, createVerifier())
+                    minimizedScenario.run(++iteration, this, verifier)
                 }
+            }
+            val isStressMode = (this is StressCTestConfiguration)
+            if (isStressMode) {
+                // stress mode does not support trace reporting, so we attempt to reproduce the failure
+                // with the model checking mode and collect the trace
+                check(failure.trace == null)
+                reporter.logFailureReproduction(failure)
+                verifier = createVerifier()
+                failure = failure.tryReproduceInModelCheckingMode(++iteration, this, verifier) ?: failure
             }
             reporter.logFailedIteration(failure)
             return failure
@@ -109,6 +119,41 @@ class LinChecker(private val testClass: Class<*>, options: Options<*, *>?) {
         )
         return strategy.use {
             it.runIteration(iteration, testCfg.invocationsPerIteration, verifier)
+        }
+    }
+
+    private fun LincheckFailure.tryReproduceInModelCheckingMode(
+        iteration: Int,
+        testCfg: CTestConfiguration,
+        verifier: Verifier
+    ): LincheckFailure? {
+        val modelCheckingConfiguration = ModelCheckingCTestConfiguration(
+            testClass = testCfg.testClass,
+            iterations = testCfg.iterations,
+            invocationsPerIteration = testCfg.invocationsPerIteration,
+            threads = testCfg.threads,
+            actorsPerThread = testCfg.actorsPerThread,
+            actorsBefore = testCfg.actorsBefore,
+            actorsAfter = testCfg.actorsAfter,
+            generatorClass = testCfg.generatorClass,
+            verifierClass = testCfg.verifierClass,
+            sequentialSpecification = testCfg.sequentialSpecification,
+            minimizeFailedScenario = false,
+            timeoutMs = testCfg.timeoutMs,
+            customScenarios = testCfg.customScenarios,
+            checkObstructionFreedom = ManagedCTestConfiguration.DEFAULT_CHECK_OBSTRUCTION_FREEDOM,
+            hangingDetectionThreshold = ManagedCTestConfiguration.DEFAULT_HANGING_DETECTION_THRESHOLD,
+            eliminateLocalObjects = ManagedCTestConfiguration.DEFAULT_ELIMINATE_LOCAL_OBJECTS,
+            guarantees = ManagedCTestConfiguration.DEFAULT_GUARANTEES,
+        )
+        val strategy = modelCheckingConfiguration.createStrategy(
+            testClass = testClass,
+            scenario = scenario,
+            validationFunction = testStructure.validationFunction,
+            stateRepresentationMethod = testStructure.stateRepresentation,
+        )
+        return strategy.use {
+            it.runIteration(iteration, MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT, verifier)
         }
     }
 
@@ -193,3 +238,5 @@ fun <O : Options<O, *>> O.check(testClass: Class<*>) = LinChecker.check(testClas
 fun <O : Options<O, *>> O.check(testClass: KClass<*>) = this.check(testClass.java)
 
 internal fun <O : Options<O, *>> O.checkImpl(testClass: Class<*>) = LinChecker(testClass, this).checkImpl()
+
+private const val MODEL_CHECKING_FAILURE_REPRODUCTION_INVOCATIONS_COUNT = 10_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -26,6 +26,7 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
     protected var executionGenerator = CTestConfiguration.DEFAULT_EXECUTION_GENERATOR
     protected var verifier = CTestConfiguration.DEFAULT_VERIFIER
     protected var minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR
+    protected var reproduceWithModelChecking = CTestConfiguration.DEFAULT_REPRODUCE_WITH_MODEL_CHECKING
     protected var sequentialSpecification: Class<*>? = null
     protected var timeoutMs: Long = CTestConfiguration.DEFAULT_TIMEOUT_MS
     protected var customScenarios: MutableList<ExecutionScenario> = mutableListOf()
@@ -117,6 +118,10 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
      */
     fun minimizeFailedScenario(minimizeFailedScenario: Boolean): OPT = applyAndCast {
         this.minimizeFailedScenario = minimizeFailedScenario
+    }
+
+    fun reproduceWithModelChecking(reproduceWithModelChecking : Boolean): OPT = applyAndCast {
+        this.reproduceWithModelChecking = reproduceWithModelChecking
     }
 
     abstract fun createTestConfigurations(testClass: Class<*>): CTEST

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -23,7 +23,7 @@ class Reporter(private val logLevel: LoggingLevel) {
     private val outErr: PrintStream = System.err
 
     fun logIteration(iteration: Int, maxIterations: Int, scenario: ExecutionScenario) = log(INFO) {
-        appendLine("\n= Iteration $iteration / $maxIterations =")
+        appendLine("\n= Iteration ${iteration + 1} / $maxIterations =")
         appendExecutionScenario(scenario)
     }
 
@@ -36,6 +36,10 @@ class Reporter(private val logLevel: LoggingLevel) {
         appendExecutionScenario(scenario)
     }
 
+    fun logFailureReproduction(failure: LincheckFailure) = log(INFO) {
+        appendLine("\nFailure detected, trying to reproduce it and collect the trace:")
+        appendFailure(failure)
+    }
 
     private inline fun log(logLevel: LoggingLevel, crossinline msg: StringBuilder.() -> Unit): Unit = synchronized(this) {
         if (this.logLevel > logLevel) return

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -9,9 +9,12 @@
  */
 package org.jetbrains.kotlinx.lincheck.strategy
 
+import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario
-import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart
+import org.jetbrains.kotlinx.lincheck.strategy.managed.Trace
+import org.jetbrains.kotlinx.lincheck.verifier.Verifier
 import org.objectweb.asm.ClassVisitor
+import java.io.Closeable
 
 /**
  * Implementation of this class describes how to run the generated execution.
@@ -22,18 +25,130 @@ import org.objectweb.asm.ClassVisitor
  */
 abstract class Strategy protected constructor(
     val scenario: ExecutionScenario
-) {
+) : Closeable {
+    /**
+     * Determines if the strategy requires bytecode transformation.
+     *
+     * @return `true` if a transformation is needed, `false` otherwise.
+     */
     open fun needsTransformation() = false
+
+    /**
+     * Creates a bytecode transformer required by the strategy..
+     *
+     * @param cv the [ClassVisitor] to create a transformer for.
+     * @return a [ClassVisitor] representing the transformer.
+     */
     open fun createTransformer(cv: ClassVisitor): ClassVisitor {
         throw UnsupportedOperationException("$javaClass strategy does not transform classes")
     }
 
-    abstract fun run(): LincheckFailure?
+    /**
+     * Sets the internal state of strategy to run the next invocation.
+     *
+     * @return true if there is next invocation to run, false if all invocations have been studied.
+     */
+    open fun nextInvocation(): Boolean = true
 
+    /**
+     * Initializes the invocation.
+     * Should be called before each call to [runInvocation].
+     */
+    open fun initializeInvocation() {}
+
+    /**
+     * Runs the current invocation and returns its result.
+     *
+     * Should be called after [initializeInvocation] and only if previous call to [nextInvocation] returned `true`:
+     *
+     * ```kotlin
+     *  with(strategy) {
+     *      if (nextInvocation()) {
+     *          initializeInvocation()
+     *          runInvocation()
+     *      }
+     *  }
+     * ```
+     *
+     * For deterministic strategies, consecutive calls to [runInvocation]
+     * (without intervening [nextInvocation] calls)
+     * should run the same invocation, leading to the same results.
+     *
+     * @return the result of the invocation run.
+     */
+    abstract fun runInvocation(): InvocationResult
+
+    /**
+     * Tries to construct the trace leading to the given invocation result.
+     *
+     * @param result The invocation result.
+     * @return The collected trace, or null if it was not possible to collect the trace.
+     */
+    open fun tryCollectTrace(result: InvocationResult): Trace? = null
+
+    /**
+     * This method is called before the execution of a specific scenario part.
+     *
+     * @param part The execution part that is about to be executed.
+     */
     open fun beforePart(part: ExecutionPart) {}
 
     /**
-     * Is invoked before each actor execution.
+     * This method is called before each actor execution.
+     *
+     * @param iThread the thread index on which the actor is starting
      */
     open fun onActorStart(iThread: Int) {}
+
+    /**
+     * Closes the strategy and releases any resources associated with it.
+     */
+    override fun close() {}
+}
+
+/**
+ * Runs one Lincheck's test iteration with the given strategy and verifier.
+ *
+ * @param iteration the id of the iteration.
+ * @param invocationsBound number of invocations to run.
+ * @param verifier the verifier to be used.
+ *
+ * @return the failure, if detected, null otherwise.
+ */
+fun Strategy.runIteration(iteration: Int, invocationsBound: Int, verifier: Verifier): LincheckFailure? {
+    var spinning = false
+    for (invocation in 0 until invocationsBound) {
+        if (!(spinning || nextInvocation()))
+            return null
+        spinning = false
+        initializeInvocation()
+        val failure = run {
+            val result = runInvocation()
+            spinning = (result is SpinCycleFoundAndReplayRequired)
+            if (!spinning)
+                verify(result, verifier)
+            else null
+        }
+        if (failure != null)
+            return failure
+    }
+    return null
+}
+
+/**
+ * Verifies the results of the given invocation.
+ * Attempts to collect the trace in case of incorrect results.
+ *
+ * @param result invocation result to verify.
+ * @param verifier the verifier to be used.
+ *
+ * @return failure, if invocation results are incorrect, null otherwise.
+ */
+fun Strategy.verify(result: InvocationResult, verifier: Verifier): LincheckFailure? = when (result) {
+    is CompletedInvocationResult ->
+        if (!verifier.verifyResults(scenario, result.results)) {
+            IncorrectResultsFailure(scenario, result.results, tryCollectTrace(result))
+        } else null
+    else ->
+        result.toLincheckFailure(scenario, tryCollectTrace(result))
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -45,6 +45,7 @@ abstract class ManagedCTestConfiguration(
     generatorClass = generatorClass,
     verifierClass = verifierClass,
     minimizeFailedScenario = minimizeFailedScenario,
+    reproduceWithModelChecking = false,
     sequentialSpecification = sequentialSpecification,
     timeoutMs = timeoutMs,
     customScenarios = customScenarios

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -44,7 +44,10 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
     eliminateLocalObjects = eliminateLocalObjects,
     customScenarios = customScenarios
 ) {
-    override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-                                stateRepresentationMethod: Method?, verifier: Verifier): Strategy
-        = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod, verifier)
+    override fun createStrategy(
+        testClass: Class<*>,
+        scenario: ExecutionScenario,
+        validationFunction: Actor?,
+        stateRepresentationMethod: Method?,
+    ): Strategy = ModelCheckingStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -34,17 +34,12 @@ import kotlin.random.*
  * than the number of all possible interleavings on the current depth level.
  */
 internal class ModelCheckingStrategy(
-    testCfg: ModelCheckingCTestConfiguration,
-    testClass: Class<*>,
-    scenario: ExecutionScenario,
-    validationFunction: Actor?,
-    stateRepresentation: Method?,
-    verifier: Verifier
-) : ManagedStrategy(testClass, scenario, verifier, validationFunction, stateRepresentation, testCfg) {
-    // The number of invocations that the strategy is eligible to use to search for an incorrect execution.
-    private val maxInvocations = testCfg.invocationsPerIteration
-    // The number of already used invocations.
-    private var usedInvocations = 0
+        testCfg: ModelCheckingCTestConfiguration,
+        testClass: Class<*>,
+        scenario: ExecutionScenario,
+        validationFunction: Actor?,
+        stateRepresentation: Method?,
+) : ManagedStrategy(testClass, scenario, validationFunction, stateRepresentation, testCfg) {
     // The maximum number of thread switch choices that strategy should perform
     // (increases when all the interleavings with the current depth are studied).
     private var maxNumberOfSwitches = 0
@@ -55,21 +50,22 @@ internal class ModelCheckingStrategy(
     // The interleaving that will be studied on the next invocation.
     private lateinit var currentInterleaving: Interleaving
 
-    override fun runImpl(): LincheckFailure? {
-        currentInterleaving = root.nextInterleaving() ?: return null
-        while (usedInvocations < maxInvocations) {
-            // run invocation and check its results
-            val invocationResult = runInvocation()
-            if (suddenInvocationResult is SpinCycleFoundAndReplayRequired) {
+    override fun nextInvocation(): Boolean {
+        currentInterleaving = root.nextInterleaving()
+            ?: return false
+        return true
+    }
+
+    override fun initializeInvocation() {
+        super.initializeInvocation()
+        currentInterleaving.initialize()
+    }
+
+    override fun runInvocation(): InvocationResult {
+        return super.runInvocation().also {
+            if (it is SpinCycleFoundAndReplayRequired)
                 currentInterleaving.rollbackAfterSpinCycleFound()
-                continue
-            }
-            usedInvocations++
-            checkResult(invocationResult)?.let { return it }
-            // get new unexplored interleaving
-            currentInterleaving = root.nextInterleaving() ?: break
         }
-        return null
     }
 
     override fun onNewSwitch(iThread: Int, mustSwitch: Boolean) {
@@ -88,11 +84,6 @@ internal class ModelCheckingStrategy(
         check(iThread == currentThread)
         currentInterleaving.newExecutionPosition(iThread)
         return currentInterleaving.isSwitchPosition()
-    }
-
-    override fun initializeInvocation() {
-        currentInterleaving.initialize()
-        super.initializeInvocation()
     }
 
     override fun beforePart(part: ExecutionPart) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
@@ -105,6 +105,13 @@ public @interface StressCTest {
     boolean minimizeFailedScenario() default true;
 
     /**
+     * If this feature is enabled and an invalid interleaving has been found,
+     * *lincheck* will try to reproduce the failure with model checking strategy and collect the trace.
+     * Enabled by default.
+     */
+    boolean reproduceWithModelChecking() default true;
+
+    /**
      * The specified class defines the sequential behavior of the testing data structure;
      * it is used by {@link Verifier} to build a labeled transition system,
      * and should have the same methods as the testing data structure.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -36,9 +36,12 @@ class StressCTestConfiguration(
     timeoutMs = timeoutMs,
     customScenarios = customScenarios
 ) {
-    override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunction: Actor?,
-                                stateRepresentationMethod: Method?, verifier: Verifier) =
-        StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod, verifier)
+    override fun createStrategy(
+        testClass: Class<*>,
+        scenario: ExecutionScenario,
+        validationFunction: Actor?,
+        stateRepresentationMethod: Method?
+    ) = StressStrategy(this, testClass, scenario, validationFunction, stateRepresentationMethod)
 
     companion object {
         const val DEFAULT_INVOCATIONS = 10000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -20,7 +20,7 @@ import java.lang.reflect.*
 class StressCTestConfiguration(
     testClass: Class<*>, iterations: Int, threads: Int, actorsPerThread: Int, actorsBefore: Int, actorsAfter: Int,
     generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
-    val invocationsPerIteration: Int, minimizeFailedScenario: Boolean,
+    val invocationsPerIteration: Int, minimizeFailedScenario: Boolean, reproduceWithModelChecking: Boolean,
     sequentialSpecification: Class<*>, timeoutMs: Long, customScenarios: List<ExecutionScenario>
 ) : CTestConfiguration(
     testClass = testClass,
@@ -32,6 +32,7 @@ class StressCTestConfiguration(
     generatorClass = generatorClass,
     verifierClass = verifierClass,
     minimizeFailedScenario = minimizeFailedScenario,
+    reproduceWithModelChecking = reproduceWithModelChecking,
     sequentialSpecification = sequentialSpecification,
     timeoutMs = timeoutMs,
     customScenarios = customScenarios

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.kt
@@ -37,6 +37,7 @@ open class StressOptions : Options<StressOptions, StressCTestConfiguration>() {
             verifierClass = verifier,
             invocationsPerIteration = invocationsPerIteration,
             minimizeFailedScenario = minimizeFailedScenario,
+            reproduceWithModelChecking = reproduceWithModelChecking,
             sequentialSpecification = chooseSequentialSpecification(sequentialSpecification, testClass),
             timeoutMs = timeoutMs,
             customScenarios = customScenarios

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressStrategy.kt
@@ -22,9 +22,7 @@ class StressStrategy(
     scenario: ExecutionScenario,
     validationFunction: Actor?,
     stateRepresentationFunction: Method?,
-    private val verifier: Verifier
 ) : Strategy(scenario) {
-    private val invocations = testCfg.invocationsPerIteration
     private val runner: Runner
 
     init {
@@ -44,19 +42,11 @@ class StressStrategy(
         }
     }
 
-    override fun run(): LincheckFailure? {
-        runner.use {
-            // Run invocations
-            for (invocation in 0 until invocations) {
-                when (val ir = runner.run()) {
-                    is CompletedInvocationResult -> {
-                        if (!verifier.verifyResults(scenario, ir.results))
-                            return IncorrectResultsFailure(scenario, ir.results)
-                    }
-                    else -> return ir.toLincheckFailure(scenario)
-                }
-            }
-            return null
-        }
+    override fun runInvocation(): InvocationResult {
+        return runner.run()
+    }
+
+    override fun close() {
+        runner.close()
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/OperationsInAbstractClassTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/OperationsInAbstractClassTest.kt
@@ -16,7 +16,7 @@ import org.junit.*
 import java.lang.AssertionError
 import kotlin.random.*
 
-@StressCTest(iterations = 1, minimizeFailedScenario = false, requireStateEquivalenceImplCheck = false)
+@StressCTest(iterations = 1, minimizeFailedScenario = false, requireStateEquivalenceImplCheck = false, reproduceWithModelChecking = false)
 class OperationsInAbstractClassTest : AbstractTestClass() {
     @Operation
     fun goodOperation() = 10

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/ParallelThreadsRunnerExceptionTest.kt
@@ -181,5 +181,5 @@ class ParallelThreadExecutionExceptionsTest {
 }
 
 fun mockStrategy(scenario: ExecutionScenario) = object : Strategy(scenario) {
-    override fun run(): LincheckFailure? = error("Not yet implemented")
+    override fun runInvocation(): InvocationResult = error("Not yet implemented")
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/runner/TestThreadExecutionHelperTest.java
@@ -29,7 +29,7 @@ public class TestThreadExecutionHelperTest {
         ExecutionScenario scenario = new ExecutionScenario(emptyList(), emptyList(), emptyList(), null);
         Strategy strategy = new Strategy(scenario) {
             @Override
-            public LincheckFailure run() {
+            public InvocationResult runInvocation() {
                 throw new UnsupportedOperationException();
             }
         };

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/LockFreeSetTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/LockFreeSetTest.kt
@@ -38,7 +38,7 @@ class LockFreeSetTest {
 
         StressOptions()
             .addCustomScenario(scenario)
-            .invocationsPerIteration(1000000)
+            .invocationsPerIteration(10_000_000)
             .iterations(0)
             .check(LockFreeSet::class)
     }


### PR DESCRIPTION
When the test fails in the stress mode, try to reproduce the failure and collect the trace using model checking mode.

Closes #151 

Please rebase and merge after #262 .
This PR utilizes a small refactoring implemented in #262 , that unifies the logic for running custom and random scenarios.