### PR TITLE
Fix Java 11 performance bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,9 +110,9 @@ tasks {
     fun Test.configureJvmTestCommon() {
         maxParallelForks = 1
         maxHeapSize = "6g"
-        val instrumentAllClassesInModelCheckingMode: String by project
-        if (instrumentAllClassesInModelCheckingMode.toBoolean()) {
-            systemProperty("lincheck.instrumentAllClassesInModelCheckingMode", "true")
+        val instrumentAllClasses: String by project
+        if (instrumentAllClasses.toBoolean()) {
+            systemProperty("lincheck.instrumentAllClasses", "true")
         }
         val extraArgs = mutableListOf<String>()
         val withEventIdSequentialCheck: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ lastCopyrightYear=2023
 
 jdkToolchainVersion=17
 runAllTestsInSeparateJVMs=false
-instrumentAllClassesInModelCheckingMode=false
+instrumentAllClasses=false
 withEventIdSequentialCheck=false
 
 kotlinVersion=1.9.21

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -42,8 +42,9 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
      * @throws LincheckAssertionError if the testing data structure is incorrect.
      */
     fun check() {
-        val failure = checkImpl() ?: return
-        throw LincheckAssertionError(failure)
+        checkImpl { failure ->
+            if (failure != null) throw LincheckAssertionError(failure)
+        }
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -28,7 +28,7 @@ internal class LincheckClassVisitor(
     private var classVersion = 0
 
     private var fileName: String = ""
-    private var className: String = ""
+    private var className: String = "" // internal class name
 
     override fun visitField(
         access: Int,
@@ -195,4 +195,7 @@ private class WrapMethodInIgnoredSectionTransformer(
     }
 }
 
+// Set storing canonical names of the classes that call internal coroutine functions;
+// it is used to optimize class re-transformation in stress mode by remembering
+// exactly what classes need to be re-transformed (only the coroutines calling classes)
 internal val coroutineCallingClasses = HashSet<String>()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -18,6 +18,9 @@ import org.objectweb.asm.commons.*
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.*
 import org.jetbrains.kotlinx.lincheck.transformation.transformers.*
 import sun.nio.ch.lincheck.*
+import sun.nio.ch.lincheck.Injections.*
+import java.util.*
+import kotlin.collections.HashSet
 
 internal class LincheckClassVisitor(
     private val instrumentationMode: InstrumentationMode,
@@ -73,7 +76,7 @@ internal class LincheckClassVisitor(
         if (access and ACC_NATIVE != 0) return mv
         if (instrumentationMode == STRESS) {
             return if (methodName != "<clinit>" && methodName != "<init>") {
-                CoroutineCancellabilitySupportTransformer(mv, access, methodName, desc)
+                CoroutineCancellabilitySupportTransformer(mv, access, className, methodName, desc)
             } else {
                 mv
             }
@@ -103,7 +106,7 @@ internal class LincheckClassVisitor(
         }
         mv = JSRInlinerAdapter(mv, access, methodName, desc, signature, exceptions)
         mv = TryCatchBlockSorter(mv, access, methodName, desc, signature, exceptions)
-        mv = CoroutineCancellabilitySupportTransformer(mv, access, methodName, desc)
+        mv = CoroutineCancellabilitySupportTransformer(mv, access, className, methodName, desc)
         if (access and ACC_SYNCHRONIZED != 0) {
             mv = SynchronizedMethodTransformer(fileName, className, methodName, mv.newAdapter(), classVersion)
         }
@@ -193,3 +196,5 @@ private class WrapMethodInIgnoredSectionTransformer(
         visitInsn(opcode)
     }
 }
+
+internal val coroutineCallingClasses = HashSet<String>()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -18,8 +18,6 @@ import org.objectweb.asm.commons.*
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.*
 import org.jetbrains.kotlinx.lincheck.transformation.transformers.*
 import sun.nio.ch.lincheck.*
-import sun.nio.ch.lincheck.Injections.*
-import java.util.*
 import kotlin.collections.HashSet
 
 internal class LincheckClassVisitor(
@@ -29,8 +27,8 @@ internal class LincheckClassVisitor(
     private val ideaPluginEnabled = ideaPluginEnabled()
     private var classVersion = 0
 
-    private lateinit var fileName: String
-    private lateinit var className: String
+    private var fileName: String = ""
+    private var className: String = ""
 
     override fun visitField(
         access: Int,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -354,7 +354,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         internalClassName: String,
         classBytes: ByteArray
     ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
-        nonTransformedClasses.putIfAbsent(internalClassName.canonicalClassName, classBytes.copyOf())
+        nonTransformedClasses.putIfAbsent(internalClassName.canonicalClassName, classBytes)
         val reader = ClassReader(classBytes)
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)
         try {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -83,7 +83,7 @@ internal object LincheckJavaAgent {
     private var isBootstrapJarAddedToClasspath = false
 
     /**
-     * Names of the classes that were instrumented since the last agent installation.
+     * Names (canonical) of the classes that were instrumented since the last agent installation.
      */
     val instrumentedClasses = HashSet<String>()
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -173,7 +173,9 @@ internal object LincheckJavaAgent {
                 // Filter classes that were transformed by Lincheck and should be restored.
                 if (!INSTRUMENT_ALL_CLASSES) {
                     it.name in instrumentedClasses
-                } else true
+                } else {
+                    true
+                }
             }.mapNotNull { clazz ->
                 // For each class, get its original bytecode.
                 val bytes = nonTransformedClasses[clazz.name]

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -315,9 +315,9 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
      * Notice that the transformation depends on the [InstrumentationMode].
      * Additionally, this object caches bytes of non-transformed classes.
      */
-    val transformedClassesModelChecking = ConcurrentHashMap<Any, ByteArray>()
-    val transformedClassesStress = ConcurrentHashMap<Any, ByteArray>()
-    val nonTransformedClasses = ConcurrentHashMap<Any, ByteArray>()
+    val transformedClassesModelChecking = ConcurrentHashMap<String, ByteArray>()
+    val transformedClassesStress = ConcurrentHashMap<String, ByteArray>()
+    val nonTransformedClasses = ConcurrentHashMap<String, ByteArray>()
 
     private val transformedClassesCache
         get() = when (instrumentationMode) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -306,6 +306,11 @@ internal object LincheckJavaAgent {
     /**
      * FOR TEST PURPOSE ONLY!
      * To test the byte-code transformation correctness, we can transform all classes.
+     *
+     * Both stress and model checking modes implement some optimizations
+     * to avoid re-transforming all loaded into VM classes on each run of a Lincheck test.
+     * When this flag is set, these optimizations are disabled, and so
+     * the Lincheck agent re-transforms all the loaded classes on each run.
      */
     internal val INSTRUMENT_ALL_CLASSES =
         System.getProperty("lincheck.instrumentAllClasses")?.toBoolean() ?: false

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -177,7 +177,8 @@ internal object LincheckJavaAgent {
                 } else {
                     true
                 }
-            }.mapNotNull { clazz ->
+            }
+            .mapNotNull { clazz ->
                 // For each class, get its original bytecode.
                 val bytes = nonTransformedClasses[clazz.name]
                 bytes?.let { ClassDefinition(clazz, it) }
@@ -351,7 +352,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         internalClassName: String,
         classBytes: ByteArray
     ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
-        nonTransformedClasses[internalClassName.canonicalClassName] = classBytes
+        nonTransformedClasses.putIfAbsent(internalClassName.canonicalClassName, classBytes.copyOf())
         val reader = ClassReader(classBytes)
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)
         try {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
@@ -28,25 +28,17 @@ internal class CoroutineCancellabilitySupportTransformer(
     desc: String?
 ) : AdviceAdapter(ASM_API, mv, access, methodName, desc) {
 
-    override fun visitMethodInsn(
-        opcodeAndSource: Int,
-        className: String?,
-        methodName: String?,
-        descriptor: String?,
-        isInterface: Boolean
-    ) {
-        val isGetResult = (methodName == "getResult") && (
-            className == "kotlinx/coroutines/CancellableContinuation" ||
-            className == "kotlinx/coroutines/CancellableContinuationImpl"
+    override fun visitMethodInsn(opcode: Int, owner: String, name: String, desc: String, itf: Boolean) {
+        val isGetResult = (name == "getResult") && (
+            owner == "kotlinx/coroutines/CancellableContinuation" ||
+            owner == "kotlinx/coroutines/CancellableContinuationImpl"
         )
         if (isGetResult) {
-            this.className?.canonicalClassName?.let {
-                coroutineCallingClasses += it.canonicalClassName
-            }
             dup()
             invokeStatic(Injections::storeCancellableContinuation)
+            className?.canonicalClassName?.let { coroutineCallingClasses += it }
         }
-        super.visitMethodInsn(opcodeAndSource, className, methodName, descriptor, isInterface)
+        super.visitMethodInsn(opcode, owner, name, desc, itf)
     }
 
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -13,10 +13,9 @@ package org.jetbrains.kotlinx.lincheck.transformation.transformers
 import org.jetbrains.kotlinx.lincheck.transformation.*
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import org.objectweb.asm.Type.VOID_TYPE
-import org.objectweb.asm.commons.GeneratorAdapter
-import sun.nio.ch.lincheck.EventTracker
-import sun.nio.ch.lincheck.Injections
+import org.objectweb.asm.Type.*
+import org.objectweb.asm.commons.*
+import sun.nio.ch.lincheck.*
 
 /**
  * [MethodCallTransformer] tracks method calls,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -11,15 +11,12 @@
 package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
 import org.jetbrains.kotlinx.lincheck.transformation.*
-import org.jetbrains.kotlinx.lincheck.transformation.ManagedStrategyMethodVisitor
-import org.jetbrains.kotlinx.lincheck.transformation.invokeIfInTestingCode
-import org.jetbrains.kotlinx.lincheck.transformation.invokeInIgnoredSection
-import org.jetbrains.kotlinx.lincheck.transformation.storeArguments
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
 import org.objectweb.asm.Type.VOID_TYPE
 import org.objectweb.asm.commons.GeneratorAdapter
-import sun.nio.ch.lincheck.*
+import sun.nio.ch.lincheck.EventTracker
+import sun.nio.ch.lincheck.Injections
 
 /**
  * [MethodCallTransformer] tracks method calls,

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/AbstractLincheckTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/AbstractLincheckTest.kt
@@ -68,4 +68,4 @@ abstract class AbstractLincheckTest(
     }
 }
 
-private const val TIMEOUT = 2 * 60_000L // 2 min
+private const val TIMEOUT = 3 * 60_000L // 3 min

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ClocksWithExceptionsInOutputTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ClocksWithExceptionsInOutputTest.kt
@@ -38,7 +38,8 @@ class ClocksWithExceptionsInOutputTest {
         actorsPerThread(2)
         minimizeFailedScenario(false)
     }
-        .checkImpl(this::class.java)
-        .checkLincheckOutput("clocks_and_exceptions.txt")
+    .checkImpl(this::class.java) { failure ->
+        failure.checkLincheckOutput("clocks_and_exceptions.txt")
+    }
 
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ExceptionsInOutputTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ExceptionsInOutputTest.kt
@@ -35,7 +35,7 @@ class ExceptionsInOutputTest {
     fun `should add stackTrace to output`() = ModelCheckingOptions().apply {
         actorsBefore(2)
     }
-        .checkImpl(this::class.java)
-        .checkLincheckOutput("exceptions_in_output.txt")
-
+        .checkImpl(this::class.java) { failure ->
+            failure.checkLincheckOutput("exceptions_in_output.txt")
+        }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InterleavingAnalysisPresentInSpinCycleFirstIterationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InterleavingAnalysisPresentInSpinCycleFirstIterationTest.kt
@@ -64,6 +64,7 @@ class InterleavingAnalysisPresentInSpinCycleFirstIterationTest {
                 thread { actor(InterleavingAnalysisPresentInSpinCycleFirstIterationTest::spinLock) }
             }
         }
-        .checkImpl(this::class.java)
-        .checkLincheckOutput("switch_in_the_middle_of_spin_cycle_causes_error.txt")
+        .checkImpl(this::class.java) { failure ->
+            failure.checkLincheckOutput("switch_in_the_middle_of_spin_cycle_causes_error.txt")
+        }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InternalLincheckBugTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/InternalLincheckBugTest.kt
@@ -41,6 +41,7 @@ class InternalLincheckBugTest {
     @Test
     fun test() = ModelCheckingOptions()
         .actorsPerThread(2)
-        .checkImpl(this::class.java)
-        .checkLincheckOutput("internal_bug_report.txt")
+        .checkImpl(this::class.java) { failure ->
+            failure.checkLincheckOutput("internal_bug_report.txt")
+        }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/TraceReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/TraceReportingTest.kt
@@ -125,7 +125,7 @@ class TraceReportingTest {
 
     @Test
     fun testEmptyTrace() {
-        val failure = ModelCheckingOptions()
+        ModelCheckingOptions()
             .iterations(0)
             .addCustomScenario {
                 parallel {
@@ -135,8 +135,9 @@ class TraceReportingTest {
                 }
             }
             .sequentialSpecification(EmptySequentialImplementation::class.java)
-            .checkImpl(this::class.java)
-        failure.checkLincheckOutput("trace_reporting_empty.txt")
+            .checkImpl(this::class.java) { failure ->
+                failure.checkLincheckOutput("trace_reporting_empty.txt")
+            }
     }
 
     class EmptySequentialImplementation {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
@@ -64,8 +64,9 @@ class ValidationFunctionCallTest {
             }
         }
     }
-        .checkImpl(this::class.java)
-        .checkLincheckOutput("validation_function_failure.txt")
+    .checkImpl(this::class.java) { failure ->
+        failure.checkLincheckOutput("validation_function_failure.txt")
+    }
 
 }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/RendezvousChannelCustomTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/verifier/linearizability/RendezvousChannelCustomTest.kt
@@ -41,7 +41,7 @@ class RendezvousChannelCustomTest : VerifierState() {
     private val pollFun = RendezvousChannelCustomTest::poll
 
     @Test
-    fun testCancellation_01() = withLincheckJavaAgent(InstrumentationMode.STRESS) {
+    fun testCancellation_01() {
         verify(RendezvousChannelCustomTest::class.java, LinearizabilityVerifier::class.java, {
             parallel {
                 thread {
@@ -55,7 +55,7 @@ class RendezvousChannelCustomTest : VerifierState() {
     }
 
     @Test
-    fun testCancellation_02() = withLincheckJavaAgent(InstrumentationMode.STRESS) {
+    fun testCancellation_02() {
         verify(RendezvousChannelCustomTest::class.java, LinearizabilityVerifier::class.java, {
             parallel {
                 thread {
@@ -69,7 +69,7 @@ class RendezvousChannelCustomTest : VerifierState() {
     }
 
     @Test
-    fun testCancellation_03() = withLincheckJavaAgent(InstrumentationMode.STRESS) {
+    fun testCancellation_03() {
         verify(RendezvousChannelCustomTest::class.java, LinearizabilityVerifier::class.java, {
             parallel {
                 thread {
@@ -83,7 +83,7 @@ class RendezvousChannelCustomTest : VerifierState() {
     }
 
     @Test
-    fun testCancellation_04()  = withLincheckJavaAgent(InstrumentationMode.STRESS){
+    fun testCancellation_04() {
         verify(RendezvousChannelCustomTest::class.java, LinearizabilityVerifier::class.java, {
             parallel {
                 thread {
@@ -97,7 +97,7 @@ class RendezvousChannelCustomTest : VerifierState() {
     }
 
     @Test
-    fun testCancellation_05() = withLincheckJavaAgent(InstrumentationMode.STRESS) {
+    fun testCancellation_05() {
         verify(RendezvousChannelCustomTest::class.java, LinearizabilityVerifier::class.java, {
             parallel {
                 thread {


### PR DESCRIPTION
Closes #308

This PR fixes the performance problem accidentally introduced in #296 , that manifested on our Java 11 CI builds. 
The root cause of the problem and the solution are described below. 

The problem was related to the JVM classes re-transformation, performed by the Java agent. 
For model checking instrumentation mode, the class re-transformation was performed lazily on demand. 
However, for the stress strategy, all the loaded classes were re-transformed eagerly for each Lincheck test.
During a long JVM run (e.g. in case of our CI builds), a lot of classes can be loaded to the JVM, and for each Lincheck test run, the Lincheck JVM agent in the stress model would try to re-transform them.

However, for the stress strategy we actually only need to intercept the suspension points, that is calls to certain internal coroutine methods. The observation is that most of the loaded classes would not contain these calls, so there is no need to constantly re-transform them. 

So the solution, implemented in this PR, is to remember all the loaded classes that actually have coroutine calls inside them, and only re-transform these classes (or newly loaded classes) on subsequent Lincheck agent installations. 


