### PR TITLE
Rollback to make `ideaPluginEnabled` flag lazy

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/IdeaPlugin.kt
@@ -439,7 +439,7 @@ internal val eventIdStrictOrderingCheck =
  * We will call `ideaPluginEnabled` method only once
  * and so on the plugin side the callback will be called also only once.
  */
-internal val ideaPluginEnabled = ideaPluginEnabled()
+internal val ideaPluginEnabled by lazy { ideaPluginEnabled() }
 
 /**
  * Debugger replaces the result of this method to `true` if idea plugin is enabled.


### PR DESCRIPTION
Without this change, stepping in the plugin does not work 