### PR TITLE
Avoid recursive enumeration of class and classloader instances when plugin is enabled

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/ObjectTraverser.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/ObjectTraverser.kt
@@ -52,6 +52,7 @@ internal fun enumerateObjects(obj: Any): Map<Any, Int> {
  * @param objectNumberMap result enumeration map
  */
 private fun enumerateObjects(obj: Any, processedObjects: MutableSet<Any>, objectNumberMap: MutableMap<Any, Int>) {
+    if (obj is Class<*> || obj is ClassLoader) return
     if (!processedObjects.add(obj)) return
     val objectNumber = getObjectNumber(obj.javaClass, obj)
     objectNumberMap[obj] = objectNumber

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/ObjectTraverserTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/ObjectTraverserTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck
+
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Checks invariants and restrictions on [enumerateObjects] method.
+ */
+class ObjectTraverserTest {
+
+    @Test
+    fun `should not traverse class and classLoader recursively while enumerating objects`() {
+        val myObject = @Suppress("unused") object : Any() {
+            var clazz: Class<*>? = this::class.java
+            var classLoader: ClassLoader? = this::class.java.classLoader
+            var integer: Int = 10
+        }
+        val objectEnumeration = enumerateObjects(myObject)
+
+        Assert.assertTrue(objectEnumeration.keys.none { it is Class<*> || it is ClassLoader })
+    }
+
+}


### PR DESCRIPTION
Closes #363 