### PR TITLE
Pass location information of each trace point to IDEA debugger.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
@@ -173,7 +173,12 @@ internal fun ManagedStrategy.runReplayIfPluginEnabled(failure: LincheckFailure) 
  * (due to difficulties with passing objects like List and TracePoint, as class versions may vary)
  *
  * Each trace point is transformed into the line of the following form:
- * `type,iThread,callDepth,shouldBeExpanded,eventId,representation`.
+ * `type;iThread;callDepth;shouldBeExpanded;eventId;representation;stackTraceElement;codeLocationId`.
+ *
+ *   stackTraceElement is "className:methodName:fileName:lineNumber" or "null" string if it is not applicable
+ *   codeLocationId is strictly growing abstract id of location, and it must grow in syntactic order to
+ *                  be able to order events occurred at same line in the same file. It is `-1` if it is not
+ *                  applicable and stackTranceElement is "null".
  *
  * Later, when [testFailed] breakpoint is triggered debugger parses these lines back to trace points.
  *

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
@@ -203,6 +203,13 @@ private fun constructTraceForPlugin(failure: LincheckFailure, trace: Trace): Arr
                 val event = node.event
                 val eventId = event.eventId
                 val representation = event.toStringImpl(withLocation = false)
+                val (location, locationId) = if (event is CodeLocationTracePoint) {
+                    val ste = event.stackTraceElement
+                    "${ste.className}:${ste.methodName}:${ste.fileName}:${ste.lineNumber}" to event.codeLocation
+                }
+                else {
+                    "null" to -1
+                }
                 val type = when (event) {
                     is SwitchEventTracePoint -> {
                         when (event.reason) {
@@ -218,15 +225,18 @@ private fun constructTraceForPlugin(failure: LincheckFailure, trace: Trace): Arr
                 }
 
                 if (representation.isNotEmpty()) {
-                    representations.add("$type;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${eventId};${representation}")
+                    representations.add("$type;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${eventId};${representation};${location};${locationId}")
                 }
             }
 
             is CallNode -> {
                 val beforeEventId = node.call.eventId
                 val representation = node.call.toStringImpl(withLocation = false)
+                val ste = node.call.stackTraceElement
+                val location = "${ste.className}:${ste.methodName}:${ste.fileName}:${ste.lineNumber}"
+
                 if (representation.isNotEmpty()) {
-                    representations.add("0;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation}")
+                    representations.add("0;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation};${location};${node.call.codeLocation}")
                 }
             }
 
@@ -234,14 +244,14 @@ private fun constructTraceForPlugin(failure: LincheckFailure, trace: Trace): Arr
                 val beforeEventId = -1
                 val representation = node.actorRepresentation
                 if (representation.isNotEmpty()) {
-                    representations.add("1;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation}")
+                    representations.add("1;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation};null;-1")
                 }
             }
 
             is ActorResultNode -> {
                 val beforeEventId = -1
                 val representation = node.resultRepresentation.toString()
-                representations.add("2;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation};${node.exceptionNumberIfExceptionResult ?: -1}")
+                representations.add("2;${node.iThread};${node.callDepth};${node.shouldBeExpanded(false)};${beforeEventId};${representation};${node.exceptionNumberIfExceptionResult ?: -1};null;-1")
             }
 
             else -> {}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -655,7 +655,7 @@ abstract class ManagedStrategy(
         // the managed strategy can construct a trace to reproduce this failure.
         // Let's then store the corresponding failing result and construct the trace.
         suddenInvocationResult = UnexpectedExceptionInvocationResult(
-            exception, 
+            exception,
             runner.collectExecutionResults()
         )
         threadScheduler.abortAllThreads()
@@ -790,7 +790,7 @@ abstract class ManagedStrategy(
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
         } else {
             null
@@ -833,7 +833,7 @@ abstract class ManagedStrategy(
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
             traceCollector!!.passCodeLocation(tracePoint)
         }
@@ -846,7 +846,7 @@ abstract class ManagedStrategy(
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
         } else {
             null
@@ -872,7 +872,7 @@ abstract class ManagedStrategy(
                 iThread = currentThreadId,
                 actorId = currentActorId[currentThreadId]!!,
                 callStackTrace = callStackTrace[currentThreadId]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
             traceCollector?.passCodeLocation(tracePoint)
         }
@@ -885,7 +885,7 @@ abstract class ManagedStrategy(
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
         } else {
             null
@@ -918,7 +918,7 @@ abstract class ManagedStrategy(
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
             traceCollector?.passCodeLocation(tracePoint)
         }
@@ -987,7 +987,7 @@ abstract class ManagedStrategy(
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
                 fieldName = fieldName,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
         } else {
             null
@@ -1014,7 +1014,7 @@ abstract class ManagedStrategy(
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
                 fieldName = "${adornedStringRepresentation(array)}[$index]",
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             )
         } else {
             null
@@ -1055,7 +1055,7 @@ abstract class ManagedStrategy(
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
                 fieldName = fieldName,
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             ).also {
                 it.initializeWrittenValue(adornedStringRepresentation(value))
             }
@@ -1081,7 +1081,7 @@ abstract class ManagedStrategy(
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
                 fieldName = "${adornedStringRepresentation(array)}[$index]",
-                stackTraceElement = CodeLocations.stackTrace(codeLocation)
+                codeLocation = codeLocation
             ).also {
                 it.initializeWrittenValue(adornedStringRepresentation(value))
             }
@@ -1153,7 +1153,7 @@ abstract class ManagedStrategy(
         val invokeDynamic = ConstantDynamic(name, descriptor, trueBootstrapMethodHandle, *bootstrapMethodArguments)
         return invokeDynamicCallSites[invokeDynamic]
     }
-    
+
     override fun cacheInvokeDynamicCallSite(
         name: String,
         descriptor: String,
@@ -1545,7 +1545,7 @@ abstract class ManagedStrategy(
             className = className,
             methodName = methodName,
             callStackTrace = callStackTrace,
-            stackTraceElement = CodeLocations.stackTrace(codeLocation),
+            codeLocation = codeLocation
         )
         // handle non-atomic methods
         if (atomicMethodDescriptor == null) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -416,8 +416,8 @@ private fun removeSyntheticFieldAccessTracePoints(trace: List<TracePoint>) {
         .forEach { point ->
             val lastCall = point.callStackTrace.lastOrNull() ?: return@forEach
             if (isSyntheticFieldAccess(lastCall.tracePoint.methodName)) {
-                if (point is ReadTracePoint) point.stackTraceElement = lastCall.tracePoint.stackTraceElement
-                if (point is WriteTracePoint) point.stackTraceElement = lastCall.tracePoint.stackTraceElement
+                if (point is ReadTracePoint) point.codeLocation = lastCall.tracePoint.codeLocation
+                if (point is WriteTracePoint) point.codeLocation = lastCall.tracePoint.codeLocation
                 point.callStackTrace = point.callStackTrace.dropLast(1)
             }
         }


### PR DESCRIPTION
Add date needed for loop visualization in IDEA plugin:

1. Stack trace element data (class, file, line)
2. Internal code locations, which means nothing outside `lincheck`, but have very important property: they are strictly incrementing. It allows to use them to distinguish trace points (and what goes first!) which reside on same line.

This PR change all trace points constructors to hold location Id and not stack trace element, as all of them need location Id now and stack trace element can be derived from location Id.

Please note, that this review contains change of version to make it custom to be able to reference it in plugin. This change should not be merged, of course.