### PR TITLE
Fix of `NoClassDefFoundError` due to unintended Lincheck analysis of `StackTraceElement` methods

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -89,6 +89,9 @@ internal class LincheckClassVisitor(
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
+        if (isStackTraceElement(className)) {
+            return mv
+        }
         if (methodName == "<init>") {
             mv = ObjectCreationTransformer(fileName, className, methodName, mv.newAdapter())
             return mv

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -89,9 +89,6 @@ internal class LincheckClassVisitor(
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
-        if (isStackTraceElement(className)) {
-            return mv
-        }
         if (methodName == "<init>") {
             mv = ObjectCreationTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
@@ -100,6 +97,10 @@ internal class LincheckClassVisitor(
             if (methodName == "loadClass") {
                 mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             }
+            return mv
+        }
+        if (isStackTraceElement(className)) {
+            mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
         if (isCoroutineInternalClass(className)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -114,7 +114,7 @@ internal class LincheckClassVisitor(
          *   - https://github.com/JetBrains/lincheck/issues/376
          *   - https://github.com/JetBrains/lincheck/issues/419
          */
-        if (containsStackTraceElementInName(className)) {
+        if (isStackTraceElementClass(className.canonicalClassName)) {
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -452,5 +452,5 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         // ClassLoader classes, to wrap `loadClass` methods in the ignored section.
         containsClassloaderInName(className) ||
         // StackTraceElement class, to wrap all its methods into the ignored section.
-        containsStackTraceElementInName(className)
+        isStackTraceElementClass(className)
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -349,7 +349,11 @@ internal val CLASS_TYPE = getType(Class::class.java)
 internal val CLASS_FOR_NAME_METHOD = Method("forName", CLASS_TYPE, arrayOf(STRING_TYPE))
 
 /**
- * Tests if the provided [className] contains `"ClassLoader"` as a substring
+ * Tests if the provided [className] contains `"ClassLoader"` as a substring.
  */
 internal fun containsClassloaderInName(className: String): Boolean = className.contains("ClassLoader")
-internal fun isStackTraceElement(className: String): Boolean = className.contains("StackTraceElement")
+
+/**
+ * Tests if the provided [className] contains `"StackTraceElement"` as a substring.
+ */
+internal fun containsStackTraceElementInName(className: String): Boolean = className.contains("StackTraceElement")

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -351,9 +351,11 @@ internal val CLASS_FOR_NAME_METHOD = Method("forName", CLASS_TYPE, arrayOf(STRIN
 /**
  * Tests if the provided [className] contains `"ClassLoader"` as a substring.
  */
-internal fun containsClassloaderInName(className: String): Boolean = className.contains("ClassLoader")
+internal fun containsClassloaderInName(className: String): Boolean =
+    className.contains("ClassLoader")
 
 /**
  * Tests if the provided [className] contains `"StackTraceElement"` as a substring.
  */
-internal fun containsStackTraceElementInName(className: String): Boolean = className.contains("StackTraceElement")
+internal fun isStackTraceElementClass(className: String): Boolean =
+    className == "java.lang.StackTraceElement"

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -352,3 +352,4 @@ internal val CLASS_FOR_NAME_METHOD = Method("forName", CLASS_TYPE, arrayOf(STRIN
  * Tests if the provided [className] contains `"ClassLoader"` as a substring
  */
 internal fun containsClassloaderInName(className: String): Boolean = className.contains("ClassLoader")
+internal fun isStackTraceElement(className: String): Boolean = className.contains("StackTraceElement")


### PR DESCRIPTION
This PR fixes issue #376 

It implements a quick bug fix specifically for #376, but does not completely solve the root problem described in #419. 
This problem in general is more ubiquitous, requires more complicated changes, and thus would be addressed by a separate PR.

The fix implemented in this PR wraps all methods from `java.lang.StackTraceElement` class into ignored sections. 
This is required due to a combination of two reasons:
1)  `StackTraceElement` own bytecode is not analyzed, but it can call methods from `java.util` (e.g., `HashMap`), which are analyzed by the Lincheck. 
2)  `StackTraceElement` methods can be called almost from any point during execution (e.g., they are called when an exeption is thrown and its stack trace is being collected). 

Thus, in order to ensure that `StackTraceElement` code is not analyzed by the Lincheck, we need to wrap its methods into an ignored section. 