### PR TITLE
Implement `final` field detection without `Class.forName(..)`

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LincheckClassLoader.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LincheckClassLoader.java
@@ -158,7 +158,7 @@ public class LincheckClassLoader extends ClassLoader {
         ClassVersionGetter infoGetter = new ClassVersionGetter();
         cr.accept(infoGetter, 0);
         ClassWriter cw = new TransformationClassWriter(infoGetter.getClassVersion(), remapper);
-        LincheckClassVisitor cv = new LincheckClassVisitor(this, transformationMode, cw);
+        LincheckClassVisitor cv = new LincheckClassVisitor(transformationMode, cw);
         cr.accept(cv, ClassReader.EXPAND_FRAMES);
         return cw.toByteArray();
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LincheckClassLoader.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LincheckClassLoader.java
@@ -158,7 +158,7 @@ public class LincheckClassLoader extends ClassLoader {
         ClassVersionGetter infoGetter = new ClassVersionGetter();
         cr.accept(infoGetter, 0);
         ClassWriter cw = new TransformationClassWriter(infoGetter.getClassVersion(), remapper);
-        LincheckClassVisitor cv = new LincheckClassVisitor(transformationMode, cw);
+        LincheckClassVisitor cv = new LincheckClassVisitor(this, transformationMode, cw);
         cr.accept(cv, ClassReader.EXPAND_FRAMES);
         return cw.toByteArray();
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
@@ -10,11 +10,13 @@
 
 package org.jetbrains.kotlinx.lincheck.transformation
 
-import org.jetbrains.kotlinx.lincheck.LincheckClassLoader.REMAPPED_PACKAGE_INTERNAL_NAME
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.FieldVisitor
-import org.objectweb.asm.Opcodes
+import org.jetbrains.kotlinx.lincheck.LincheckClassLoader.*
+import org.jetbrains.kotlinx.lincheck.transformation.FinalFields.FinalFieldsVisitor
+import org.jetbrains.kotlinx.lincheck.transformation.FinalFields.addFinalField
+import org.jetbrains.kotlinx.lincheck.transformation.FinalFields.addMutableField
+import org.jetbrains.kotlinx.lincheck.transformation.FinalFields.collectFieldInformation
+import org.jetbrains.kotlinx.lincheck.transformation.FinalFields.isFinalField
+import org.objectweb.asm.*
 
 /**
  * [CodeLocations] object is used to maintain the mapping between unique IDs and code locations.
@@ -64,56 +66,93 @@ internal object CodeLocations {
  *
  * However, sometimes due to the order of class processing, we may not have information about this field yet,
  * as its class it is not loaded for now.
- * Then, we fall back to the slow-path algorithm [findField]: we read bytecode and analyze it using [FinalFieldsVisitor].
+ * Then, we fall back to the slow-path algorithm [collectFieldInformation]: we read bytecode and analyze it using [FinalFieldsVisitor].
  * If field is found, we record this information and return the result, otherwise we scan superclass and all implemented
  * interfaces in the same way.
  */
 internal object FinalFields {
 
     /**
-     * Stores a map FIELD NAME -> IS FINAL for each processed class.
+     * Stores a map INTERNAL_CLASS_NAME -> { FIELD_NAME -> IS FINAL } for each processed class.
      */
-    private val finalFields = HashMap<String, HashMap<String, Boolean>>()
+    private val classToFieldsMap = HashMap<String, HashMap<String, Boolean>>()
 
     /**
-     * Registers the field [fieldName] as a final field of the class [className]
+     * Registers the field [fieldName] as a final field of the class [internalClassName].
      */
-    fun addFinalField(className: String, fieldName: String) {
-        val internalName = className.normalizedClassName
-        val fieldsForClass = finalFields[internalName]
-        if (fieldsForClass == null) {
-            finalFields[className] = hashMapOf(fieldName to true)
-        } else {
-            fieldsForClass[fieldName] = true
-        }
+    fun addFinalField(internalClassName: String, fieldName: String) {
+        val fields = classToFieldsMap.computeIfAbsent(internalClassName) { HashMap() }
+        fields[fieldName] = false
     }
 
     /**
-     * Registers the field [fieldName] as a mutable field of the class [className]
+     * Registers the field [fieldName] as a mutable field of the class [internalClassName].
      */
-    fun addMutableField(className: String, fieldName: String) {
-        val internalName = className.normalizedClassName
-        val fieldsForClass = finalFields[internalName]
-        if (fieldsForClass == null) {
-            finalFields[className] = hashMapOf(fieldName to false)
-        } else {
-            fieldsForClass[fieldName] = false
-        }
+    fun addMutableField(internalClassName: String, fieldName: String) {
+        val fields = classToFieldsMap.computeIfAbsent(internalClassName) { HashMap() }
+        fields[fieldName] = true
     }
 
     /**
      * Determines if this field is final or not.
      */
-    fun isFinalField(className: String, fieldName: String): Boolean {
-        val internalName = className.normalizedClassName
-        val fieldsForClass = finalFields.computeIfAbsent(internalName) { hashMapOf() }
-        // Fast-path, in case we have information about this field
-        fieldsForClass[fieldName]?.let { return it }
-        // If we haven't processed this class yet, fall back to a slow-path, reading byte-code of a class
-        findField(internalName, fieldsForClass, fieldName)
-        // Here we must have information about this field, as we scanned all the hierarchy of this class
-        val isFieldFinal = fieldsForClass[fieldName] ?: error("Internal error: can't find field with $fieldName in class $className")
-        return isFieldFinal
+    fun isFinalField(internalClassName: String, fieldName: String): Boolean {
+        val fields = classToFieldsMap.computeIfAbsent(internalClassName) { HashMap() }
+        // Fast-path, in case we already have information about this field.
+        fields[fieldName]?.let { return it }
+        // If we haven't processed this class yet, fall back to a slow-path, reading the class byte-code.
+        collectFieldInformation(internalClassName, fieldName, fields)
+        // Here we must have information about this field, as we scanned all the hierarchy of this class.
+        return fields[fieldName] ?: error("Internal error: can't find field with $fieldName in class $internalClassName")
+    }
+
+    /**
+     * The slow-path of deciding if this field is final or not.
+     * Reads class from the classloader, scans it and extracts information about declared fields.
+     * If the field is not found, recursively searches in the superclass and implemented interfaces.
+     */
+    private fun collectFieldInformation(
+        internalClassName: String,
+        fieldName: String,
+        fields: MutableMap<String, Boolean>
+    ): Boolean {
+        // Read the class from classLoader.
+        val classReader = getClassReader(internalClassName)
+        val visitor = FinalFieldsVisitor()
+        // Scan class.
+        classReader.accept(visitor, 0)
+        // Store information about all final and mutable fields.
+        visitor.finalFields.forEach { field -> fields[field] = true }
+        visitor.mutableFields.forEach { field -> fields[field] = false }
+        // If the field is found - return it.
+        if (fieldName in visitor.finalFields || fieldName in visitor.mutableFields) return true
+        // If field is not present in this class - search in the superclass recursively.
+        visitor.superClassName?.let { internalSuperClassName ->
+            val internalSuperClassNameNormalized = internalSuperClassName.normalizedClassName
+            val superClassFields = classToFieldsMap.computeIfAbsent(internalSuperClassNameNormalized) { hashMapOf() }
+            val fieldFound = collectFieldInformation(internalSuperClassNameNormalized, fieldName, superClassFields)
+            // Copy all field information found in the superclass to the current class map.
+            addFieldsInfoFromSuperclass(internalSuperClassNameNormalized, internalClassName)
+            if (fieldFound) return true
+        }
+        // If field is not present in this class - search in the all implemented interfaces recursively.
+        visitor.implementedInterfaces.forEach { interfaceName ->
+            val normalizedInterfaceName = interfaceName.normalizedClassName
+            val interfaceFields = classToFieldsMap.computeIfAbsent(normalizedInterfaceName) { hashMapOf() }
+            val fieldFound = collectFieldInformation(normalizedInterfaceName, fieldName, interfaceFields)
+            // Copy all field information found in the interface to the current class map.
+            addFieldsInfoFromSuperclass(normalizedInterfaceName, internalClassName)
+            if (fieldFound) return true
+        }
+        // There is no such field in this class.
+        return false
+    }
+
+    private fun getClassReader(internalClassName: String): ClassReader {
+        val resource = "$internalClassName.class"
+        val inputStream = ClassLoader.getSystemClassLoader().getResourceAsStream(resource)
+            ?: error("Cannot create ClassReader for type $internalClassName")
+        return inputStream.use { ClassReader(inputStream) }
     }
 
     /**
@@ -121,8 +160,8 @@ internal object FinalFields {
      * parent fields to child map to avoid potential scanning of a child class in the search of a parent field.
      */
     private fun addFieldsInfoFromSuperclass(superType: String, type: String) {
-        val superFields = finalFields[superType] ?: return
-        val fields = finalFields.computeIfAbsent(type) { hashMapOf() }
+        val superFields = classToFieldsMap[superType] ?: return
+        val fields = classToFieldsMap.computeIfAbsent(type) { hashMapOf() }
         superFields.forEach { (fieldName, isFinal) ->
             // If we have a field shadowing (the same field name in the child class),
             // it's important not to override this information.
@@ -133,55 +172,6 @@ internal object FinalFields {
                 fields[fieldName] = isFinal
             }
         }
-    }
-
-
-    /**
-     * The slow-path of deciding if this field is final or not.
-     * Reads class from the classloader, scans it and extracts information about declared fields.
-     * If the field is not found, recursively searches in the superclass and implemented interfaces.
-     */
-    private fun findField(
-        type: String,
-        typeIsFinalFieldMap: MutableMap<String, Boolean>,
-        fieldName: String
-    ): Boolean {
-        // Read class from classLoader.
-        val classReader = typeInfo(type)
-        val visitor = FinalFieldsVisitor()
-        // Scan class.
-        classReader.accept(visitor, 0)
-        // Store information about all final and mutable fields.
-        visitor.finalFields.forEach { field -> typeIsFinalFieldMap[field] = true }
-        visitor.mutableFields.forEach { field -> typeIsFinalFieldMap[field] = false }
-        // If the field is found - return it.
-        if (fieldName in visitor.finalFields || fieldName in visitor.mutableFields) return true
-        // If field is not present in this class - search in the superclass recursively.
-        visitor.superClassName?.let { superName ->
-            val normalizedSuperName = superName.normalizedClassName
-            val superclassFields = finalFields.computeIfAbsent(normalizedSuperName) { hashMapOf() }
-            val fieldFound = findField(normalizedSuperName, superclassFields, fieldName)
-            // Copy all field information found in the superclass to the current class map.
-            addFieldsInfoFromSuperclass(normalizedSuperName, type)
-            if (fieldFound) return true
-        }
-        // If field is not present in this class - search in the all implemented interfaces recursively.
-        visitor.implementedInterfaces.forEach { interfaceName ->
-            val normalizedInterfaceName = interfaceName.normalizedClassName
-            val interfaceFields = finalFields.computeIfAbsent(normalizedInterfaceName) { hashMapOf() }
-            val fieldFound = findField(normalizedInterfaceName, interfaceFields, fieldName)
-            // Copy all field information found in the interface to the current class map.
-            addFieldsInfoFromSuperclass(normalizedInterfaceName, type)
-            if (fieldFound) return true
-        }
-        // There is no such field in this class.
-        return false
-    }
-
-    private fun typeInfo(type: String): ClassReader {
-        val resource = "$type.class"
-        val inputStream = ClassLoader.getSystemClassLoader().getResourceAsStream(resource) ?: error("Cannot create ClassReader for type $type")
-        return inputStream.use { ClassReader(inputStream) }
     }
 
     private val String.normalizedClassName: String
@@ -197,16 +187,17 @@ internal object FinalFields {
      * This visitor collects information about fields, declared in this class,
      * about superclass and implemented interfaces.
      */
-    private class FinalFieldsVisitor : ClassVisitor(Opcodes.ASM9) {
-
-        var superClassName: String? = null
-        lateinit var implementedInterfaces: Array<String>
+    private class FinalFieldsVisitor : ClassVisitor(ASM_API) {
+        val implementedInterfaces = arrayListOf<String>()
         val finalFields = arrayListOf<String>()
         val mutableFields = arrayListOf<String>()
 
+        var superClassName: String? = null
+
+
         override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<String>?) {
             superClassName = superName
-            implementedInterfaces = interfaces ?: emptyArray()
+            interfaces?.let { implementedInterfaces += interfaces }
             super.visit(version, access, name, signature, superName, interfaces)
         }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
@@ -206,26 +206,13 @@ internal object FinalFields {
         val finalFields = arrayListOf<String>()
         val mutableFields = arrayListOf<String>()
 
-        override fun visit(
-            version: Int,
-            access: Int,
-            name: String,
-            signature: String?,
-            superName: String?,
-            interfaces: Array<String>?
-        ) {
+        override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<String>?) {
             superClassName = superName
             implementedInterfaces = interfaces ?: emptyArray()
             super.visit(version, access, name, signature, superName, interfaces)
         }
 
-        override fun visitField(
-            access: Int,
-            name: String,
-            descriptor: String?,
-            signature: String?,
-            value: Any?
-        ): FieldVisitor? {
+        override fun visitField(access: Int, name: String, descriptor: String?, signature: String?, value: Any?): FieldVisitor? {
             if ((access and Opcodes.ACC_FINAL) != 0) {
                 finalFields.add(name)
             } else {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/CodeInformation.kt
@@ -10,9 +10,12 @@
 
 package org.jetbrains.kotlinx.lincheck.transformation
 
+import org.jetbrains.kotlinx.lincheck.LincheckClassLoader
 import org.jetbrains.kotlinx.lincheck.LincheckClassLoader.REMAPPED_PACKAGE_INTERNAL_NAME
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier.*
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.Opcodes
 
 /**
  * [CodeLocations] object is used to maintain the mapping between unique IDs and code locations.
@@ -53,37 +56,183 @@ internal object CodeLocations {
 
 /**
  * [FinalFields] object is used to track final fields across different classes.
- * As a field may be declared in the parent class, [isFinalField] method recursively traverses all the
- * hierarchy to find the field and check it.
+ * It is used only during byte-code transformation to get information about fields
+ * and decide should we track reads of a field or not.
+ *
+ * During transformation [addFinalField] and [addMutableField] methods are called when
+ * we meet a field declaration. Then, when we are faced with field read instruction, [isFinalField] method
+ * is called.
+ *
+ * However, sometimes due to the order of class processing, we may not have information about this field yet,
+ * as its class it is not loaded for now.
+ * Then, we fall back to the slow-path algorithm [findField]: we read bytecode and analyze it using [FinalFieldsVisitor].
+ * If field is found, we record this information and return the result, otherwise we scan superclass and all implemented
+ * interfaces in the same way.
  */
 internal object FinalFields {
 
-    fun isFinalField(ownerInternal: String, fieldName: String): Boolean {
-        var internalName = ownerInternal
-        if (internalName.startsWith(REMAPPED_PACKAGE_INTERNAL_NAME)) {
-            internalName = internalName.substring(REMAPPED_PACKAGE_INTERNAL_NAME.length)
-        }
-        return try {
-            val clazz = Class.forName(internalName.canonicalClassName)
-            val field = findField(clazz, fieldName) ?: throw NoSuchFieldException("No $fieldName in ${clazz.name}")
-            (field.modifiers and FINAL) == FINAL
-        } catch (e: ClassNotFoundException) {
-            throw RuntimeException(e)
-        } catch (e: NoSuchFieldException) {
-            throw RuntimeException(e)
+    /**
+     * Stores a map FIELD NAME -> IS FINAL for each processed class.
+     */
+    private val finalFields = HashMap<String, HashMap<String, Boolean>>()
+
+    /**
+     * Registers the field [fieldName] as a final field of the class [className]
+     */
+    fun addFinalField(className: String, fieldName: String) {
+        val internalName = className.normalizedClassName
+        val fieldsForClass = finalFields[internalName]
+        if (fieldsForClass == null) {
+            finalFields[className] = hashMapOf(fieldName to true)
+        } else {
+            fieldsForClass[fieldName] = true
         }
     }
 
-    private fun findField(clazz: Class<*>?, fieldName: String): Field? {
-        if (clazz == null) return null
-        val fields = clazz.declaredFields
-        for (field in fields) if (field.name == fieldName) return field
-        // No field found in this class.
-        // Search in super class first, then in interfaces.
-        findField(clazz.superclass, fieldName)?.let { return it }
-        clazz.interfaces.forEach { iClass ->
-            findField(iClass, fieldName)?.let { return it }
+    /**
+     * Registers the field [fieldName] as a mutable field of the class [className]
+     */
+    fun addMutableField(className: String, fieldName: String) {
+        val internalName = className.normalizedClassName
+        val fieldsForClass = finalFields[internalName]
+        if (fieldsForClass == null) {
+            finalFields[className] = hashMapOf(fieldName to false)
+        } else {
+            fieldsForClass[fieldName] = false
         }
-        return null
     }
+
+    /**
+     * Determines if this field is final or not.
+     */
+    fun isFinalField(classLoader: LincheckClassLoader, className: String, fieldName: String): Boolean {
+        val internalName = className.normalizedClassName
+        val fieldsForClass = finalFields.computeIfAbsent(internalName) { hashMapOf() }
+        // Fast-path, in case we have information about this field
+        fieldsForClass[fieldName]?.let { return it }
+        // If we haven't processed this class yet, fall back to a slow-path, reading byte-code of a class
+        findField(classLoader, internalName, fieldsForClass, fieldName)
+        // Here we must have information about this field, as we scanned all the hierarchy of this class
+        val isFieldFinal = fieldsForClass[fieldName] ?: error("Internal error: can't find field with $fieldName in class $className")
+        return isFieldFinal
+    }
+
+    /**
+     * When processing of a superclass is done, it's important to add all information about
+     * parent fields to child map to avoid potential scanning of a child class in the search of a parent field.
+     */
+    private fun addFieldsInfoFromSuperclass(superType: String, type: String) {
+        val superFields = finalFields[superType] ?: return
+        val fields = finalFields.computeIfAbsent(type) { hashMapOf() }
+        superFields.forEach { (fieldName, isFinal) ->
+            // If we have a field shadowing (the same field name in the child class),
+            // it's important not to override this information.
+            // For example, we may have a final field X in a parent class, and a mutable field X in a child class.
+            // So, while copying information from the parent class to the child class, we mustn't override that field
+            // X in the child class is mutable, as it may lead to omitted beforeRead events.
+            if (fieldName !in fields) {
+                fields[fieldName] = isFinal
+            }
+        }
+    }
+
+
+    /**
+     * The slow-path of deciding if this field is final or not.
+     * Reads class from the classloader, scans it and extracts information about declared fields.
+     * If the field is not found, recursively searches in the superclass and implemented interfaces.
+     */
+    private fun findField(
+        classLoader: ClassLoader,
+        type: String,
+        typeIsFinalFieldMap: MutableMap<String, Boolean>,
+        fieldName: String
+    ): Boolean {
+        // Read class from classLoader.
+        val classReader = typeInfo(classLoader, type)
+        val visitor = FinalFieldsVisitor()
+        // Scan class.
+        classReader.accept(visitor, 0)
+        // Store information about all final and mutable fields.
+        visitor.finalFields.forEach { field -> typeIsFinalFieldMap[field] = true }
+        visitor.mutableFields.forEach { field -> typeIsFinalFieldMap[field] = false }
+        // If the field is found - return it.
+        if (fieldName in visitor.finalFields || fieldName in visitor.mutableFields) return true
+        // If field is not present in this class - search in the superclass recursively.
+        visitor.superClassName?.let { superName ->
+            val normalizedSuperName = superName.normalizedClassName
+            val superclassFields = finalFields.computeIfAbsent(normalizedSuperName) { hashMapOf() }
+            val fieldFound = findField(classLoader, normalizedSuperName, superclassFields, fieldName)
+            // Copy all field information found in the superclass to the current class map.
+            addFieldsInfoFromSuperclass(normalizedSuperName, type)
+            if (fieldFound) return true
+        }
+        // If field is not present in this class - search in the all implemented interfaces recursively.
+        visitor.implementedInterfaces.forEach { interfaceName ->
+            val normalizedInterfaceName = interfaceName.normalizedClassName
+            val interfaceFields = finalFields.computeIfAbsent(normalizedInterfaceName) { hashMapOf() }
+            val fieldFound = findField(classLoader, normalizedInterfaceName, interfaceFields, fieldName)
+            // Copy all field information found in the interface to the current class map.
+            addFieldsInfoFromSuperclass(normalizedInterfaceName, type)
+            if (fieldFound) return true
+        }
+        // There is no such field in this class.
+        return false
+    }
+
+    private fun typeInfo(classLoader: ClassLoader, type: String): ClassReader {
+        val resource = "$type.class"
+        val inputStream = classLoader.getResourceAsStream(resource) ?: error("Cannot create ClassReader for type $type")
+        return inputStream.use { ClassReader(inputStream) }
+    }
+
+    private val String.normalizedClassName: String
+        get() {
+            var internalName = this
+            if (internalName.startsWith(REMAPPED_PACKAGE_INTERNAL_NAME)) {
+                internalName = internalName.substring(REMAPPED_PACKAGE_INTERNAL_NAME.length)
+            }
+            return internalName
+        }
+
+    /**
+     * This visitor collects information about fields, declared in this class,
+     * about superclass and implemented interfaces.
+     */
+    private class FinalFieldsVisitor : ClassVisitor(Opcodes.ASM9) {
+
+        var superClassName: String? = null
+        lateinit var implementedInterfaces: Array<String>
+        val finalFields = arrayListOf<String>()
+        val mutableFields = arrayListOf<String>()
+
+        override fun visit(
+            version: Int,
+            access: Int,
+            name: String,
+            signature: String?,
+            superName: String?,
+            interfaces: Array<String>?
+        ) {
+            superClassName = superName
+            implementedInterfaces = interfaces ?: emptyArray()
+            super.visit(version, access, name, signature, superName, interfaces)
+        }
+
+        override fun visitField(
+            access: Int,
+            name: String,
+            descriptor: String?,
+            signature: String?,
+            value: Any?
+        ): FieldVisitor? {
+            if ((access and Opcodes.ACC_FINAL) != 0) {
+                finalFields.add(name)
+            } else {
+                mutableFields.add(name)
+            }
+            return super.visitField(access, name, descriptor, signature, value)
+        }
+    }
+
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlinx.lincheck.transformation.TransformationMode.*
 import java.util.*
 
 internal class LincheckClassVisitor(
-    private val classLoader: LincheckClassLoader,
     private val transformationMode: TransformationMode,
     classVisitor: ClassVisitor
 ) : ClassVisitor(
@@ -517,7 +516,7 @@ internal class LincheckClassVisitor(
         lateinit var analyzer: AnalyzerAdapter
 
         override fun visitFieldInsn(opcode: Int, owner: String, fieldName: String, desc: String) = adapter.run {
-            if (isCoroutineInternalClass(owner) || isCoroutineStateMachineClass(owner) || FinalFields.isFinalField(classLoader, owner, fieldName)
+            if (isCoroutineInternalClass(owner) || isCoroutineStateMachineClass(owner) || FinalFields.isFinalField(owner, fieldName)
             ) {
                 visitFieldInsn(opcode, owner, fieldName, desc)
                 return

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -12,6 +12,7 @@ package org.jetbrains.kotlinx.lincheck.transformation
 
 import org.jetbrains.kotlinx.lincheck.LincheckClassLoader.ASM_API
 import org.jetbrains.kotlinx.lincheck.Injections
+import org.jetbrains.kotlinx.lincheck.LincheckClassLoader
 import org.jetbrains.kotlinx.lincheck.strategy.managed.JavaUtilRemapper
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
@@ -23,6 +24,7 @@ import org.jetbrains.kotlinx.lincheck.transformation.TransformationMode.*
 import java.util.*
 
 internal class LincheckClassVisitor(
+    private val classLoader: LincheckClassLoader,
     private val transformationMode: TransformationMode,
     classVisitor: ClassVisitor
 ) : ClassVisitor(
@@ -32,6 +34,21 @@ internal class LincheckClassVisitor(
     private lateinit var className: String
     private var classVersion = 0
     private var fileName: String? = null
+
+    override fun visitField(
+        access: Int,
+        fieldName: String,
+        descriptor: String?,
+        signature: String?,
+        value: Any?
+    ): FieldVisitor {
+        if (access and ACC_FINAL != 0) {
+            FinalFields.addFinalField(className, fieldName)
+        } else {
+            FinalFields.addMutableField(className, fieldName)
+        }
+        return super.visitField(access, fieldName, descriptor, signature, value)
+    }
 
     override fun visit(
         version: Int,
@@ -500,10 +517,7 @@ internal class LincheckClassVisitor(
         lateinit var analyzer: AnalyzerAdapter
 
         override fun visitFieldInsn(opcode: Int, owner: String, fieldName: String, desc: String) = adapter.run {
-            if (isCoroutineInternalClass(owner) || isCoroutineStateMachineClass(owner) || FinalFields.isFinalField(
-                    owner,
-                    fieldName
-                )
+            if (isCoroutineInternalClass(owner) || isCoroutineStateMachineClass(owner) || FinalFields.isFinalField(classLoader, owner, fieldName)
             ) {
                 visitFieldInsn(opcode, owner, fieldName, desc)
                 return


### PR DESCRIPTION
New way of final field detection without `Class.forName`. We need this change for merging transformation via Java agents.