### PR TITLE
fix: broken links to test samples

### DIFF
--- a/docs/topics/constraints.md
+++ b/docs/topics/constraints.md
@@ -96,7 +96,7 @@ Here is an example of the scenario generated for this test:
 Note that all consuming `poll()` and `peek()` invocations are performed from a single thread, thus satisfying the
 "single-consumer" restriction.
 
-> [Get the full code](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/MPSCQueueTest.kt).
+> [Get the full code](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/MPSCQueueTest.kt).
 >
 {style="note"}
 

--- a/docs/topics/introduction.md
+++ b/docs/topics/introduction.md
@@ -170,7 +170,7 @@ The updated `BasicCounterTest` class will look like this:
    * **T2**: The second thread resumes and increments the previously obtained counter value, incorrectly updating the
    counter to `1`.
 
-> [Get the full code](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/BasicCounterTest.kt).
+> [Get the full code](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/BasicCounterTest.kt).
 >
 {style="note"}
 
@@ -252,7 +252,7 @@ The following interleaving leads to the error:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 ```
 
-> [Get the full code](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/ConcurrentLinkedDequeTest.kt).
+> [Get the full code](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/ConcurrentLinkedDequeTest.kt).
 >
 {style="note"}
 

--- a/docs/topics/operation-arguments.md
+++ b/docs/topics/operation-arguments.md
@@ -130,11 +130,6 @@ For this, configure the generator for a `key: Int` parameter:
 Due to the small range of keys, Lincheck quickly reveals the race: when two values are being added concurrently by the same key, 
 one of the values may be overwritten and lost.
 
-> [Get the full code](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/MultiMapTest.kt).
->
-{style="note"}
-
-
 ## Next step
 
 Learn how to test data structures that set [access constraints on the execution](constraints.md),

--- a/docs/topics/progress-guarantees.md
+++ b/docs/topics/progress-guarantees.md
@@ -103,8 +103,8 @@ class ConcurrentSkipListMapTest {
 At the moment, Lincheck supports only the obstruction-freedom progress guarantees. However, most real-life liveness bugs
 add unexpected blocking code, so the obstruction-freedom check will also help with lock-free and wait-free algorithms.
 
-> * Get the [full code of the example](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/ConcurrentMapTest.kt).
-> * See [another example](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/ObstructionFreedomViolationTest.kt)
+> * Get the [full code of the example](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/ConcurrentMapTest.kt).
+> * See [another example](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/ObstructionFreedomViolationTest.kt)
 >   where the Michael-Scott queue implementation is tested for progress guarantees.
 >
 {style="note"}

--- a/docs/topics/sequential-specification.md
+++ b/docs/topics/sequential-specification.md
@@ -49,6 +49,6 @@ class SequentialQueue {
 }
 ```
 
-> Get the [full code of the examples](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/ConcurrentLinkedQueueTest.kt).
+> Get the [full code of the examples](https://github.com/JetBrains/lincheck/blob/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/ConcurrentLinkedQueueTest.kt).
 >
 {style="note"}

--- a/docs/topics/testing-strategies.md
+++ b/docs/topics/testing-strategies.md
@@ -267,8 +267,8 @@ states in the trace, add the `stateRepresentation()` function to the `CounterTes
 In case of stress testing, Lincheck prints the state representation right before and after the parallel part of the scenario,
 as well as at the end.
 
-> * Get the [full code of these examples](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/CounterTest.kt)
-> * See more [test examples](https://github.com/Kotlin/kotlinx-lincheck/blob/guide/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/guide/StackTest.kt)
+> * Get the [full code of these examples](https://github.com/JetBrains/lincheck/tree/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide/CounterTest.kt)
+> * See more [test examples](https://github.com/JetBrains/lincheck/tree/master/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/guide)
 >
 {style="note"}
 


### PR DESCRIPTION
This PR fixes broken links to test samples. For the missing tests, links were removed