### PR TITLE
Prevent IllegalArgumentException

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -625,7 +625,7 @@ private class TraceNodePrefixFactory(nThreads: Int) {
             val arrowDepth = arrowDepth
             return PrefixProvider {
                 val extraPrefix = if (arrowDepth == 1) 0 else extraPrefixLength(iThread)
-                TRACE_INDENTATION.repeat(max(0, arrowDepth - 2 + extraPrefix)) + "| " + TRACE_INDENTATION.repeat(callDepth - arrowDepth + 1)
+                TRACE_INDENTATION.repeat(max(0, arrowDepth - 2 + extraPrefix)) + "| " + TRACE_INDENTATION.repeat(max(0, callDepth - arrowDepth + 1))
             }
         }
         return PrefixProvider { extraPrefixIfNeeded(iThread) + TRACE_INDENTATION.repeat(callDepth) }


### PR DESCRIPTION
When running my tests I get this error:

```
java.lang.IllegalArgumentException: Count 'n' must be non-negative, but was -5.

	at kotlin.text.StringsKt__StringsJVMKt.repeat(StringsJVM.kt:775)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceNodePrefixFactory.prefixForNode$lambda$5(TraceReporter.kt:628)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceNode.getPrefix(TraceReporter.kt:354)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceLeafEvent.addRepresentationTo(TraceReporter.kt:415)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceReporterKt.traceGraphToRepresentationList(TraceReporter.kt:343)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceReporterKt.appendShortTrace(TraceReporter.kt:43)
	at org.jetbrains.kotlinx.lincheck.strategy.managed.TraceReporterKt.appendTrace(TraceReporter.kt:31)
	at org.jetbrains.kotlinx.lincheck.ReporterKt.appendFailure(Reporter.kt:392)
	at org.jetbrains.kotlinx.lincheck.strategy.LincheckFailure.toString(LincheckFailure.kt:22)
	at java.base/java.lang.StringConcatHelper.stringOf(StringConcatHelper.java:467)
	at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:422)
	at org.jetbrains.kotlinx.lincheck.LincheckAssertionError.<init>(LincheckAssertionError.kt:17)
	at org.jetbrains.kotlinx.lincheck.LinChecker$check$1.invoke(LinChecker.kt:48)
	at org.jetbrains.kotlinx.lincheck.LinChecker$check$1.invoke(LinChecker.kt:47)
	at org.jetbrains.kotlinx.lincheck.LinChecker.checkImpl$lincheck(LinChecker.kt:67)
	at org.jetbrains.kotlinx.lincheck.LinChecker.check(LinChecker.kt:47)
	at org.jetbrains.kotlinx.lincheck.LinChecker$Companion.check(LinChecker.kt:195)
	at org.jetbrains.kotlinx.lincheck.LinChecker.check(LinChecker.kt)
```