### PR TITLE
Bump minimal plugin version to 0.2

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
@@ -15,7 +15,7 @@ import sun.nio.ch.lincheck.*
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 
-const val MINIMAL_PLUGIN_VERSION = "0.0.1"
+const val MINIMAL_PLUGIN_VERSION = "0.2"
 
 // ============== This methods are used by debugger from IDEA plugin to communicate with Lincheck ============== //
 


### PR DESCRIPTION
The #296 update breaks compatibility with the previous plugin versions, so we need to increase the minimum version