### PR TITLE
Use `ClassReader.EXPAND_FRAMES` as dictated by the `AnalyzerAdapter` documentation

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -359,8 +359,9 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
     ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
         val reader = ClassReader(classBytes)
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)
+        val visitor = LincheckClassVisitor(instrumentationMode, writer)
         try {
-            reader.accept(LincheckClassVisitor(instrumentationMode, writer), ClassReader.SKIP_FRAMES)
+            reader.accept(visitor, ClassReader.EXPAND_FRAMES)
             writer.toByteArray()
         } catch (e: Throwable) {
             System.err.println("Unable to transform $internalClassName")


### PR DESCRIPTION
In `LincheckJavaAgent`, use `ClassReader.EXPAND_FRAMES` as dictated by the `AnalyzerAdapter` documentation:

> public class **AnalyzerAdapter**
extends [MethodVisitor](https://asm.ow2.io/javadoc/org/objectweb/asm/MethodVisitor.html)

> A [MethodVisitor](https://asm.ow2.io/javadoc/org/objectweb/asm/MethodVisitor.html) that keeps track of stack map frame changes between [visitFrame(int, int, Object[], int, Object[])](https://asm.ow2.io/javadoc/org/objectweb/asm/commons/AnalyzerAdapter.html#visitFrame(int,int,java.lang.Object%5B%5D,int,java.lang.Object%5B%5D)) calls. This adapter must be used with the [ClassReader.EXPAND_FRAMES](https://asm.ow2.io/javadoc/org/objectweb/asm/ClassReader.html#EXPAND_FRAMES) option.

https://asm.ow2.io/javadoc/org/objectweb/asm/commons/AnalyzerAdapter.html