### PR TITLE
Make it optional for parameter names to match named generators

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
 
         val test by compilations.getting {
             kotlinOptions.jvmTarget = "11"
+            kotlinOptions.options.javaParameters = true
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestStructure.java
@@ -243,12 +243,17 @@ public class CTestStructure {
         Param paramAnn = p.getAnnotation(Param.class);
         // If this annotation not presented use named generator based on name presented in @Operation or parameter name.
         if (paramAnn == null) {
-            // If name in @Operation is presented, return the generator with this name,
-            // otherwise return generator with parameter's name
-            String name = nameInOperation != null ? nameInOperation :
-                (p.isNamePresent() ? p.getName() : null);
-            if (name != null)
-                return checkAndGetNamedGenerator(namedGens, name);
+            // If name in @Operation is presented, return the generator with this name
+            if (nameInOperation != null)
+                return checkAndGetNamedGenerator(namedGens, nameInOperation);
+
+            // Otherwise, if the parameter name matches a named generator, use that one
+            if (p.isNamePresent()) {
+                ParameterGenerator<?> generator = namedGens.get(p.getName());
+                if (generator != null)
+                    return generator;
+            }
+
             // Parameter generator is not specified, try to create a default one
             ParameterGenerator<?> defaultGenerator = defaultGens.get(p.getType());
             if (defaultGenerator != null)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/generator/ParamGeneratorsTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/generator/ParamGeneratorsTests.kt
@@ -89,6 +89,24 @@ class MethodParameterGenerationTestWithSecondParameterAnnotated {
 }
 
 /**
+ *  Test checks that a named generator matching a parameter name is applied.
+ *
+ *  This relies on the parameter name being available (i.e. by being compiled with `-java-parameters`).
+ */
+@Param(name = "key", gen = IntGen::class, conf = "0:10")
+class MethodParameterGenerationTestWithParameterNameMatchingGenerator {
+    @Operation
+    fun operation(key: Int) {
+        if (key < 0 || key > 10) {
+            throw InternalLincheckTestUnexpectedException
+        }
+    }
+
+    @Test
+    fun test() = ModelCheckingOptions().check(this::class)
+}
+
+/**
  *  Test checks that method with both parameters of the same type won't receive same values all the time
  */
 class MethodParameterGenerationTest {


### PR DESCRIPTION
Previously, if parameter names were enabled at compile-time, all parameters were required to match a named generator. This made including parameter names and using Lincheck with languages always enabling parameter names, like Scala, impractical. This PR:

- Enables `javaParameters` when compiling tests in order to include parameter names - this makes all tests fail
- Makes matching parameter names optional, such that tests work again
- Adds a test that matching named generators on parameter names works