### PR TITLE
Make `ForcibleExecutionFinishException` an `Error`

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -301,7 +301,7 @@ internal val String.internalClassName get() = this.replace('.', '/')
 internal fun exceptionCanBeValidExecutionResult(exception: Throwable): Boolean {
     return exception !is ThreadDeath && // used to stop thread in FixedActiveThreadsExecutor by calling thread.stop method
             exception !is InternalLincheckTestUnexpectedException &&
-            exception !is ForcibleExecutionFinishException &&
+            exception !is ForcibleExecutionFinishError &&
             !isIllegalAccessOfUnsafeDueToJavaVersion(exception)
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -143,7 +143,7 @@ internal class MethodCallTracePoint(
         append(")")
         if (returnedValue != NO_VALUE)
             append(": ${adornedStringRepresentation(returnedValue)}")
-        else if (thrownException != null && thrownException != ForcibleExecutionFinishException)
+        else if (thrownException != null && thrownException != ForcibleExecutionFinishError)
             append(": threw ${thrownException!!.javaClass.simpleName}")
         append(" at ${stackTraceElement.shorten()}")
     }.toString()

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ForcibleFinishExceptionInTryBlockTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ForcibleFinishExceptionInTryBlockTest.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
-import org.jetbrains.kotlinx.lincheck_test.*
 import org.junit.*
 
 class ForcibleFinishExceptionInTryBlockTest {
@@ -42,7 +41,7 @@ class ForcibleFinishExceptionInTryBlockTest {
             .threads(2)
         val failure = options.checkImpl(this::class.java)
         check(failure != null) { "the test should fail" }
-        val forcibleFinishExceptionName = ForcibleExecutionFinishException::class.simpleName!!
+        val forcibleFinishExceptionName = ForcibleExecutionFinishError::class.simpleName!!
         check(failure is DeadlockWithDumpFailure) { "$forcibleFinishExceptionName overrode deadlock because of try-finally" }
         val log = StringBuilder().appendFailure(failure).toString()
         check(forcibleFinishExceptionName !in log) {


### PR DESCRIPTION
Make `ForcibleExecutionFinishException` an `Error` to avoid catching it in the user code.

Fixes #225 