### PR TITLE
Bugfix for Loop Detector

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -395,6 +395,7 @@ abstract class ManagedStrategy(
         currentActorId[iThread]++
         callStackTrace[iThread].clear()
         suspendedFunctionsStack[iThread].clear()
+        loopDetector.onActorStart(iThread)
     }
 
     /**
@@ -993,6 +994,11 @@ abstract class ManagedStrategy(
                 }
             }
             return detectedFirstTime || detectedEarly
+        }
+
+        fun onActorStart(iThread: Int) {
+            check(iThread == lastExecutedThread)
+            currentThreadCodeLocationVisitCountMap.clear()
         }
 
         fun onThreadSwitch(iThread: Int) {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/HangingDetectionThresholdTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/HangingDetectionThresholdTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.strategy.modelchecking
+
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class HangingDetectionThresholdTest {
+    private var c = AtomicInteger(0)
+
+    private fun get(): Int {
+        return c.get()
+    }
+
+    @Operation
+    fun operation() {
+        get()
+        get()
+    }
+
+    @Test
+    fun test() {
+        val options = ModelCheckingOptions()
+            .checkObstructionFreedom()
+            .minimizeFailedScenario(false)
+            // we check that no actor can hit the same code location more than twice;
+            // because `operation` has only two calls to `get`, it should be true
+            .hangingDetectionThreshold(2)
+            .addCustomScenario {
+                parallel {
+                    thread {
+                        actor(::operation)
+                        actor(::operation)
+                    }
+                }
+            }
+            .iterations(0)
+
+        val failure = options.checkImpl(HangingDetectionThresholdTest::class.java)
+        check(failure == null)
+    }
+
+}


### PR DESCRIPTION
Reset code location counters inside `LoopDetector` on each actor start