### PR TITLE
Fix instrumentation of newly loaded classes 

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectLabelFactory.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectLabelFactory.kt
@@ -80,9 +80,8 @@ object ObjectLabelFactory {
         // There is a Kotlin compiler bug that leads to exception
         // `java.lang.InternalError: Malformed class name`
         // when trying to query for a class name of an anonymous class on JDK 8:
-        // https://youtrack.jetbrains.com/issue/KT-16727/
-        //
-        // in such a case we fall back to returning `<unknown>` class name
+        // - https://youtrack.jetbrains.com/issue/KT-16727/
+        // in such a case we fall back to returning `<unknown>` class name.
         .getOrElse {
             "<unknown>"
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectLabelFactory.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectLabelFactory.kt
@@ -69,12 +69,13 @@ object ObjectLabelFactory {
         if (obj is Thread) {
             return "Thread#${getObjectNumber(Thread::class.java, obj)}"
         }
-        val objectName = runCatching {
+        runCatching {
             if (obj.javaClass.isAnonymousClass) {
-                obj.javaClass.simpleNameForAnonymous
-            } else {
-                objectName(obj)
+                return obj.javaClass.simpleNameForAnonymous
             }
+        }
+        val objectName = runCatching {
+            objectName(obj)
         }
         // There is a Kotlin compiler bug that leads to exception
         // `java.lang.InternalError: Malformed class name`

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -351,7 +351,9 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         protectionDomain: ProtectionDomain?,
         classBytes: ByteArray
     ): ByteArray? = runInIgnoredSection {
-        require(internalClassName != null) { "Class name must not be null" }
+        require(internalClassName != null) {
+            "Class name must not be null"
+        }
         // If the class should not be transformed, return immediately.
         if (!shouldTransform(internalClassName.canonicalClassName, instrumentationMode)) {
             return null

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -351,12 +351,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         protectionDomain: ProtectionDomain?,
         classBytes: ByteArray
     ): ByteArray? = runInIgnoredSection {
-        if (classBeingRedefined == null) {
-            // No internal class name is expected if no class is provided.
-            return null
-        } else {
-            require(internalClassName != null) { "Class name must not be null" }
-        }
+        require(internalClassName != null) { "Class name must not be null" }
         // If the class should not be transformed, return immediately.
         if (!shouldTransform(internalClassName.canonicalClassName, instrumentationMode)) {
             return null


### PR DESCRIPTION
Before this commit, the instrumentation would only be triggered for re-transformed or re-defined classes. 
With this change, instrumentation is also applied to new classes loaded during Lincheck test execution. 