### PR TITLE
Use Gradle toolchain to specify the JDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dependencies {
 To use model checking strategy for Java 9 and later, add the following JVM properties:
 
 ```text
+--add-opens", "java.base/java.lang=ALL-UNNAMED
 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 --add-exports java.base/jdk.internal.util=ALL-UNNAMED
 --add-exports java.base/sun.security.action=ALL-UNNAMED

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,10 @@ kotlin {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        val jdkToolchainVersion: String by project
+        languageVersion = JavaLanguageVersion.of(jdkToolchainVersion)
+    }
 }
 
 sourceSets.main {
@@ -93,6 +97,7 @@ tasks {
         maxParallelForks = 1
         maxHeapSize = "6g"
         jvmArgs(
+            "--add-opens", "java.base/java.lang=ALL-UNNAMED",
             "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
             "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED",
             "--add-exports", "java.base/sun.security.action=ALL-UNNAMED"

--- a/docs/topics/testing-strategies.md
+++ b/docs/topics/testing-strategies.md
@@ -107,6 +107,7 @@ class CounterTest {
 > ```
 > tasks.withType<Test> {
 >   jvmArgs(
+>     "--add-opens", "java.base/java.lang=ALL-UNNAMED",
 >     "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
 >     "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED",
 >     "--add-exports", "java.base/sun.security.action=ALL-UNNAMED"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,8 @@ version=2.25-SNAPSHOT
 inceptionYear=2019
 lastCopyrightYear=2023
 
+jdkToolchainVersion = 17
+
 kotlinVersion=1.9.21
 kotlinxCoroutinesVersion=1.7.3
 asmVersion=9.6

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,9 +8,12 @@ pluginManagement {
     repositories {
         maven(url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/maven")
         mavenCentral()
-        jcenter()
         gradlePluginPortal()
     }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
 }
 
 val name: String by settings

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -319,6 +319,7 @@ internal fun isIllegalAccessOfUnsafeDueToJavaVersion(exception: Throwable): Bool
 internal const val ADD_OPENS_MESSAGE =
     "It seems that you use Java 9+ and the code uses Unsafe or similar constructions that are not accessible from unnamed modules.\n" +
             "Please add the following lines to your test running configuration:\n" +
+            "--add-opens java.base/java.lang=ALL-UNNAMED\n" +
             "--add-opens java.base/jdk.internal.misc=ALL-UNNAMED\n" +
             "--add-exports java.base/jdk.internal.util=ALL-UNNAMED\n" +
             "--add-exports java.base/sun.security.action=ALL-UNNAMED"

--- a/src/jvm/test/resources/expected_logs/illegal_module_access.txt
+++ b/src/jvm/test/resources/expected_logs/illegal_module_access.txt
@@ -7,6 +7,7 @@
 
 java.lang.RuntimeException: It seems that you use Java 9+ and the code uses Unsafe or similar constructions that are not accessible from unnamed modules.
 Please add the following lines to your test running configuration:
+--add-opens java.base/java.lang=ALL-UNNAMED
 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 --add-exports java.base/jdk.internal.util=ALL-UNNAMED
 --add-exports java.base/sun.security.action=ALL-UNNAMED


### PR DESCRIPTION
It's easier to test Lincheck on different VM versions using toolchains