### PR TITLE
Optimize spin loops and fix regression

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -12,9 +12,7 @@ package org.jetbrains.kotlinx.lincheck.runner
 import kotlinx.atomicfu.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.execution.*
-import org.jetbrains.kotlinx.lincheck.util.Spinner
-import org.jetbrains.kotlinx.lincheck.util.SpinnerGroup
-import org.jetbrains.kotlinx.lincheck.util.spinWaitBoundedFor
+import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.kotlinx.lincheck.TestThread
 import java.io.*
 import java.lang.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -53,7 +53,8 @@ internal class FixedActiveThreadsExecutor(private val testName: String, private 
     // we set `nThreads + 1` as a number of threads, because
     // we have `nThreads` of the scenario plus the main thread waiting for the result;
     // if this number is greater than the number of available CPUs,
-    // the main thread will be parked immediately without spinning
+    // the main thread will be parked immediately without spinning;
+    // in this case, if `nCPUs = nThreads` all the scenario threads still will be spinning
     private val resultSpinner = Spinner(nThreads + 1)
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -50,7 +50,11 @@ internal class FixedActiveThreadsExecutor(private val testName: String, private 
      *
      * Only the main thread submitting tasks manipulates this spinner.
      */
-    private val resultSpinner = Spinner(nThreads)
+    // we set `nThreads + 1` as a number of threads, because
+    // we have `nThreads` of the scenario plus the main thread waiting for the result;
+    // if this number is greater than the number of available CPUs,
+    // the main thread will be parked immediately without spinning
+    private val resultSpinner = Spinner(nThreads + 1)
 
     /**
      * This flag is set to `true` when [await] detects a hang.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -18,8 +18,7 @@ import org.jetbrains.kotlinx.lincheck.runner.ParallelThreadsRunner.Completion.*
 import org.jetbrains.kotlinx.lincheck.runner.UseClocks.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy
-import org.jetbrains.kotlinx.lincheck.util.SpinnerGroup
-import org.jetbrains.kotlinx.lincheck.util.spinWaitUntil
+import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.kotlinx.lincheck.TestThread
 import java.lang.reflect.*
 import java.util.concurrent.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -17,8 +17,7 @@ import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
-import org.jetbrains.kotlinx.lincheck.util.SpinnerGroup
-import org.jetbrains.kotlinx.lincheck.util.spinWaitUntil
+import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.jetbrains.kotlinx.lincheck.transformation.CodeLocations
 import org.jetbrains.kotlinx.lincheck.Injections

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -269,5 +269,5 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
 
 private const val MAX_BACKOFF_STEP : Int = 6 // 2^6 = 64 spin-loop iteration per call
 
-private const val SPIN_CALLS_BEFORE_YIELD : Int = 10_000
-private const val SPIN_CALLS_BEFORE_EXIT  : Int = 100_000
+private const val SPIN_CALLS_BEFORE_YIELD : Int = 1_000
+private const val SPIN_CALLS_BEFORE_EXIT  : Int = 10_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -170,4 +170,4 @@ fun SpinnerGroup(nThreads: Int): List<Spinner> {
 }
 
 
-const val SPIN_CYCLES_BOUND: Int = 10_000
+const val SPIN_CYCLES_BOUND: Int = 1_000_000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -20,7 +20,7 @@ package org.jetbrains.kotlinx.lincheck.util
  *
  * @constructor Creates an instance of the [Spinner] class.
  */
-class Spinner(val nThreads: Int = -1) {
+internal class Spinner(val nThreads: Int = -1) {
 
     /**
      * Determines whether the spinner should actually spin in a loop,
@@ -62,8 +62,6 @@ class Spinner(val nThreads: Int = -1) {
      *
      * @param condition A lambda function that determines the condition to wait for.
      *   The function should return true when the condition is satisfied, and false otherwise.
-     *
-     * @see Spinner
      */
     inline fun spinWaitUntil(condition: () -> Boolean) {
         var counter = 0
@@ -118,8 +116,6 @@ class Spinner(val nThreads: Int = -1) {
      *
      * @return `true` if the condition is met; `false` if the condition was not met and
      *   the spin-wait loop exited because the bound was reached.
-     *
-     * @see Spinner
      */
     inline fun Spinner.spinWaitBoundedUntil(condition: () -> Boolean): Boolean {
         var counter = 0
@@ -135,28 +131,27 @@ class Spinner(val nThreads: Int = -1) {
         }
         return result
     }
+}
 
-    /**
-     * Waits for the result of the given [getter] function in the spin-loop until the result is not null.
-     * Exits the spin-loop after a certain number of spin-loop iterations.
-     *
-     * @param getter A lambda function that returns the result to wait for.
-     *
-     * @return The result of waiting, or null if
-     *   the spin-wait loop exited because the bound was reached.
-     *
-     * @see Spinner.spinWaitBoundedFor
-     */
-    inline fun <T> spinWaitBoundedFor(getter: () -> T?): T? {
-        spinWaitBoundedUntil {
-            val result = getter()
-            if (result != null)
-                return result
-            false
-        }
-        return null
+/**
+ * Waits for the result of the given [getter] function in the spin-loop until the result is not null.
+ * Exits the spin-loop after a certain number of spin-loop iterations.
+ *
+ * @param getter A lambda function that returns the result to wait for.
+ *
+ * @return The result of waiting, or null if
+ *   the spin-wait loop exited because the bound was reached.
+ *
+ * @see Spinner.spinWaitBoundedFor
+ */
+internal inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
+    spinWaitBoundedUntil {
+        val result = getter()
+        if (result != null)
+            return result
+        false
     }
-
+    return null
 }
 
 /**
@@ -165,7 +160,8 @@ class Spinner(val nThreads: Int = -1) {
  *
  * @param nThreads The number of threads in the group.
  */
-fun SpinnerGroup(nThreads: Int): List<Spinner> {
+@Suppress("FunctionName")
+internal fun SpinnerGroup(nThreads: Int): List<Spinner> {
     return Array(nThreads) { Spinner(nThreads) }.asList()
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -155,10 +155,7 @@ class Spinner(val nThreads: Int = -1) {
         counter += spinLoopIterations
         backoffStep = (backoffStep + 1).coerceAtMost(SPIN_LOOP_ITERATIONS_PER_CALL)
         // if yield limit is approached,
-        // then yield and give other threads the opportunity to run;
-        // we add 1 to counter, because the number of spin-wait loop iterations
-        // in the exponential backoff strategy is equal to
-        // `sum(2^i) for i=0..n = 2^(n+1) - 1`
+        // then yield and give other threads the opportunity to run
         if (counter >= (1 + yieldCounter) * yieldLimit) {
             yieldCounter += 1
             Thread.yield()
@@ -283,6 +280,6 @@ inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
  * here we define them via their exponent number.
  */
 
-private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 6   // 2^6 = 64
-private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 14  // 2^14 = 16,384
-private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 20  // 2^20 = 1,048,576
+private const val SPIN_LOOP_ITERATIONS_PER_CALL     : Int = 6   // 2^6  = 64
+private const val SPIN_LOOP_ITERATIONS_BEFORE_YIELD : Int = 20  // 2^20 = 1,048,576
+private const val SPIN_LOOP_ITERATIONS_BEFORE_EXIT  : Int = 26  // 2^26 = 67,108,864

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Spinner.kt
@@ -40,26 +40,6 @@ internal class Spinner(val nThreads: Int = -1) {
      * Waits in the spin-loop until the given condition is true
      * with periodical yielding to other threads.
      *
-     * For example, the spin-lock can be implemented with
-     * the help of the [spinWaitUntil] as follows:
-     *
-     * ```
-     *  class SpinLock {
-     *      private val lock = AtomicBoolean()
-     *      private val spinner = Spinner()
-     *
-     *      fun lock() {
-     *          spinner.spinWaitUntil {
-     *              lock.compareAndSet(false, true)
-     *          }
-     *      }
-     *
-     *      fun unlock() {
-     *          lock.set(false)
-     *      }
-     *  }
-     * ```
-     *
      * @param condition A lambda function that determines the condition to wait for.
      *   The function should return true when the condition is satisfied, and false otherwise.
      */
@@ -79,37 +59,6 @@ internal class Spinner(val nThreads: Int = -1) {
      * Waits in the spin-loop until the given condition is true.
      * Exits the spin-loop after a certain number of spin-loop iterations ---
      * typically, in this case, one may want to fall back into some blocking synchronization.
-     *
-     * For example, a simple spin-lock that fall-backs into thread parking can be implemented with
-     * the help of the [spinWaitBoundedUntil] as follows:
-     *
-     * ```
-     *  class SimpleQueuedLock {
-     *      private val lock = AtomicBoolean()
-     *      private val queue = ConcurrentLinkedQueue<Thread>()
-     *      private val spinner = Spinner()
-     *
-     *      fun lock() {
-     *          while (true) {
-     *              val locked = spinner.spinWaitBoundedUntil {
-     *                  lock.compareAndSet(false, true)
-     *              }
-     *              if (locked) return
-     *              val thread = Thread.currentThread()
-     *              if (!queue.contains(thread)
-     *                  queue.add(thread)
-     *              LockSupport.park()
-     *          }
-     *      }
-     *
-     *      fun unlock() {
-     *          lock.set(false)
-     *          queue.poll()?.also {
-     *              LockSupport.unpark(it)
-     *          }
-     *      }
-     *  }
-     * ```
      *
      * @param condition A lambda function that determines the condition to wait for.
      *   The function should return true when the condition is satisfied, and false otherwise.


### PR DESCRIPTION
This PR implements optimizes and simplified spin loops:
1. make the counter local variable;
2. count only the number if `spin` calls. 

It also fixes the regression problem on machines with small number of CPUs by changing the `nThreads` parameter of `resultSpinner` to also count for the main thread. If the number of scenario threads + main thread is greater than the number of available CPUs, the main thread does not spin and parks immediately.