### PR TITLE
Fix local objects detector

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/ObjectTraverser.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/ObjectTraverser.kt
@@ -101,11 +101,7 @@ private fun enumerateObjects(obj: Any, objectNumberMap: MutableMap<Any, Int>) {
             }
         },
         onField = { _, f, value ->
-            if (
-                Modifier.isStatic(f.modifiers) ||
-                f.isEnumConstant ||
-                f.name == "serialVersionUID"
-            ) {
+            if (f.isEnumConstant || f.name == "serialVersionUID") {
                 null
             }
             else {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/FieldSearchHelper.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/FieldSearchHelper.kt
@@ -56,6 +56,7 @@ internal object FieldSearchHelper {
 
         traverseObjectGraph(
             testObject,
+            traverseStaticFields = true,
             onArrayElement = { _, _, _ -> null }, // do not traverse array elements further
             onField = { ownerObject, field, fieldValue ->
                 when {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -580,7 +580,7 @@ internal class LocalObjectManager : ObjectTracker {
      * Checks if an object is only locally accessible.
      */
     private fun isLocalObject(obj: Any?) =
-        obj === StaticObject || localObjects.contains(obj)
+        localObjects.contains(obj)
 
     override fun reset() {
         localObjects.clear()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -569,8 +569,11 @@ internal class LocalObjectManager : ObjectTracker {
     /**
      * Removes the specified local object and all reachable objects from the set of local objects.
      */
-    private fun markObjectNonLocal(obj: Any) {
-        traverseObjectGraph(obj) { localObjects.remove(it) }
+    private fun markObjectNonLocal(root: Any) {
+        traverseObjectGraph(root) { obj ->
+            val wasLocal = localObjects.remove(obj)
+            if (wasLocal) obj else null
+        }
     }
 
     override fun shouldTrackObjectAccess(obj: Any): Boolean =

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
@@ -99,6 +99,7 @@ internal inline fun traverseObjectGraph(
  * @param traverseStaticFields if true, then all static fields are also traversed,
  *   otherwise only non-static fields are traversed.
  * @param onObject callback that is invoked for each object in the graph.
+ *   Should return the next object to traverse, may return null to prune further traversal.
  *
  * @see traverseObjectGraph
  */

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
@@ -87,6 +87,23 @@ internal inline fun traverseObjectGraph(
 }
 
 /**
+ * Traverses a subgraph of objects reachable from a given root object in BFS order,
+ * and applies a callback on each visited object.
+ *
+ * @param root the starting object for the traversal.
+ * @param onObject callback that is invoked for each object in the graph.
+ *
+ * @see traverseObjectGraph
+ */
+internal inline fun traverseObjectGraph(root: Any, onObject: (obj: Any) -> Unit) {
+    onObject(root)
+    traverseObjectGraph(root,
+        onField = { _, _, fieldValue -> fieldValue?.also { onObject(it) } },
+        onArrayElement = { _, _, arrayElement -> arrayElement?.also { onObject(it) } }
+    )
+}
+
+/**
  * Traverses [array] elements if it is a pure array, java atomic array, or atomicfu array, otherwise no-op.
  *
  * @param array array which elements to traverse.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ObjectGraph.kt
@@ -105,12 +105,12 @@ internal inline fun traverseObjectGraph(
 internal inline fun traverseObjectGraph(
     root: Any,
     traverseStaticFields: Boolean = false,
-    onObject: (obj: Any) -> Unit
+    onObject: (obj: Any) -> Any?
 ) {
-    onObject(root)
-    traverseObjectGraph(root,
-        onField = { _, _, fieldValue -> fieldValue?.also { onObject(it) } },
-        onArrayElement = { _, _, arrayElement -> arrayElement?.also { onObject(it) } },
+    val obj = onObject(root) ?: return
+    traverseObjectGraph(obj,
+        onField = { _, _, fieldValue -> fieldValue?.let(onObject) },
+        onArrayElement = { _, _, arrayElement -> arrayElement?.let(onObject) },
         traverseStaticFields = traverseStaticFields,
     )
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
@@ -89,8 +89,7 @@ class LocalObjectEscapeConstructorTest {
          * and thus should insert switch points before accesses to this object's fields,
          * because the `localB` object escapes its thread as it is referenced by the escaped object `localA`
          */
-        if (localB.i != 0)
-            throw LocalEscapedException()
+        if (localB.i != 0) throw LocalEscapedException()
     }
 
     @Operation

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
@@ -9,11 +9,12 @@
  */
 package org.jetbrains.kotlinx.lincheck_test.transformation
 
-import org.jetbrains.kotlinx.lincheck.LinChecker
-import org.jetbrains.kotlinx.lincheck.annotations.Operation
-import org.jetbrains.kotlinx.lincheck.check
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingCTest
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.execution.parallelResults
 import org.junit.Test
 import sun.misc.Unsafe
 import java.lang.invoke.MethodHandles
@@ -62,6 +63,62 @@ class LocalObjectEliminationTest {
     private data class A(var value: Int, var any: Any, val array: IntArray)
 }
 
+class LocalObjectEscapeConstructorTest {
+
+    private class A(var b: B)
+
+    private class B(var i: Int)
+
+    private class LocalEscapedException : Exception()
+
+    @Volatile
+    private var a: A? = null
+
+    @Operation
+    fun escapeLocal() {
+        val localB = B(0)
+        val localA = A(localB)
+        /* if we uncomment this line, then there is an explicit write
+         * of `localB` into `localA` field that the model checker will detect;
+         * however, the model checker still should detect object escaping even without explicit write,
+         * because `localB` is assigned to `localA` field in the constructor
+         */
+        // localA.b = localB
+        a = localA
+        /* the model checker should not treat `localB` as a local object
+         * and thus should insert switch points before accesses to this object's fields,
+         * because the `localB` object escapes its thread as it is referenced by the escaped object `localA`
+         */
+        if (localB.i != 0)
+            throw LocalEscapedException()
+    }
+
+    @Operation
+    fun changeState() {
+        val b = a?.b ?: return
+        b.i = 1
+    }
+
+    @Test
+    fun test() {
+        val failure = ModelCheckingOptions()
+            .iterations(0) // we will run only custom scenarios
+            .addCustomScenario {
+                parallel {
+                    thread { actor(::escapeLocal) }
+                    thread { actor(::changeState) }
+                }
+            }
+            .checkImpl(this::class.java)
+        // the test should fail
+        check(failure is IncorrectResultsFailure)
+        // `escapeLocal` function should throw `LocalEscapedException`
+        val result = failure.results.parallelResults[0][0]
+        check(result is ExceptionResult)
+        check(result.throwable is LocalEscapedException)
+    }
+
+}
 
 /**
  * This test checks that despite some object isn't explicitly assigned to some shared value,


### PR DESCRIPTION
This PR changes our approach to the local objects tracking. 

Current approach maintains a map `LocalObject -> List<LocalObject>` , which for each local object stores a list of objects immediately reachable from it (via its fields). This map is used to compute a set of local objects reachable from another given local object. Once a local object is assigned to a field of non-local object, all reachable objects are marked as non-local. 

The problem with this approach is that it is error prone and requires a lot of efforts to maintain the map in the correct state. If the map is not maintained in the correct state, some objects might be incorrectly classified as local (see new test added in this PR). 

So instead, in this PR we implement an alternative approach. We still maintain a *set* of local objects, however when we need to compute a set of objects reachable from given one, we instead traverse the object graph using the utility function. 
Thus there is no need to maintain a separate data structure approximating reachable objects.

This PR also should help with #415 , as it would be much more easier to just traverse all objects reachable from the given `Thread` objects once it starts, and mark them as non-local. 

Note this PR depends on PR #420 , so we first need to merge it, and then rebase. 