### PR TITLE
Automate representation tests repair process

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,10 @@ tasks {
         if (instrumentAllClasses.toBoolean()) {
             systemProperty("lincheck.instrumentAllClasses", "true")
         }
+        val overwriteRepresentationTestsOutput: String by project
+        if (overwriteRepresentationTestsOutput.toBoolean()) {
+            systemProperty("lincheck.overwriteRepresentationTestsOutput", "true")
+        }
         val extraArgs = mutableListOf<String>()
         val withEventIdSequentialCheck: String by project
         if (withEventIdSequentialCheck.toBoolean()) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,17 @@ tasks {
         if (instrumentAllClasses.toBoolean()) {
             systemProperty("lincheck.instrumentAllClasses", "true")
         }
+        // The `overwriteRepresentationTestsOutput` flag is used to automatically repair representation tests.
+        // Representation tests work by comparing an actual output of the test (execution trace in most cases)
+        // with the expected output stored in a file (which is kept in resources).
+        // Normally, if the actual and expected outputs differ, the test fails,
+        // but when this flag is set, instead the expected output is overwritten with the actual output.
+        // This helps to quickly repair the tests when the output difference is non-essential
+        // or when the output logic actually has changed in the code.
+        // The test system relies on that the gradle test task is run from the root directory of the project,
+        // to search for the directory where the expected output files are stored.
+        //
+        // PLEASE USE CAREFULLY: always first verify that the changes in the output are expected!
         val overwriteRepresentationTestsOutput: String by project
         if (overwriteRepresentationTestsOutput.toBoolean()) {
             systemProperty("lincheck.overwriteRepresentationTestsOutput", "true")

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ jdkToolchainVersion=17
 runAllTestsInSeparateJVMs=false
 instrumentAllClasses=false
 withEventIdSequentialCheck=false
+overwriteRepresentationTestsOutput=false
 
 kotlinVersion=1.9.25
 kotlinxCoroutinesVersion=1.7.3


### PR DESCRIPTION
Add a flag to automatically overwrite representation tests output.