### PR TITLE
Fix potential IndexOutOfBoundsException in curActorIsBlocking and concurrentActorCausesBlocking

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.objectweb.asm.*
-import java.io.*
 import java.lang.reflect.*
 import java.util.*
 import kotlin.collections.set
@@ -251,14 +250,14 @@ abstract class ManagedStrategy(
     }
 
     private fun failIfObstructionFreedomIsRequired(lazyMessage: () -> String) {
-        if (testCfg.checkObstructionFreedom && !curActorIsBlocking && !concurrentActorCausesBlocking) {
+        if (testCfg.checkObstructionFreedom && !currentActorIsBlocking && !concurrentActorCausesBlocking) {
             suddenInvocationResult = ObstructionFreedomViolationInvocationResult(lazyMessage())
             // Forcibly finish the current execution by throwing an exception.
             throw ForcibleExecutionFinishError
         }
     }
 
-    private val curActorIsBlocking: Boolean
+    private val currentActorIsBlocking: Boolean
         get() {
             val actorId = currentActorId[currentThread]
             return (actorId >= 0) && scenario.threads[currentThread][actorId].blocking

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -259,11 +259,14 @@ abstract class ManagedStrategy(
     }
 
     private val curActorIsBlocking: Boolean
-        get() = scenario.threads[currentThread][currentActorId[currentThread]].blocking
+        get() {
+            val actorId = currentActorId[currentThread]
+            return (actorId >= 0) && scenario.threads[currentThread][actorId].blocking
+        }
 
     private val concurrentActorCausesBlocking: Boolean
         get() = currentActorId.mapIndexed { iThread, actorId ->
-                    if (iThread != currentThread && !finished[iThread])
+                    if (iThread != currentThread && actorId >= 0 && !finished[iThread])
                         scenario.threads[iThread][actorId]
                     else null
                 }.filterNotNull().any { it.causesBlocking }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -260,7 +260,10 @@ abstract class ManagedStrategy(
     private val currentActorIsBlocking: Boolean
         get() {
             val actorId = currentActorId[currentThread]
-            return (actorId >= 0) && scenario.threads[currentThread][actorId].blocking
+            // handle the case when the first actor has not yet started,
+            // see https://github.com/JetBrains/lincheck/pull/277
+            if (actorId < 0) return false
+            return scenario.threads[currentThread][actorId].blocking
         }
 
     private val concurrentActorCausesBlocking: Boolean


### PR DESCRIPTION
both properties access the current actor id `actorId = currentActorId[iThread]` but do not handle the case when `actorId = -1`, that is the case before any actor has started executing