### PR TITLE
Add minimalistic logger to Lincheck

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,8 +178,8 @@ tasks {
             extraArgs.add("-Dlincheck.traceDebuggerMode=true")
         }
         extraArgs.add("-Dlincheck.version=$version")
-        findProperty("lincheck.log.file")?.let { extraArgs.add("-Dlincheck.log.file=${it as String}") }
-        findProperty("lincheck.log.level")?.let { extraArgs.add("-Dlincheck.log.level=${it as String}") }
+        findProperty("lincheck.logFile")?.let { extraArgs.add("-Dlincheck.logFile=${it as String}") }
+        findProperty("lincheck.logLevel")?.let { extraArgs.add("-Dlincheck.logLevel=${it as String}") }
         jvmArgs(extraArgs)
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,6 +178,8 @@ tasks {
             extraArgs.add("-Dlincheck.traceDebuggerMode=true")
         }
         extraArgs.add("-Dlincheck.version=$version")
+        findProperty("lincheck.log.file")?.let { extraArgs.add("-Dlincheck.log.file=${it as String}") }
+        findProperty("lincheck.log.level")?.let { extraArgs.add("-Dlincheck.log.level=${it as String}") }
         jvmArgs(extraArgs)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelChecki
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
+import org.jetbrains.kotlinx.lincheck.util.DEFAULT_LOG_LEVEL
 import kotlin.reflect.*
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -12,6 +12,8 @@ package org.jetbrains.kotlinx.lincheck
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
+import org.jetbrains.kotlinx.lincheck.util.DEFAULT_LOG_LEVEL
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
 
 /**
  * Abstract class for test options.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -10,11 +10,12 @@
 
 package org.jetbrains.kotlinx.lincheck
 
-import org.jetbrains.kotlinx.lincheck.LoggingLevel.*
 import sun.nio.ch.lincheck.TestThread
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel.*
 import java.io.*
 import kotlin.math.max
 import kotlin.reflect.jvm.javaMethod
@@ -44,11 +45,6 @@ class Reporter(private val logLevel: LoggingLevel) {
         val output = if (logLevel == WARN) outErr else out
         output.println(sb)
     }
-}
-
-@JvmField val DEFAULT_LOG_LEVEL = WARN
-enum class LoggingLevel {
-    INFO, WARN, OFF
 }
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/TraceDebugger.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/TraceDebugger.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.lincheck.execution.threadsResults
 import org.jetbrains.kotlinx.lincheck.strategy.managed.forClasses
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.ensureClassHierarchyIsTransformed
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/annotations/LogLevel.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/annotations/LogLevel.java
@@ -10,7 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck.annotations;
 
-import org.jetbrains.kotlinx.lincheck.LoggingLevel;
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlinx.lincheck.transformation.LincheckClassFileTransforme
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.INSTRUMENT_ALL_CLASSES
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumentationMode
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumentedClasses
-import org.jetbrains.kotlinx.lincheck.util.LincheckLogger
+import org.jetbrains.kotlinx.lincheck.util.Logger
 import org.jetbrains.kotlinx.lincheck.util.readFieldViaUnsafe
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
@@ -389,7 +389,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         internalClassName: String,
         classBytes: ByteArray
     ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
-        LincheckLogger.log("Transform class '${internalClassName.canonicalClassName}'")
+        Logger.debug { "Transforming $internalClassName" }
 
         val reader = ClassReader(classBytes)
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlinx.lincheck.transformation.LincheckClassFileTransforme
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.INSTRUMENT_ALL_CLASSES
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumentationMode
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumentedClasses
+import org.jetbrains.kotlinx.lincheck.util.LincheckLogger
 import org.jetbrains.kotlinx.lincheck.util.readFieldViaUnsafe
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
@@ -388,6 +389,8 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         internalClassName: String,
         classBytes: ByteArray
     ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
+        LincheckLogger.log("Transform class '${internalClassName.canonicalClassName}'")
+
         val reader = ClassReader(classBytes)
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)
         val visitor = LincheckClassVisitor(writer, instrumentationMode)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Logger.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/Logger.kt
@@ -1,0 +1,91 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.util
+
+import java.io.*
+import java.text.SimpleDateFormat
+import java.util.*
+
+object LincheckLogger {
+    private val LINE_SEPARATOR = System.lineSeparator()
+    private val formatter: ThreadLocal<SimpleDateFormat> = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue(): SimpleDateFormat {
+            return SimpleDateFormat("dd.MM.yyyy HH:mm:ss")
+        }
+    }
+
+    private val logFilename = System.getProperty("lincheck.log.file") ?: null
+    private val logFile = if (logFilename != null) File(logFilename) else null
+    private var logWriter: Writer? = null
+
+    init {
+        println("property: lincheck.log.file = " + System.getProperty("lincheck.log.file"))
+        logFile?.let {
+            initFile(it)
+            logWriter = BufferedWriter(FileWriter(it))
+            println("Lincheck log file could be found at: ${it.absolutePath}")
+        }
+    }
+
+    /**
+     * Logs will be printed to log file if it exists.
+     */
+    fun log(s: String) {
+        logFile?.let {
+            write(s, logWriter!!)
+        }
+    }
+
+    /**
+     * Errors will be printed to log file if it is set.
+     * However, they will always be printed to the `System.err`.
+     */
+    fun error(m: String, e: Throwable) {
+        logFile?.let {
+            write(m, e, logWriter!!)
+        }
+        System.err.println(m)
+        e.printStackTrace(System.err)
+    }
+
+    private fun write(m: String, e: Throwable, writer: Writer) {
+        try {
+            writer.write(getCurrentTimeStamp() + " " + m + LINE_SEPARATOR)
+            writer.flush()
+            e.printStackTrace(PrintWriter(writer))
+        }
+        catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun write(s: String, writer: Writer) {
+        try {
+            writer.write(getCurrentTimeStamp() + " " + s + LINE_SEPARATOR)
+            writer.flush()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun getCurrentTimeStamp(): String {
+        return "[" + formatter.get().format(Date()) + "]"
+    }
+
+    private fun initFile(file: File) {
+        // create parent directories
+        file.parentFile?.let { if (!it.exists()) it.mkdirs() }
+
+        // create file
+        if (file.exists()) file.delete()
+        file.createNewFile()
+    }
+}

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/ModelCheckingOptionsTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/modelchecking/ModelCheckingOptionsTest.java
@@ -10,7 +10,7 @@
 package org.jetbrains.kotlinx.lincheck_test.strategy.modelchecking;
 
 import org.jetbrains.kotlinx.lincheck.LinChecker;
-import org.jetbrains.kotlinx.lincheck.LoggingLevel;
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel;
 import org.jetbrains.kotlinx.lincheck.annotations.Operation;
 import org.jetbrains.kotlinx.lincheck.execution.RandomExecutionGenerator;
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions;

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/stress/StressOptionsTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/stress/StressOptionsTest.java
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.lincheck.*;
 import org.jetbrains.kotlinx.lincheck.annotations.*;
 import org.jetbrains.kotlinx.lincheck.execution.*;
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*;
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel;
 import org.jetbrains.kotlinx.lincheck.verifier.linearizability.*;
 import org.junit.*;
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/channel/IncorrectBufferedChannelTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/transformation/channel/IncorrectBufferedChannelTest.kt
@@ -14,7 +14,7 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.jetbrains.kotlinx.lincheck.LoggingLevel
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.check
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions


### PR DESCRIPTION
Partially addresses: #434 
* Simple logger added
* Transformed classes are printed to log file
* How it works:
   * One can specify (dev: in `gradle.properties`, lib users in VM arguments) flag `lincheck.log.file` to print log to file (default is `System.err`) 
   * Specify flag `lincheck.log.level` to setup logging level (default is a logging level defined in lincheck source code)