### PR TITLE
Do not call `Thread.stop()` in `FixedActiveThreadsExecutor` on Java 20+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,12 @@ tasks {
     }
 
     val jvmTest = named<Test>("jvmTest") {
-        exclude("**/*IsolatedTest*")
+        if (System.getProperty("idea.active") != "true") {
+            // We need to be able to run these tests in IntelliJ IDEA.
+            // Unfortunately, the current Gradle support doesn't detect
+            // the `jvmTestIsolated` task.
+            exclude("**/*IsolatedTest*")
+        }
         configureJvmTestCommon()
         val runAllTestsInSeparateJVMs: String by project
         forkEvery = if (runAllTestsInSeparateJVMs.toBoolean()) 1 else 0

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -199,9 +199,11 @@ internal class FixedActiveThreadsExecutor(private val nThreads: Int, runnerHash:
 
     override fun close() {
         shutdown()
-        if (hangDetected) {
-            for (thread in threads)
-                thread.stop()
+        // Thread.stop() throws UnsupportedOperationException
+        // starting from Java 20.
+        if (hangDetected && majorJavaVersion < 20) {
+            @Suppress("DEPRECATION")
+            threads.forEach { it.stop() }
         }
     }
 
@@ -212,6 +214,8 @@ internal class FixedActiveThreadsExecutor(private val nThreads: Int, runnerHash:
     }
 
 }
+
+private val majorJavaVersion = Runtime.version().version()[0]
 
 private const val SPINNING_LOOP_ITERATIONS_BEFORE_PARK = 1000_000
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/HangingDetectionTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/HangingDetectionTests.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 
-class HangingInParallelPartTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class HangingInParallelPartIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
 
     @Operation
     fun hang() {
@@ -40,7 +40,7 @@ class HangingInParallelPartTest : AbstractLincheckTest(DeadlockWithDumpFailure::
 
 }
 
-class HangingInInitPartTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class HangingInInitPartIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
 
     @Operation
     fun hang() {
@@ -70,7 +70,7 @@ class HangingInInitPartTest : AbstractLincheckTest(DeadlockWithDumpFailure::clas
 
 }
 
-class HangingInPostPartTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class HangingInPostPartIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
 
     @Operation
     fun hang() {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/DeadlockIsolatedTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/DeadlockIsolatedTests.kt
@@ -7,7 +7,7 @@
  * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.jetbrains.kotlinx.lincheck_test.runner
+package org.jetbrains.kotlinx.lincheck_test.isolated
 
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
@@ -15,7 +15,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck_test.AbstractLincheckTest
 import java.util.concurrent.atomic.AtomicBoolean
 
-class DeadlockOnSynchronizedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class DeadlockOnSynchronizedIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
     private var counter = 0
     private var lock1 = Any()
     private var lock2 = Any()
@@ -46,7 +46,7 @@ class DeadlockOnSynchronizedTest : AbstractLincheckTest(DeadlockWithDumpFailure:
     override fun extractState(): Any = counter
 }
 
-class DeadlockOnSynchronizedWaitTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class DeadlockOnSynchronizedWaitIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
     private var lock = Object()
 
     @Operation
@@ -65,7 +65,7 @@ class DeadlockOnSynchronizedWaitTest : AbstractLincheckTest(DeadlockWithDumpFail
     override fun extractState(): Any = 0 // constant
 }
 
-class LiveLockTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+class LiveLockIsolatedTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
     private var counter = 0
     private val lock1 = AtomicBoolean(false)
     private val lock2 = AtomicBoolean(false)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/FixedActiveThreadsExecutorIsolatedTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/FixedActiveThreadsExecutorIsolatedTest.kt
@@ -7,13 +7,13 @@
  * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.jetbrains.kotlinx.lincheck_test.runner
+package org.jetbrains.kotlinx.lincheck_test.isolated
 
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.junit.*
 import java.util.concurrent.*
 
-class FixedActiveThreadsExecutorTest {
+class FixedActiveThreadsExecutorIsolatedTest {
     @Test
     fun testSubmit() = FixedActiveThreadsExecutor(2, 0).use { executor ->
         val executed = arrayOf(false, false)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/ThreadDumpIsolatedTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/isolated/ThreadDumpIsolatedTest.kt
@@ -1,34 +1,32 @@
 /*
  * Lincheck
  *
- * Copyright (C) 2019 - 2023 JetBrains s.r.o.
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
  *
  * This Source Code Form is subject to the terms of the
  * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.jetbrains.kotlinx.lincheck_test.representation
+package org.jetbrains.kotlinx.lincheck_test.isolated
 
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
-import org.jetbrains.kotlinx.lincheck_test.runner.*
 import org.junit.*
 
 /**
  * This test checks that there is no old thread in thread dump.
  */
-class ThreadDumpTest {
+class ThreadDumpIsolatedTest {
     @Test
     fun test() {
-        val iterations = 30
-        repeat(iterations) {
+        repeat(30) {
             val options = StressOptions()
                 .minimizeFailedScenario(false)
                 .iterations(100_000)
                 .invocationsPerIteration(1)
                 .invocationTimeout(100)
-            val failure = options.checkImpl(DeadlockOnSynchronizedTest::class.java)
+            val failure = options.checkImpl(DeadlockOnSynchronizedIsolatedTest::class.java)
             check(failure is DeadlockWithDumpFailure) { "${DeadlockWithDumpFailure::class.simpleName} was expected but ${failure?.javaClass} was obtained"}
             check(failure.threadDump!!.size == 2) { "thread dump for 2 threads expected, but for ${failure.threadDump.size} threads was detected"}
         }


### PR DESCRIPTION
Fixes #210 