### PR TITLE
Fix object creation tracking

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ObjectCreationTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ObjectCreationTransformer.kt
@@ -54,6 +54,9 @@ internal class ObjectCreationTransformer(
      * Whenever we encounter a constructor call (i.e., `<init>`) we check for the counter
      * and inject the object creation tracking method if the counter is not null.
      *
+     * The solution with allocated objects counter is inspired by:
+     * https://github.com/google/allocation-instrumenter
+     *
      * TODO: keeping just a counter might be not reliable in some cases,
      *   perhaps we need more robust solution, checking for particular bytecode instructions sequence, e.g.:
      *   `NEW; DUP; INVOKESPECIAL <init>`

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/LocalObjectsTests.kt
@@ -50,6 +50,18 @@ class LocalObjectEliminationTest {
             b.array[0] = it
         }
         a.any = b
+        // check that closure object and captured `x: IntRef` object
+        // are correctly classified as local objects;
+        // note that these classes itself are not instrumented,
+        // but the creation of their instances still should be tracked
+        var x = 0
+        val closure = {
+            a.value += 1
+            x += 1
+        }
+        repeat(20) {
+            closure()
+        }
         return (a.any as A).array.sum()
     }
 


### PR DESCRIPTION
Before this PR, `ObjectCreationTransformer` injected `Injections::afterNewObjectCreation` only on the objects on which `Object::<init>` constructor was called. However, if the instrumented code created a new instance of some `Derived` class, such that its `Base` class is not instrumented, then no `Object::<init>` constructor call would be tracked by the current algorithm (since only `Derived::<init>` will be called from the instrumented code).
    
To fix this issue, we now track any `::<init>` constructor call, and keep a counter of uninitialized objects to distinguish between actual constructor calls, and the calls of the base class constructor from the derived class constructor.
