### PR TITLE
Optimize spin-wait loop in Spinner

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -252,6 +252,6 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
     return null
 }
 
-private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 10
+private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 100
 private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 10_000_000
 private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 100_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -124,7 +124,7 @@ class Spinner(val nThreads: Int = -1) {
      *   for example, to fall back into a blocking synchronization.
      */
     fun spin(): Boolean {
-        // spin a few iterations
+        Thread.onSpinWait()
         counter++
         // if yield limit is approached,
         // then yield and give other threads the opportunity to run

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -253,5 +253,5 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
 }
 
 private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 10
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1_000_000
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 100_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 100_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1000_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -216,5 +216,5 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
     return null
 }
 
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 10_000_000
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1_000_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 100_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -253,5 +253,5 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
 }
 
 private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 10
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 100_000_000
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1_000_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 10_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 100_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -254,4 +254,4 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
 
 private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 10
 private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 100_000_000
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1000_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1_000_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -101,12 +101,6 @@ class Spinner(val nThreads: Int = -1) {
     }
 
     /**
-     * The number of spin-loop iterations to be performed per call to [spin].
-     */
-    private val spinLoopIterationsPerCall: Int =
-        if (shouldSpin) SPIN_LOOP_ITERATIONS_PER_CALL else 1
-
-    /**
      * The number of spin-loop iterations before yielding the current thread
      * to give other threads the opportunity to run.
      */
@@ -131,9 +125,7 @@ class Spinner(val nThreads: Int = -1) {
      */
     fun spin(): Boolean {
         // spin a few iterations
-        repeat(spinLoopIterationsPerCall) {
-            counter++
-        }
+        counter++
         // if yield limit is approached,
         // then yield and give other threads the opportunity to run
         if (counter % yieldLimit == 0) {
@@ -224,6 +216,5 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
     return null
 }
 
-private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 1 shl 5  // 32
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 1 shl 14 // 16,384
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1 shl 20 // 1,048,576
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 10_000_000
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 1_000_000_000

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/LockFreeSetTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/LockFreeSetTest.kt
@@ -38,7 +38,7 @@ class LockFreeSetTest {
 
         StressOptions()
             .addCustomScenario(scenario)
-            .invocationsPerIteration(1000000)
+            .invocationsPerIteration(10_000_000)
             .iterations(0)
             .check(LockFreeSet::class)
     }


### PR DESCRIPTION
Tweak constants in `Spinner` to ensure rare `Thread.yield()` calls. 