### PR TITLE
Identity hash code substitution

### DIFF
--- a/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
@@ -32,7 +32,7 @@ public interface EventTracker {
     void beforeNewObjectCreation(String className);
     void afterNewObjectCreation(Object obj);
     long getNextObjectId();
-    void advanceCurrentObjectIdWithKnownOldObjectId(long oldId);
+    void advanceCurrentObjectId(long oldId);
 
     boolean beforeReadField(Object obj, String className, String fieldName, int codeLocation,
                             boolean isStatic, boolean isFinal);

--- a/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
@@ -31,6 +31,8 @@ public interface EventTracker {
 
     void beforeNewObjectCreation(String className);
     void afterNewObjectCreation(Object obj);
+    long getNextObjectId();
+    void advanceCurrentObjectIdWithKnownOldObjectId(long oldId);
 
     boolean beforeReadField(Object obj, String className, String fieldName, int codeLocation,
                             boolean isStatic, boolean isFinal);

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -305,6 +305,24 @@ public class Injections {
     }
 
     /**
+     * Retrieves the next object id, used for identity hash code substitution, and then advances it by one.
+     */
+    public static long getNextObjectId() {
+        return getEventTracker().getNextObjectId();
+    }
+
+    /**
+     * Ensures that for the same old id, previously received with {@code getNextObjectId},
+     * the counter after calling the function persists.
+     * <p> 
+     * If for given {@code oldId} there is no saved {@code newId}, the function saves the current value.
+     * If for given {@code oldId} there is a saved {@code newId}, the function sets the counter to the {@code newId}.
+     */
+    public static void advanceCurrentObjectIdWithKnownOldObjectId(long oldId) {
+        getEventTracker().advanceCurrentObjectIdWithKnownOldObjectId(oldId);
+    }
+
+    /**
      * Called from the instrumented code to replace [java.lang.Object.hashCode] method call with some
      * deterministic value.
      */

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -312,14 +312,30 @@ public class Injections {
     }
 
     /**
-     * Ensures that for the same old id, previously received with {@code getNextObjectId},
-     * the counter after calling the function persists.
-     * <p> 
-     * If for given {@code oldId} there is no saved {@code newId}, the function saves the current value.
-     * If for given {@code oldId} there is a saved {@code newId}, the function sets the counter to the {@code newId}.
+     * Advances the current object id with the delta, associated with the old id {@code oldId},
+     * previously received with {@code getNextObjectId}.
+     * <p>
+     * If for the given {@code oldId} there is no saved {@code newId},
+     * the function saves the current object id and associates it with the {@code oldId}.
+     * On subsequent re-runs, when for the given {@code oldId} there exists a saved {@code newId},
+     * the function sets the counter to the {@code newId}.
+     * <p>
+     * This function is typically used to account for some cached computations:
+     * on the first run the actual computation is performed and its result is cached,
+     * and on subsequent runs the cached value is re-used.
+     * One example of such a situation is the {@code invokedynamic} instruction.
+     * <p>
+     * In such cases, on the first run, the performed computation may allocate more objects,
+     * assigning more object ids to them.
+     * On subsequent runs, however, these objects will not be allocated, and thus the object ids numbering may vary.
+     * To account for this, before the first invocation of the cached computation,
+     * the last allocated object id {@code oldId} can be saved, and after the computation,
+     * the new last object id can be associated with it via a call {@code advanceCurrentObjectId(oldId)}.
+     * On subsequent re-runs, the cached computation will be skipped, but the
+     * current object id will still be advanced by the required delta via a call to {@code advanceCurrentObjectId(oldId)}.
      */
-    public static void advanceCurrentObjectIdWithKnownOldObjectId(long oldId) {
-        getEventTracker().advanceCurrentObjectIdWithKnownOldObjectId(oldId);
+    public static void advanceCurrentObjectId(long oldId) {
+        getEventTracker().advanceCurrentObjectId(oldId);
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -72,7 +72,7 @@ abstract class ManagedStrategy(
     protected val currentActorId = IntArray(nThreads)
 
     // Tracker of objects' identity hash codes.
-    internal abstract val identityHashCodeTracker: ObjectInitialHashCodes
+    internal abstract val identityHashCodeTracker: ObjectIdentityHashCodeTracker
     // Tracker of the monitors' operations.
     protected abstract val monitorTracker: MonitorTracker
     // Tracker of the thread parking.
@@ -797,8 +797,8 @@ abstract class ManagedStrategy(
         LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
     }
 
-    override fun advanceCurrentObjectIdWithKnownOldObjectId(oldId: Long) {
-        identityHashCodeTracker.advanceCurrentObjectIdWithKnownOldObjectId(oldId)
+    override fun advanceCurrentObjectId(oldId: Long) {
+        identityHashCodeTracker.advanceCurrentObjectId(oldId)
     }
 
     override fun getNextObjectId(): Long = identityHashCodeTracker.getNextObjectId()
@@ -806,7 +806,7 @@ abstract class ManagedStrategy(
     override fun afterNewObjectCreation(obj: Any) {
         if (obj is String || obj is Int || obj is Long || obj is Byte || obj is Char || obj is Float || obj is Double) return
         runInIgnoredSection {
-            identityHashCodeTracker.onNewTrackedObjectCreation(obj)
+            identityHashCodeTracker.afterNewTrackedObjectCreation(obj)
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectInitialHashCodes.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectInitialHashCodes.kt
@@ -1,0 +1,90 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.strategy.managed
+
+import org.jetbrains.kotlinx.lincheck.util.UnsafeHolder
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+
+private typealias Id = Long
+
+/**
+ * This class stores initial identity hashcodes of created objects.
+ * When the program is rerun the firstly calculated hashcodes are left as is and used to
+ * substitute new hashcodes via [sun.misc.Unsafe] in the object headers.
+ *
+ * To guarantee correct work, ensure that replays are deterministic.
+ */
+internal class ObjectInitialHashCodes {
+    companion object {
+        /**
+         * Offset (in bytes) of identity hashcode in an object header.
+         *
+         * @see <a href="https://shipilev.net/jvm/anatomy-quarks/26-identity-hash-code/#_hashcode_storage">JVM Anatomy Quark #26: Identity Hash Code</a>
+         */
+        private const val IDENTITY_HASHCODE_OFFSET: Long = 1L
+    }
+    private val initialHashCodes = ConcurrentHashMap<Id, Int>()
+    private val nextObjectId = AtomicLong(0)
+    private val objectIdAdvances = ConcurrentHashMap<Id, Id>()
+
+    /**
+     * This method substitutes identity hash code of the object in its header with the initial (from the first test execution) identity hashcode.
+     * @return id of the created object.
+     */
+    @OptIn(ExperimentalStdlibApi::class)
+    fun onNewTrackedObjectCreation(obj: Any): Id {
+        val currentObjectId = getNextObjectId()
+        val initialIdentityHashCode = getInitialIdentityHashCode(
+            currentObjectId,
+            System.identityHashCode(obj)
+        )
+        // TODO: bizarre and crazy code below (might not work for all JVM implementations)
+        UnsafeHolder.UNSAFE.putInt(obj, IDENTITY_HASHCODE_OFFSET, initialIdentityHashCode)
+
+        return currentObjectId
+    }
+
+    /**
+     * Resets ids numeration and starts them from 0.
+     */
+    fun resetObjectIds() {
+        nextObjectId.set(0)
+    }
+
+    /**
+     * Ensures that for the same old id, previously received with {@code getNextObjectId},
+     * the counter after calling the function persists.
+     * <p>
+     * If for given {@code oldId} there is no saved {@code newId}, the function saves the current value.
+     * If for given {@code oldId} there is a saved {@code newId}, the function sets the counter to the {@code newId}.
+     */
+    fun advanceCurrentObjectIdWithKnownOldObjectId(oldObjectId: Id) {
+        val newObjectId = nextObjectId.get()
+        val existingAdvance = objectIdAdvances.putIfAbsent(oldObjectId, newObjectId)
+        if (existingAdvance != null) {
+            nextObjectId.set(existingAdvance)
+        }
+    }
+
+    /**
+     * @return id of current object and increments the global counter.
+     */
+    fun getNextObjectId(): Id = nextObjectId.getAndIncrement()
+
+    /**
+     * @return initial identity hashcode for object with specified [objectId].
+     * If this is first time function is called for this object, then provided [identityHashCode] is treated as initial.
+     */
+    private fun getInitialIdentityHashCode(objectId: Id, identityHashCode: Int): Int =
+        initialHashCodes.getOrPut(objectId) { identityHashCode }
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -53,6 +53,8 @@ internal class ModelCheckingStrategy(
     // The interleaving that will be studied on the next invocation.
     private lateinit var currentInterleaving: Interleaving
 
+    // Tracker of objects' identity hash codes.
+    override val identityHashCodeTracker: ObjectInitialHashCodes = ObjectInitialHashCodes()
     // Tracker of the monitors' operations.
     override val monitorTracker: MonitorTracker = ModelCheckingMonitorTracker(nThreads)
     // Tracker of the thread parking.
@@ -61,6 +63,7 @@ internal class ModelCheckingStrategy(
     override fun nextInvocation(): Boolean {
         currentInterleaving = root.nextInterleaving()
             ?: return false
+        identityHashCodeTracker.resetObjectIds()
         return true
     }
 
@@ -133,6 +136,7 @@ internal class ModelCheckingStrategy(
 
     private fun doReplay(): InvocationResult {
         cleanObjectNumeration()
+        identityHashCodeTracker.resetObjectIds()
         currentInterleaving = currentInterleaving.copy()
         resetEventIdProvider()
         return runInvocation()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -54,7 +54,7 @@ internal class ModelCheckingStrategy(
     private lateinit var currentInterleaving: Interleaving
 
     // Tracker of objects' identity hash codes.
-    override val identityHashCodeTracker: ObjectInitialHashCodes = ObjectInitialHashCodes()
+    override val identityHashCodeTracker: ObjectIdentityHashCodeTracker = ObjectIdentityHashCodeTracker()
     // Tracker of the monitors' operations.
     override val monitorTracker: MonitorTracker = ModelCheckingMonitorTracker(nThreads)
     // Tracker of the thread parking.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -159,6 +159,50 @@ internal fun GeneratorAdapter.storeArguments(methodDescriptor: String): IntArray
 }
 
 /**
+ * Executes a try-catch-finally block within the context of the GeneratorAdapter.
+ * 
+ * Attention: this method does not insert `finally` blocks before return statements.
+ *
+ * @param tryBlock The code block to be executed in the try section.
+ * @param exceptionType The type of exception to be caught in the catch section, or null to catch all exceptions.
+ * @param catchBlock The code block to be executed in the catch section if an exception is thrown. By default, it re-throws the exception.
+ * @param finallyBlock The code block to be executed in the finally section. This is optional.
+ */
+internal fun GeneratorAdapter.tryCatchFinally(
+    tryBlock: GeneratorAdapter.() -> Unit,
+    exceptionType: Type? = null,
+    catchBlock: GeneratorAdapter.() -> Unit = { throwException() },
+    finallyBlock: (GeneratorAdapter.() -> Unit)? = null,
+) {
+    val startTryBlockLabel = newLabel()
+    val endTryBlockLabel = newLabel()
+    val exceptionHandlerLabel = newLabel()
+    val endLabel = newLabel()
+    visitTryCatchBlock(
+        startTryBlockLabel,
+        endTryBlockLabel,
+        exceptionHandlerLabel,
+        exceptionType?.internalName
+    )
+    visitLabel(startTryBlockLabel)
+    tryBlock()
+    visitLabel(endTryBlockLabel)
+    if (finallyBlock != null) finallyBlock()
+    goTo(endLabel)
+    visitLabel(exceptionHandlerLabel)
+    if (finallyBlock != null) {
+        val exception = newLocal(exceptionType ?: getType(Throwable::class.java))
+        storeLocal(exception)
+        finallyBlock()
+        loadLocal(exception)
+        catchBlock()
+    } else {
+        catchBlock()
+    }
+    visitLabel(endLabel)
+}
+
+/**
  * Copies arguments of the method in the local variables.
  *
  * Before execution:

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InvokeDynamicTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InvokeDynamicTransformer.kt
@@ -1,0 +1,143 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.transformation.transformers
+
+import org.jetbrains.kotlinx.lincheck.transformation.*
+import org.objectweb.asm.Handle
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.commons.GeneratorAdapter
+import org.objectweb.asm.commons.Method
+import sun.nio.ch.lincheck.Injections
+import java.lang.invoke.CallSite
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+
+
+internal class InvokeDynamicTransformer(
+    fileName: String,
+    className: String,
+    methodName: String,
+    adapter: GeneratorAdapter
+) : ManagedStrategyMethodVisitor(fileName, className, methodName, adapter) {
+    override fun visitInvokeDynamicInsn(
+        name: String,
+        descriptor: String,
+        bootstrapMethodHandle: Handle,
+        vararg bootstrapMethodArguments: Any?
+    ) = adapter.run {
+        invokeIfInTestingCode(
+            original = { visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, *bootstrapMethodArguments) },
+        ) {
+            val arguments = storeArguments(descriptor)
+            
+            // InvokeDynamic execution consists of the following steps:
+            // 1. Calling bootstrap method, which creates the actual function to call later;
+            // 2. Caching it by JVM;
+            // 3. Calling it by JVM.
+            // On the subsequent runs, JVM uses cached function.
+            
+            // The current implementation performs these steps manually each time.
+            // Once native calls are supported, it would be possible to cache `MethodHandle`s creation.
+            
+            // Bootstrap method is a function, which creates the actual call-site.
+            // Its first three parameters are predefined and are supplied by JVM when it invokes `invokedynamic`.
+            // After those parameters, there are regular parameters.
+            // Also, there can be `vararg` parameters.
+            
+            // (predefined, predefined, predefined, regular, regular, [Ljava/lang/Object; <- is vararg)
+            // vararg parameter might exist or not
+            
+            // https://openjdk.org/jeps/309
+            // https://www.infoq.com/articles/Invokedynamic-Javas-secret-weapon/
+            // https://www.baeldung.com/java-string-concatenation-invoke-dynamic
+            
+            val bootstrapMethodParameterTypes = Type.getArgumentTypes(bootstrapMethodHandle.desc)
+            require(bootstrapMethodParameterTypes[0] == Type.getType(MethodHandles.Lookup::class.java))
+            require(bootstrapMethodParameterTypes[1] == Type.getType(String::class.java))
+            require(bootstrapMethodParameterTypes[2] == Type.getType(MethodType::class.java))
+            
+            // pushing predefined arguments manually
+            invokeStatic(MethodHandles::lookup)
+            visitLdcInsn(name)
+            visitLdcInsn(Type.getMethodType(descriptor))
+            val jvmPredefinedParametersCount = 3
+            
+            val isMethodWithVarArgs = isMethodVarArgs(bootstrapMethodHandle)
+            val notVarargsArgumentsCount = bootstrapMethodParameterTypes.size - jvmPredefinedParametersCount - (if (isMethodWithVarArgs) 1 else 0)
+            val varargsArgumentsCount = bootstrapMethodArguments.size - notVarargsArgumentsCount
+            // adding regular arguments
+            for (arg in bootstrapMethodArguments.take(notVarargsArgumentsCount)) {
+                visitLdcInsn(arg)
+            }
+            // adding vararg
+            if (isMethodWithVarArgs) {
+                val varargArguments = bootstrapMethodArguments.takeLast(varargsArgumentsCount)
+                visitLdcInsn(varargsArgumentsCount)
+                // [Ljava/lang/Object; -> Ljava/lang/Object;, [[Ljava/lang/Object; -> [Ljava/lang/Object;
+                val arrayElementType = bootstrapMethodParameterTypes.last().descriptor.drop(1).let(Type::getType)
+                newArray(arrayElementType)
+                for ((i, arg) in varargArguments.withIndex()) {
+                    dup()
+                    visitLdcInsn(i)
+                    visitLdcInsn(arg)
+                    if (arg != null && arrayElementType.sort == Type.OBJECT) {
+                        box(Type.getType(arg.javaClass))
+                    }
+                    arrayStore(arrayElementType)
+                }
+            }
+            
+            // creating java.lang.invoke.MethodHandle manually
+            invokeInIgnoredSection {
+                visitMethodInsn(
+                    Opcodes.INVOKESTATIC,
+                    bootstrapMethodHandle.owner,
+                    bootstrapMethodHandle.name,
+                    bootstrapMethodHandle.desc,
+                    bootstrapMethodHandle.isInterface
+                )
+                invokeVirtual(
+                    Type.getType(CallSite::class.java),
+                    Method.getMethod(CallSite::class.java.getMethod("dynamicInvoker"))
+                )
+            }
+            // todo cache all above when native calls are available
+            loadLocals(arguments)
+            advancingCounter {
+                visitMethodInsn(
+                    Opcodes.INVOKEVIRTUAL, "java/lang/invoke/MethodHandle", "invokeExact", descriptor, false
+                )
+            }
+        }
+    }
+
+    private fun isMethodVarArgs(
+        bootstrapMethodHandle: Handle,
+    ): Boolean {
+        val ownerClassName = bootstrapMethodHandle.owner.replace('/', '.')
+        val methods = Class.forName(ownerClassName).declaredMethods
+        return methods.single { Type.getMethodDescriptor(it) == bootstrapMethodHandle.desc }.isVarArgs
+    }
+
+    private fun GeneratorAdapter.advancingCounter(code: GeneratorAdapter.() -> Unit) {
+        invokeStatic(Injections::getNextObjectId)
+        val oldId = newLocal(Type.LONG_TYPE)
+        storeLocal(oldId)
+        tryCatchFinally(
+            tryBlock = code,
+            finallyBlock = {
+                loadLocal(oldId)
+                invokeStatic(Injections::advanceCurrentObjectIdWithKnownOldObjectId)
+            }
+        )
+    }
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InvokeDynamicTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InvokeDynamicTransformer.kt
@@ -136,7 +136,7 @@ internal class InvokeDynamicTransformer(
             tryBlock = code,
             finallyBlock = {
                 loadLocal(oldId)
-                invokeStatic(Injections::advanceCurrentObjectIdWithKnownOldObjectId)
+                invokeStatic(Injections::advanceCurrentObjectId)
             }
         )
     }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/traceDebugger/AbstractNativeCallTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/traceDebugger/AbstractNativeCallTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.traceDebugger
+
+import org.jetbrains.kotlinx.lincheck.ExceptionResult
+import org.jetbrains.kotlinx.lincheck.checkImpl
+import org.jetbrains.kotlinx.lincheck.execution.ExecutionResult
+import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario
+import org.jetbrains.kotlinx.lincheck.execution.parallelResults
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.verifier.Verifier
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * Checks for absence of non-determinism and absence (or existence) of exceptions.
+ */
+abstract class AbstractNativeCallTest {
+    private fun testTraceDebugger() {
+        val oldStdOut = System.out
+        val oldErr = System.err
+        val stdOutOutputCollector = ByteArrayOutputStream()
+        val myStdOut = PrintStream(stdOutOutputCollector)
+        val stdErrOutputCollector = ByteArrayOutputStream()
+        val myStdErr = PrintStream(stdErrOutputCollector)
+        System.setOut(myStdOut)
+        System.setErr(myStdErr)
+        try {
+            ModelCheckingOptions()
+                .actorsBefore(0)
+                .actorsAfter(0)
+                .iterations(30)
+                .threads(2)
+                .actorsPerThread(1)
+                .verifier(FailingVerifier::class.java)
+                .customize()
+                .checkImpl(this::class.java) { lincheckFailure ->
+                    val results = lincheckFailure?.results?.parallelResults?.flatten()?.takeIf { it.isNotEmpty() }
+                    require(results != null) { lincheckFailure.toString() }
+                    if (shouldFail()) {
+                        require(results.all { it is ExceptionResult })// { lincheckFailure.toString() }
+                    } else {
+                        require(results.none { it is ExceptionResult })// { lincheckFailure.toString() }
+                    }
+                }
+        } finally {
+            val forbiddenString = "Non-determinism found."
+            System.setOut(oldStdOut)
+            System.setErr(oldErr)
+            val stdOutOutput = stdOutOutputCollector.toString()
+            println(stdOutOutput)
+            val stdErrOutput = stdErrOutputCollector.toString()
+            System.err.print(stdErrOutput)
+            require(!stdOutOutput.contains(forbiddenString) && !stdErrOutput.contains(forbiddenString))
+        }
+    }
+    
+    open fun shouldFail() = false
+
+    @Test
+    fun test() = testTraceDebugger()
+    
+    open fun ModelCheckingOptions.customize(): ModelCheckingOptions = this
+}
+
+@Suppress("UNUSED_PARAMETER")
+class FailingVerifier(sequentialSpecification: Class<*>) : Verifier {
+    override fun verifyResults(scenario: ExecutionScenario?, results: ExecutionResult?) = false
+}

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/traceDebugger/HashCodeTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/traceDebugger/HashCodeTests.kt
@@ -1,0 +1,159 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.traceDebugger
+
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import java.util.*
+
+abstract class HashCodeTest : AbstractNativeCallTest()
+
+class SimpleHashCodeTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Any().hashCode() }
+}
+
+class IdentityHashCodeTest : HashCodeTest() {
+    @Operation
+    fun operation(): List<Int> = List(100) { System.identityHashCode(Any()) }
+}
+
+
+class ObjectsHashCodeTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Objects.hashCode(Any()) }
+}
+
+
+class ObjectsHashCodeVarargTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Objects.hash(Any(), Any()) }
+}
+
+class SimpleToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Any().toString() }
+}
+
+class HashCodeToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Any().hashCode().toString() }
+}
+
+class StringBuilderToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { buildString { appendLine(Any()) } }
+}
+
+class StringBuilderHashCodeToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { buildString { appendLine(Any().hashCode()) } }
+}
+
+class InvokeDynamicToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { "${Any()} ${Any()}" }
+}
+
+class InvokeDynamicInnerClassCreationTest : HashCodeTest() {
+    class A {
+        override fun toString(): String = Any().hashCode().toString()
+    }
+    @Operation
+    fun operation(): List<String> = List(100) { "${A()} ${A()}" }
+}
+
+class InvokeDynamicHashCodeToStringTest : HashCodeTest() {
+    @Operation
+    fun operation(): List<String> = List(100) { "${Any().hashCode()} ${Any().hashCode()}" }
+}
+
+class StringFormatToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { String.format("%s %s", Any(), Any()) }
+}
+
+class StringFormatHashCodeToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { String.format("%s %s", Any().hashCode(), Any().hashCode()) }
+}
+
+data class Wrapper(val value: Any)
+
+class WrapperHashCodeTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Wrapper(Any()).hashCode() }
+}
+
+class WrapperToStringTest : HashCodeTest() {
+    @Operation
+    fun operation() = List(100) { Wrapper(Any()).toString() }
+}
+
+class InitInternalToStringTest : HashCodeTest() {
+    class A {
+        internal val value = "${Any()} ${Any()}"
+        override fun toString(): String = value
+    }
+    @Operation
+    fun operation() = List(100) { "${A()} ${A()}" }
+}
+
+class ClassInitInternalToStringTest : HashCodeTest() {
+    object A {
+        @JvmStatic
+        internal val value = "${Any()} ${Any()}"
+    }
+    fun f(): String = A.value
+    
+    @Operation
+    fun operation() = List(100) { "${f()} ${f()}" }
+}
+
+class FailingInvokeDynamicTest : HashCodeTest() {
+    private class A {
+        override fun toString(): String {
+            throw IllegalStateException()
+        }
+    }
+    @Operation
+    fun operation(): List<String> {
+        try {
+            List(100) { "${A()} ${A()}" }
+        } catch (_: Throwable) {
+            // ignore
+        }
+        return List(100) { Any().toString() }
+    }
+}
+
+class FailingInvokeDynamicWithStateTest : HashCodeTest() {
+    private class A {
+        var x = 0
+        override fun toString(): String {
+            try {
+                x = Any().hashCode()
+                throw IllegalStateException()
+            } finally {
+                x = x xor Any().hashCode()
+            }
+        }
+    }
+    
+    @Operation
+    fun operation(): List<String> {
+        try {
+            List(100) { "${A()} ${A()} ${A().x}" }
+        } catch (_: Throwable) {
+            // ignore
+        }
+        return List(100) { Any().toString() + " " + A().x }
+    }
+}

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/HashCodeTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/HashCodeTests.kt
@@ -12,7 +12,6 @@ package org.jetbrains.kotlinx.lincheck_test.transformation
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
-import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
 
 /**
@@ -78,7 +77,6 @@ class IdentityHashCodeOnNullTest {
     fun test() = ModelCheckingOptions().check(this::class)
 }
 
-@Ignore // TODO: easier to support when `javaagent` is merged
 class IdentityHashCodeDiffersTest() {
     @Operation
     fun operation() {


### PR DESCRIPTION
Substitute identity hashcode, received on the first run, on the following runs.