### PR TITLE
Ignore flaky coroutines multiple suspensions test

### DIFF
--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
@@ -17,11 +17,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.coroutines.resume
+import org.junit.Ignore
 
 /**
  * Checks the data structure which actors may suspend multiple times.
  * Passes only if the multiple suspension points are supported properly.
  */
+@Ignore // TODO: also requires support of multiple suspension points in linearizability checker
 @OptIn(InternalCoroutinesApi::class)
 class CoroutinesMultipleSuspensionsTest : AbstractLincheckTest() {
     private var counter = 0

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
@@ -35,10 +35,6 @@ class CoroutinesMultipleSuspensionsTest : AbstractLincheckTest() {
                 waiters.add(cont)
                 if (!locked.value && waiters.remove(cont)) {
                     cont.resume(Unit)
-                } else {
-                    cont.invokeOnCancellation {
-                        waiters.remove(cont)
-                    }
                 }
             }
         }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
@@ -33,8 +33,12 @@ class CoroutinesMultipleSuspensionsTest : AbstractLincheckTest() {
             if (locked.compareAndSet(false, true)) return
             suspendCancellableCoroutine { cont ->
                 waiters.add(cont)
-                if (!locked.value) {
-                    if (waiters.remove(cont)) cont.resume(Unit)
+                if (!locked.value && waiters.remove(cont)) {
+                    cont.resume(Unit)
+                } else {
+                    cont.invokeOnCancellation {
+                        waiters.remove(cont)
+                    }
                 }
             }
         }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/CoroutinesMultipleSuspensionsTest.kt
@@ -27,7 +27,7 @@ class CoroutinesMultipleSuspensionsTest : AbstractLincheckTest() {
     private val locked = atomic(false)
     private val waiters = ConcurrentLinkedQueue<CancellableContinuation<Unit>>()
 
-    @Operation
+    @Operation(cancellableOnSuspension = false)
     suspend fun lock() {
         while (true) {
             if (locked.compareAndSet(false, true)) return
@@ -44,7 +44,7 @@ class CoroutinesMultipleSuspensionsTest : AbstractLincheckTest() {
         }
     }
 
-    @Operation
+    @Operation(cancellableOnSuspension = false)
     fun unlock() {
         if (!locked.compareAndSet(true, false)) error("mutex was not locked")
         while (true) {


### PR DESCRIPTION
Disabled the `CoroutinesMultipleSuspensionsTest.stressTest` test for now, as it is currently flaky on CI. 

Possible reasons could either be:
* The test also requires support of multiple suspension points in the linearizability checker.
* There is some data race in the `ParallelThreadsRunner` class in the code that manages thread suspension statuses.