### PR TITLE
Improve performance by caching some reflection-related data

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -23,6 +23,7 @@ import java.lang.ref.*
 import java.lang.reflect.*
 import java.lang.reflect.Method
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 
@@ -324,3 +325,6 @@ internal fun <T> Class<T>.newDefaultInstance(): T {
 
     throw IllegalStateException("No suitable constructor found for ${this.canonicalName}")
 }
+
+// We store the class references in a local map to avoid repeated Class.forName calls and reflection overhead
+val classCache = ConcurrentHashMap<String, Class<*>>()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ThreadMap.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/ThreadMap.kt
@@ -19,4 +19,3 @@ fun <T> threadMapOf(): ThreadMap<T> =
 
 fun <T> mutableThreadMapOf(): MutableThreadMap<T> =
     mutableMapOf()
-


### PR DESCRIPTION
Speeds up `ConcurrentLinkedDequeTest` from 42s to 28s on my local machine 