### PR TITLE
Fix number of iterations in spin-loops in case if #cpus < #threads

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -34,7 +34,7 @@ internal class FixedActiveThreadsExecutor(private val nThreads: Int, runnerHash:
     /**
      * Spinners for each thread used for spin-wait on tasks.
      */
-    private val taskSpinners = SpinnerGroup(nThreads, shouldYield = false)
+    private val taskSpinners = SpinnerGroup(nThreads)
 
     /**
      * null, waiting in [submitAndAwait] thread, DONE, or exception
@@ -44,7 +44,7 @@ internal class FixedActiveThreadsExecutor(private val nThreads: Int, runnerHash:
     /**
      * Spinners for each thread used for spin-wait on results.
      */
-    private val resultSpinners = SpinnerGroup(nThreads, shouldYield = false)
+    private val resultSpinners = SpinnerGroup(nThreads)
 
     /**
      * This flag is set to `true` when [await] detects a hang.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -43,7 +43,7 @@ internal open class ParallelThreadsRunner(
     private val useClocks: UseClocks // specifies whether `HBClock`-s should always be used or with some probability
 ) : Runner(strategy, testClass, validationFunction, stateRepresentationFunction) {
     private val runnerHash = this.hashCode() // helps to distinguish this runner threads from others
-    private val executor = FixedActiveThreadsExecutor(scenario.nThreads, runnerHash) // should be closed in `close()`
+    val executor = FixedActiveThreadsExecutor(scenario.nThreads, runnerHash) // should be closed in `close()`
 
     private lateinit var testInstance: Any
 
@@ -378,7 +378,7 @@ internal open class ParallelThreadsRunner(
         // wait for other threads to start
         var i = 1
         while (uninitializedThreads.get() != 0) {
-            if (i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0) {
+            if (i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0 || executor.numberOfThreadsExceedAvailableProcessors) {
                 yieldInvokedInOnStart = true
                 Thread.yield()
             }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -65,7 +65,6 @@ internal open class ParallelThreadsRunner(
     private fun trySetCancelledStatus(iThread: Int, actorId: Int) = completionStatuses[iThread].compareAndSet(actorId, null, CompletionStatus.CANCELLED)
 
     private val uninitializedThreads = AtomicInteger(scenario.nThreads) // for threads synchronization
-    private var yieldInvokedInOnStart = false
 
     private var initialPartExecution: TestThreadExecution? = null
     private var parallelPartExecutions: Array<TestThreadExecution> = arrayOf()
@@ -379,7 +378,6 @@ internal open class ParallelThreadsRunner(
         var i = 1
         while (uninitializedThreads.get() != 0) {
             if (i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0 || executor.numberOfThreadsExceedAvailableProcessors) {
-                yieldInvokedInOnStart = true
                 Thread.yield()
             }
             i++

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
+import org.jetbrains.kotlinx.lincheck.util.*
 import org.objectweb.asm.*
 import java.lang.reflect.*
 import java.util.*
@@ -43,6 +44,9 @@ abstract class ManagedStrategy(
     // Runner for scenario invocations,
     // can be replaced with a new one for trace construction.
     private var runner: ManagedStrategyRunner
+
+    // Spin-waiters for each thread
+    private val spinners = SpinnerGroup(nThreads)
 
     companion object {
         // Shares location ids between class transformers in order
@@ -107,9 +111,6 @@ abstract class ManagedStrategy(
             throw t
         }
     }
-
-    private val numberOfThreadsExceedAvailableProcessors =
-        runner.executor.numberOfThreadsExceedAvailableProcessors
 
     private fun createRunner(): ManagedStrategyRunner =
         ManagedStrategyRunner(this, testClass, validationFunction, stateRepresentationFunction, testCfg.timeoutMs, UseClocks.ALWAYS)
@@ -420,13 +421,11 @@ abstract class ManagedStrategy(
      * the execution according to the strategy decision.
      */
     private fun awaitTurn(iThread: Int) {
-        // Wait actively until the thread is allowed to continue
-        var i = 0
-        while (currentThread != iThread) {
+        spinners[iThread].wait {
             // Finish forcibly if an error occurred and we already have an `InvocationResult`.
-            if (suddenInvocationResult != null) throw ForcibleExecutionFinishError
-            if (++i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0 || numberOfThreadsExceedAvailableProcessors)
-                Thread.yield()
+            if (suddenInvocationResult != null)
+                throw ForcibleExecutionFinishError
+            currentThread == iThread
         }
     }
 
@@ -1442,8 +1441,6 @@ internal object ForcibleExecutionFinishError : Error() {
 }
 
 private const val COROUTINE_SUSPENSION_CODE_LOCATION = -1 // currently the exact place of coroutine suspension is not known
-
-private const val SPINNING_LOOP_ITERATIONS_BEFORE_YIELD = 100_000
 
 private const val OBSTRUCTION_FREEDOM_SPINLOCK_VIOLATION_MESSAGE =
     "The algorithm should be non-blocking, but an active lock is detected"

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -108,6 +108,9 @@ abstract class ManagedStrategy(
         }
     }
 
+    private val numberOfThreadsExceedAvailableProcessors =
+        runner.executor.numberOfThreadsExceedAvailableProcessors
+
     private fun createRunner(): ManagedStrategyRunner =
         ManagedStrategyRunner(this, testClass, validationFunction, stateRepresentationFunction, testCfg.timeoutMs, UseClocks.ALWAYS)
 
@@ -422,7 +425,8 @@ abstract class ManagedStrategy(
         while (currentThread != iThread) {
             // Finish forcibly if an error occurred and we already have an `InvocationResult`.
             if (suddenInvocationResult != null) throw ForcibleExecutionFinishError
-            if (++i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0) Thread.yield()
+            if (++i % SPINNING_LOOP_ITERATIONS_BEFORE_YIELD == 0 || numberOfThreadsExceedAvailableProcessors)
+                Thread.yield()
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -15,6 +15,7 @@ package org.jetbrains.kotlinx.lincheck.util
  *
  * This class provides a method [spin], that should be called inside a spin-loop.
  * This method performs a few spin-loop iterations and optionally periodically yields.
+ *
  * For example, a simple spin-lock class can be implemented with the help of the [Spinner] as follows:
  *
  * ```

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -1,0 +1,69 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.util
+
+class Spinner(val nThreads: Int = -1, shouldYield: Boolean = true) {
+
+    private var counter: Int = 0
+
+    private inline val iterationsCount: Int
+        get() = SPINNING_LOOP_ITERATIONS_PER_CALL
+
+    private val yieldLimit = run {
+        val nProcessors = Runtime.getRuntime().availableProcessors()
+        if (nProcessors < nThreads) 1 else SPINNING_LOOP_ITERATIONS_BEFORE_YIELD
+    }
+
+    val isYielding: Boolean = shouldYield
+
+    fun spin(): Boolean {
+        if (counter >= yieldLimit) {
+            if (isYielding)
+                Thread.yield()
+            counter = 0
+            return false
+        }
+        repeat(iterationsCount) { counter++ }
+        return true
+    }
+
+    fun reset() {
+        counter = 0
+    }
+
+}
+
+@JvmInline
+value class SpinnerGroup private constructor(private val spinners: Array<Spinner>) {
+
+    constructor(nThreads: Int) : this(spinners = Array(nThreads) { Spinner(nThreads) })
+
+    operator fun get(i: Int): Spinner =
+        spinners[i]
+}
+
+inline fun Spinner.wait(condition: () -> Boolean) {
+    while (!condition()) {
+        spin()
+    }
+    reset()
+}
+
+inline fun Spinner.boundedWait(condition: () -> Boolean): Boolean {
+    while (!condition()) {
+        if (!spin()) return condition()
+    }
+    reset()
+    return false
+}
+
+private const val SPINNING_LOOP_ITERATIONS_PER_CALL : Int = 1 shl 5 // 32
+private const val SPINNING_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1 shl 14 // 16384

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -10,42 +10,147 @@
 
 package org.jetbrains.kotlinx.lincheck.util
 
+/**
+ * A spinner implements spinning in a loop with optional yielding to other threads.
+ *
+ * This class provides a method [spin], that should be called inside a spin-loop.
+ * This method performs a few spin-loop iterations and optionally periodically yields.
+ * For example, a simple spin-lock class can be implemented with the help of the [Spinner] as follows:
+ *
+ * ```
+ *  class SpinLock {
+ *      private val lock = AtomicBoolean()
+ *      private val spinner = Spinner()
+ *
+ *      fun lock() {
+ *          while (!lock.compareAndSet(false, true)) {
+*               spinner.spin()
+*           }
+ *      }
+ *
+ *      fun unlock() {
+ *          lock.set(false)
+ *      }
+ *  }
+ * ```
+ *
+ * The `lock` method can be shortened with the help of the [wait] extension method:
+ *
+ * ```
+ *  fun lock() {
+ *      spinner.wait { lock.compareAndSet(false, true) }
+ *  }
+ * ```
+ *
+ * Sometimes, it is useful to fall back into a blocking synchronization if the spin-loop spins for too long.
+ * For this purpose, the [spin] method has a boolean return value.
+ * It returns `true` if the spinning should be continued,
+ * or `false` if it is advised to exit the spin-loop.
+ *
+ * ```
+ *  class SimpleQueuedLock {
+ *      private val lock = AtomicBoolean()
+ *      private val queue = ConcurrentLinkedQueue<Thread>()
+ *      private val spinner = Spinner()
+ *
+ *      fun lock() {
+ *          while (!lock.compareAndSet(false, true)) {
+ *              if (spinner.spin())
+ *                  continue
+ *              val thread = Thread.currentThread()
+ *              if (!queue.contains(thread))
+ *                  queue.add(thread)
+ *              LockSupport.park()
+ *          }
+ *      }
+ *
+ *      fun unlock() {
+ *          lock.set(false)
+ *          queue.poll()?.also {
+ *              LockSupport.unpark(it)
+ *          }
+ *      }
+ *  }
+ * ```
+ *
+ * @property nThreads If passed, denotes the number of threads in a group that
+ *   may wait for a common condition in the spin-loop.
+ * @property shouldYield Defines whether the spin-loop should periodically yield to
+ *   give other threads the opportunity to run.
+ *
+ * @constructor Creates an instance of the [Spinner] class.
+ */
 class Spinner(
     val nThreads: Int = -1,
     shouldYield: Boolean = true,
 ) {
 
+    /**
+     * Counter of performed spin-loop iterations.
+     */
     private var counter: Int = 0
 
+    /**
+     * Determines whether the spinner should actually spin in a loop,
+     * or if it should exit immediately.
+     *
+     * The value is calculated based on the number of available processors
+     * and the number of threads (if provided in the constructor).
+     * If the number of processors is less than the number of threads,
+     * then the spinner should exit the loop immediately.
+     */
     private val shouldSpin: Boolean = run {
         val nProcessors = Runtime.getRuntime().availableProcessors()
         (nProcessors >= nThreads)
     }
 
+    /**
+     * The number of spin-loop iterations to be performed per call to [spin].
+     */
     private val spinLoopIterationsPerCall: Int =
         if (shouldSpin) SPIN_LOOP_ITERATIONS_PER_CALL else 1
 
+    /**
+     * The number of spin-loop iterations before yielding the current thread
+     * to give other threads the opportunity to run.
+     */
     private val yieldLimit = when {
         shouldYield && shouldSpin -> SPIN_LOOP_ITERATIONS_BEFORE_YIELD
         shouldYield -> 1
         else -> -1
     }
 
+    /**
+     * Determines whether the spinner should yield to other threads based on the yield limit.
+     */
     private inline val shouldYield: Boolean
         get() = yieldLimit > 0
 
+    /**
+     * The exit limit determines the number of spin-loop iterations
+     * after which the spin-loop is advised to exit.
+     */
     private val exitLimit = when {
         shouldSpin -> SPIN_LOOP_ITERATIONS_BEFORE_EXIT
         else -> 1
     }
 
+    /**
+     * Spins the counter for a few iterations.
+     * In addition, in the case of a yielding spinner, it yields occasionally
+     * to give other threads the opportunity to run.
+     *
+     * @return `true` if the spin-loop should continue;
+     *   `false` if the spin-loop is advised to exit,
+     *   for example, to fall back into a blocking synchronization.
+     */
     fun spin(): Boolean {
         // spin a few iterations
         repeat(spinLoopIterationsPerCall) {
             counter++
         }
         // if yield limit is approached,
-        // then yield and give other threads the possibility to work
+        // then yield and give other threads the opportunity to run
         if (shouldYield && counter % yieldLimit == 0) {
             Thread.yield()
         }
@@ -58,22 +163,47 @@ class Spinner(
         return true
     }
 
+    /**
+     * Resets the state of the spinner.
+     */
     fun reset() {
         counter = 0
     }
 
 }
 
+/**
+ * A [SpinnerGroup] represents a group of spinners that can be accessed by their index.
+ * It provides a convenient way to manage multiple spinners together.
+ */
 @JvmInline
 value class SpinnerGroup private constructor(private val spinners: Array<Spinner>) {
 
+    /**
+     * This constructor creates a spinners group to be used by the specified number of threads.
+     *
+     * @param nThreads The number of threads in the group.
+     * @param shouldYield Determines whether the spin-loop in each Spinner should periodically yield
+     *   to give other threads the opportunity to run.
+     */
     constructor(nThreads: Int, shouldYield: Boolean = true)
             : this(Array(nThreads) { Spinner(nThreads, shouldYield = shouldYield) })
 
+    /**
+     * Retrieves the spinner at the specified index.
+     */
     operator fun get(i: Int): Spinner =
         spinners[i]
 }
 
+/**
+ * Waits in the spin-loop until the given condition is true.
+ *
+ * @param condition a lambda function that determines the condition to wait for.
+ *   The function should return true when the condition is satisfied, and false otherwise.
+ *
+ * @see Spinner
+ */
 inline fun Spinner.wait(condition: () -> Boolean) {
     while (!condition()) {
         spin()
@@ -81,6 +211,17 @@ inline fun Spinner.wait(condition: () -> Boolean) {
     reset()
 }
 
+/**
+ * Waits in the spin-loop until the given condition is true.
+ * Exits the spin-loop after a certain number of spin-loop iterations.
+ *
+ * @param condition a lambda function that determines the condition to wait for.
+ *   The function should return true when the condition is satisfied, and false otherwise.
+
+ * @return `true` if the condition is met; `false` if the condition is not met.
+ *
+ * @see Spinner
+ */
 inline fun Spinner.boundedWait(condition: () -> Boolean): Boolean {
     var result = true
     while (!condition()) {
@@ -92,6 +233,16 @@ inline fun Spinner.boundedWait(condition: () -> Boolean): Boolean {
     return result
 }
 
+/**
+ * Waits for the result of the given [getter] function in the spin-loop until the result is not null.
+ * Exits the spin-loop after a certain number of spin-loop iterations.
+ *
+ * @param getter a lambda function that returns the result to wait for.
+ *
+ * @return the result of waiting.
+ *
+ * @see Spinner
+ */
 inline fun <T> Spinner.boundedWaitFor(getter: () -> T?): T? {
     boundedWait {
         val result = getter()
@@ -102,6 +253,6 @@ inline fun <T> Spinner.boundedWaitFor(getter: () -> T?): T? {
     return null
 }
 
-private const val SPIN_LOOP_ITERATIONS_PER_CALL: Int = 1 shl 5 // 32
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD: Int = 1 shl 14 // 16,384
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT: Int = 1 shl 20 // 1,048,576
+private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 1 shl 5  // 32
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1 shl 14 // 16,384
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1 shl 20 // 1,048,576

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -40,6 +40,10 @@ class Spinner(
     }
 
     fun spin(): Boolean {
+        // spin a few iterations
+        repeat(spinLoopIterationsPerCall) {
+            counter++
+        }
         // if exit limit is approached,
         // reset counter and signal to exit the spin-loop
         if (counter >= exitLimit) {
@@ -48,12 +52,8 @@ class Spinner(
         }
         // if yield limit is approached,
         // then yield and give other threads the possibility to work
-        if (shouldYield && counter % yieldLimit == 0 && counter >= 0) {
+        if (shouldYield && counter % yieldLimit == 0) {
             Thread.yield()
-        }
-        // spin a few iterations
-        repeat(spinLoopIterationsPerCall) {
-            counter++
         }
         return true
     }
@@ -102,6 +102,6 @@ inline fun <T> Spinner.boundedWaitFor(getter: () -> T?): T? {
     return null
 }
 
-private const val SPIN_LOOP_ITERATIONS_PER_CALL : Int = 1 shl 5 // 32
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1 shl 14 // 16,384
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT : Int = 1 shl 20 // 1,048,576
+private const val SPIN_LOOP_ITERATIONS_PER_CALL: Int = 1 shl 5 // 32
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD: Int = 1 shl 14 // 16,384
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT: Int = 1 shl 20 // 1,048,576

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -44,16 +44,16 @@ class Spinner(
         repeat(spinLoopIterationsPerCall) {
             counter++
         }
+        // if yield limit is approached,
+        // then yield and give other threads the possibility to work
+        if (shouldYield && counter % yieldLimit == 0) {
+            Thread.yield()
+        }
         // if exit limit is approached,
         // reset counter and signal to exit the spin-loop
         if (counter >= exitLimit) {
             counter = 0
             return false
-        }
-        // if yield limit is approached,
-        // then yield and give other threads the possibility to work
-        if (shouldYield && counter % yieldLimit == 0) {
-            Thread.yield()
         }
         return true
     }

--- a/src/jvm/test/resources/expected_logs/illegal_module_access.txt
+++ b/src/jvm/test/resources/expected_logs/illegal_module_access.txt
@@ -11,13 +11,13 @@ Please add the following lines to your test running configuration:
 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 --add-exports java.base/jdk.internal.util=ALL-UNNAMED
 --add-exports java.base/sun.security.action=ALL-UNNAMED
-	at org.jetbrains.kotlinx.lincheck.UtilsKt.wrapInvalidAccessFromUnnamedModuleExceptionWithDescription(Utils.kt:338)
-	at org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy.onFailure(ManagedStrategy.kt:330)
-	at org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategyRunner.onFailure(ManagedStrategy.kt:1105)
+	at org.jetbrains.kotlinx.lincheck.UtilsKt.wrapInvalidAccessFromUnnamedModuleExceptionWithDescription(Utils.kt:309)
+	at org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy.onFailure(ManagedStrategy.kt:400)
+	at org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategyRunner.onFailure(ManagedStrategy.kt:1270)
 	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution.failOnExceptionIsUnexpected(TestThreadExecution.java:59)
-	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution226.run(Unknown Source)
-	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$8(FixedActiveThreadsExecutor.kt:149)
-	at java.base/java.lang.Thread.run(Thread.java:833)
+	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution8068.run(Unknown Source)
+	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$7(FixedActiveThreadsExecutor.kt:160)
+	at java.base/java.lang.Thread.run(Thread.java:840)
 Caused by: java.lang.IllegalAccessException: module java.base does not "opens java.io" to unnamed module
 	at org.jetbrains.kotlinx.lincheck_test.representation.IllegalModuleAccessOutputMessageTest$operation$1.invoke(IllegalModuleAccessOutputMessageTest.kt:39)
 	at org.jetbrains.kotlinx.lincheck_test.representation.IllegalModuleAccessOutputMessageTest$operation$1.invoke(IllegalModuleAccessOutputMessageTest.kt:39)

--- a/src/jvm/test/resources/expected_logs/internal_bug_report.txt
+++ b/src/jvm/test/resources/expected_logs/internal_bug_report.txt
@@ -6,6 +6,6 @@ Exception stacktrace:
 java.lang.IllegalStateException: Internal bug
 	at org.jetbrains.kotlinx.lincheck.util.InternalLincheckExceptionEmulator.throwException(InternalLincheckExceptionEmulator.kt:23)
 	at org.jetbrains.kotlinx.lincheck_test.representation.InternalLincheckBugTest.operation2(InternalLincheckBugTest.kt:38)
-	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution301.run(Unknown Source)
-	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$8(FixedActiveThreadsExecutor.kt:149)
-	at java.base/java.lang.Thread.run(Thread.java:833)
+	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution8393.run(Unknown Source)
+	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$7(FixedActiveThreadsExecutor.kt:160)
+	at java.base/java.lang.Thread.run(Thread.java:840)

--- a/src/jvm/test/resources/expected_logs/validation_function_failure.txt
+++ b/src/jvm/test/resources/expected_logs/validation_function_failure.txt
@@ -13,9 +13,9 @@
 
 
 java.lang.IllegalStateException: Validation works!
-	at org.jetbrains.kotlinx.lincheck_test.representation.ValidationFunctionCallTest.validateWithError(ValidationFunctionTests.kt:45)
-	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution8218.run(Unknown Source)
-	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$8(FixedActiveThreadsExecutor.kt:151)
+	at org.jetbrains.kotlinx.lincheck_test.representation.ValidationFunctionCallTest.validateWithError(ValidationFunctionTests.kt:44)
+	at org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution9079.run(Unknown Source)
+	at org.jetbrains.kotlinx.lincheck.runner.FixedActiveThreadsExecutor.testThreadRunnable$lambda$7(FixedActiveThreadsExecutor.kt:160)
 	at java.base/java.lang.Thread.run(Thread.java:840)
 
 


### PR DESCRIPTION
Currently, Lincheck performs extremely slow on the machines where number of CPUs is less than a number of threads in the tested scenario. 

The reason for that is because there are several places in the Lincheck codebase where spin-loops are used to wait for a certain condition. These loops spin a fixed (large) number of times. But if there are no available CPUs, then these spin-loops just consume all the available computational resources and the test hangs.

Previously, only in one of the places where spin-loops are utilized there was implemented a special check for the case when `#cpus < #threads`. Because of code duplication, other similar places were omitted by mistake.

To address this issue, I extracted common spin-looping logic into an utility class `Spinner` (inspired by the similar solutions in the Rust's [crossbeam](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html) and [parking-lot](https://docs.rs/parking_lot_core/latest/parking_lot_core/struct.SpinWait.html) libraries).

This class also has a special handling for the case when `#cpus < #threads` to avoid redundant spinning.

In future, we might consider to improve the performance of the spinning by utilizing the [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) strategy, similarly as how it is done in the [crossbeam](https://docs.rs/crossbeam/latest/crossbeam/utils/struct.Backoff.html) library.

Closes #280