### PR TITLE
Set lincheck version in tests for the plugin compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,7 @@ tasks {
         if (withEventIdSequentialCheck.toBoolean()) {
             extraArgs.add("-Dlincheck.debug.withEventIdSequentialCheck=true")
         }
+        extraArgs.add("-Dlincheck.version=$version")
         jvmArgs(extraArgs)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -479,6 +479,8 @@ internal class ModelCheckingStrategy(
          * We provide lincheck version to [testFailed] method to the plugin be able to
          * determine if this version is compatible with the plugin version.
          */
-        private val lincheckVersion by lazy { this::class.java.`package`.implementationVersion }
+        internal val lincheckVersion by lazy {
+            this::class.java.`package`.implementationVersion ?: System.getProperty("lincheck.version")
+        }
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/LincheckVersionTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/LincheckVersionTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.strategy.modelchecking
+
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingStrategy
+import org.junit.Assert
+import org.junit.Test
+
+class LincheckVersionTest {
+    @Test
+    fun `test version should be accessible at runtime`() {
+        val version = ModelCheckingStrategy.lincheckVersion
+        Assert.assertNotNull(version)
+        Assert.assertTrue(version.matches("\\d+(\\.\\d+)+(-SNAPSHOT)?".toRegex()))
+    }
+}


### PR DESCRIPTION
For the plugin version compatibility check, we must know the lincheck version. This is done with 'implementation version' mark in a jar, but in lincheck tests, class files are taken directly from disc. So, for debugging lincheck tests, we pass a system property that contains the version.