### PR TITLE
Ensure internal class names do not leak from `transformation` module

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -186,8 +186,6 @@ internal fun collectThreadDump(runner: Runner) = Thread.getAllStackTraces().filt
     t is TestThread && runner.isCurrentRunnerThread(t)
 }
 
-internal val String.canonicalClassName get() = this.replace('/', '.')
-
 internal val Throwable.text: String get() {
     val writer = StringWriter()
     printStackTrace(PrintWriter(writer))

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -157,7 +157,7 @@ abstract class ManagedStrategy(
 
     /**
      * For each thread, represents a shadow stack used to reflect the program's actual stack.
-     * 
+     *
      * Collected and used only in the trace collecting stage.
      */
     // TODO: unify with `callStackTrace`
@@ -1002,11 +1002,11 @@ abstract class ManagedStrategy(
      */
     override fun beforeReadField(obj: Any?, className: String, fieldName: String, codeLocation: Int,
                                  isStatic: Boolean, isFinal: Boolean) = runInIgnoredSection {
-        updateSnapshotOnFieldAccess(obj, className.canonicalClassName, fieldName)
+        updateSnapshotOnFieldAccess(obj, className, fieldName)
         // We need to ensure all the classes related to the reading object are instrumented.
         // The following call checks all the static fields.
         if (isStatic) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(className.canonicalClassName)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
         }
         // Optimization: do not track final field reads
         if (isFinal) {
@@ -1077,7 +1077,7 @@ abstract class ManagedStrategy(
 
     override fun beforeWriteField(obj: Any?, className: String, fieldName: String, value: Any?, codeLocation: Int,
                                   isStatic: Boolean, isFinal: Boolean): Boolean = runInIgnoredSection {
-        updateSnapshotOnFieldAccess(obj, className.canonicalClassName, fieldName)
+        updateSnapshotOnFieldAccess(obj, className, fieldName)
         objectTracker?.registerObjectLink(fromObject = obj ?: StaticObject, toObject = value)
         if (!shouldTrackObjectAccess(obj)) {
             return@runInIgnoredSection false
@@ -1678,7 +1678,7 @@ abstract class ManagedStrategy(
             methodName = methodName,
             callStackTrace = callStackTrace,
             codeLocation = codeLocation,
-            isStatic = owner == null
+            isStatic = (owner == null)
         )
         // handle non-atomic methods
         if (atomicMethodDescriptor == null) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1019,7 +1019,7 @@ abstract class ManagedStrategy(
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
             ReadTracePoint(
-                ownerRepresentation = if (isStatic) simpleClassName(className) else findOwnerName(obj!!),
+                ownerRepresentation = if (isStatic) className.toSimpleClassName() else findOwnerName(obj!!),
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
@@ -1089,7 +1089,7 @@ abstract class ManagedStrategy(
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
             WriteTracePoint(
-                ownerRepresentation = if (isStatic) simpleClassName(className) else findOwnerName(obj!!),
+                ownerRepresentation = if (isStatic) className.toSimpleClassName() else findOwnerName(obj!!),
                 iThread = iThread,
                 actorId = currentActorId[iThread]!!,
                 callStackTrace = callStackTrace[iThread]!!,
@@ -1682,7 +1682,7 @@ abstract class ManagedStrategy(
         )
         // handle non-atomic methods
         if (atomicMethodDescriptor == null) {
-            val ownerName = if (owner != null) findOwnerName(owner) else simpleClassName(className)
+            val ownerName = if (owner != null) findOwnerName(owner) else className.toSimpleClassName()
             if (ownerName != null) {
                 tracePoint.initializeOwnerName(ownerName)
             }
@@ -1709,8 +1709,6 @@ abstract class ManagedStrategy(
         val enumPrefix = if (obj?.javaClass?.isEnum == true) "Enum:" else ""
         return "$enumPrefix${obj?.javaClass?.name ?: "null"}"
     }
-
-    private fun simpleClassName(className: String) = className.canonicalClassName.takeLastWhile { it != '.' }
 
     private fun initializeUnsafeMethodCallTracePoint(
         tracePoint: MethodCallTracePoint,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -158,7 +158,7 @@ internal class LincheckClassVisitor(
         mv = ThreadTransformer(fileName, className, methodName, desc, mv.newAdapter())
         // We can do further instrumentation in methods of the custom thread subclasses,
         // but not in the `java.lang.Thread` itself.
-        if (className == JAVA_THREAD_CLASSNAME) {
+        if (isThreadClass(className.toCanonicalClassName())) {
             return mv
         }
         if (access and ACC_SYNCHRONIZED != 0) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -90,7 +90,7 @@ internal class LincheckClassVisitor(
         // but instead uses internal API `JavaLangAccess.start`.
         // To detect threads started in this way, we instrument this class
         // and inject the appropriate hook on calls to the `JavaLangAccess.start` method.
-        if (isThreadContainerClass(className.canonicalClassName)) {
+        if (isThreadContainerClass(className.toCanonicalClassName())) {
             if (methodName == "start") {
                 mv = ThreadTransformer(fileName, className, methodName, desc, mv.newAdapter())
             } else {
@@ -100,7 +100,7 @@ internal class LincheckClassVisitor(
         }
         // Wrap `ClassLoader::loadClass` calls into ignored sections
         // to ensure their code is not analyzed by the Lincheck.
-        if (containsClassloaderInName(className.canonicalClassName)) {
+        if (containsClassloaderInName(className.toCanonicalClassName())) {
             if (methodName == "loadClass") {
                 mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             }
@@ -108,7 +108,7 @@ internal class LincheckClassVisitor(
         }
         // Wrap `MethodHandles.Lookup.findX` and related methods into ignored sections
         // to ensure their code is not analyzed by the Lincheck.
-        if (isIgnoredMethodHandleMethod(className.canonicalClassName, methodName)) {
+        if (isIgnoredMethodHandleMethod(className.toCanonicalClassName(), methodName)) {
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
@@ -124,7 +124,7 @@ internal class LincheckClassVisitor(
          *   - https://github.com/JetBrains/lincheck/issues/376
          *   - https://github.com/JetBrains/lincheck/issues/419
          */
-        if (isStackTraceElementClass(className.canonicalClassName)) {
+        if (isStackTraceElementClass(className.toCanonicalClassName())) {
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -128,7 +128,7 @@ internal class LincheckClassVisitor(
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
-        if (isCoroutineInternalClass(className)) {
+        if (isCoroutineInternalClass(className.toCanonicalClassName())) {
             return mv
         }
         // Debugger implicitly evaluates toString for variables rendering

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -11,7 +11,6 @@
 package org.jetbrains.kotlinx.lincheck.transformation
 
 import net.bytebuddy.agent.ByteBuddyAgent
-import org.jetbrains.kotlinx.lincheck.canonicalClassName
 import org.jetbrains.kotlinx.lincheck.isInTraceDebuggerMode
 import org.jetbrains.kotlinx.lincheck.runInIgnoredSection
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.MODEL_CHECKING
@@ -372,7 +371,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         // - https://youtrack.jetbrains.com/issue/KT-16727/
         if (internalClassName == null) return null
         // If the class should not be transformed, return immediately.
-        if (!shouldTransform(internalClassName.canonicalClassName, instrumentationMode)) {
+        if (!shouldTransform(internalClassName.toCanonicalClassName(), instrumentationMode)) {
             return null
         }
         // In the model checking mode, we transform classes lazily,
@@ -380,9 +379,9 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         if (!INSTRUMENT_ALL_CLASSES &&
             instrumentationMode == MODEL_CHECKING &&
             // do not re-transform already instrumented classes
-            internalClassName.canonicalClassName !in instrumentedClasses &&
+            internalClassName.toCanonicalClassName() !in instrumentedClasses &&
             // always transform eagerly instrumented classes
-            !isEagerlyInstrumentedClass(internalClassName.canonicalClassName)) {
+            !isEagerlyInstrumentedClass(internalClassName.toCanonicalClassName())) {
             return null
         }
         return transformImpl(loader, internalClassName, classBytes)
@@ -392,7 +391,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         loader: ClassLoader?,
         internalClassName: String,
         classBytes: ByteArray
-    ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.canonicalClassName) {
+    ): ByteArray = transformedClassesCache.computeIfAbsent(internalClassName.toCanonicalClassName()) {
         Logger.debug { "Transforming $internalClassName" }
 
         val reader = ClassReader(classBytes)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerAgent.kt
@@ -11,7 +11,6 @@
 package org.jetbrains.kotlinx.lincheck.transformation
 
 import org.jetbrains.kotlinx.lincheck.TraceDebuggerInjections
-import org.jetbrains.kotlinx.lincheck.canonicalClassName
 import org.jetbrains.kotlinx.lincheck.isInTraceDebuggerMode
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
@@ -47,7 +46,7 @@ internal object TraceDebuggerTransformer : ClassFileTransformer {
         classBytes: ByteArray
     ): ByteArray? {
         // If the class should not be transformed, return immediately.
-        if (TraceDebuggerInjections.classUnderTraceDebugging != internalClassName.canonicalClassName) {
+        if (TraceDebuggerInjections.classUnderTraceDebugging != internalClassName.toCanonicalClassName()) {
             return null
         }
         return transformImpl(loader, internalClassName, classBytes)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerClassVisitor.kt
@@ -11,7 +11,8 @@
 package org.jetbrains.kotlinx.lincheck.transformation
 
 import org.jetbrains.kotlinx.lincheck.TraceDebuggerInjections
-import org.jetbrains.kotlinx.lincheck.canonicalClassName
+import org.jetbrains.kotlinx.lincheck.transformation.TraceDebuggerAgent.classUnderTraceDebugging
+import org.jetbrains.kotlinx.lincheck.transformation.TraceDebuggerAgent.methodUnderTraceDebugging
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.commons.GeneratorAdapter
@@ -31,7 +32,7 @@ class TraceDebuggerClassVisitor(
         interfaces: Array<String>
     ) {
         super.visit(version, access, name, signature, superName, interfaces)
-        className = name.canonicalClassName
+        className = name.toCanonicalClassName()
     }
 
     override fun visitMethod(

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TraceDebuggerClassVisitor.kt
@@ -11,8 +11,6 @@
 package org.jetbrains.kotlinx.lincheck.transformation
 
 import org.jetbrains.kotlinx.lincheck.TraceDebuggerInjections
-import org.jetbrains.kotlinx.lincheck.transformation.TraceDebuggerAgent.classUnderTraceDebugging
-import org.jetbrains.kotlinx.lincheck.transformation.TraceDebuggerAgent.methodUnderTraceDebugging
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.commons.GeneratorAdapter
@@ -45,7 +43,8 @@ class TraceDebuggerClassVisitor(
         fun MethodVisitor.newAdapter() = GeneratorAdapter(this, access, methodName, desc)
 
         var mv = super.visitMethod(access, methodName, desc, signature, exceptions)
-        if (className == TraceDebuggerInjections.classUnderTraceDebugging && methodName == TraceDebuggerInjections.methodUnderTraceDebugging) {
+        if (className == TraceDebuggerInjections.classUnderTraceDebugging &&
+            methodName == TraceDebuggerInjections.methodUnderTraceDebugging) {
             mv = TraceDebuggerRunMethodTransformer(mv.newAdapter())
         }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -500,7 +500,9 @@ internal fun isCoroutineStateMachineClass(className: String): Boolean {
     if (className.startsWith("java.")) return false
     if (className.startsWith("kotlin.") && !className.startsWith("kotlin.coroutines.")) return false
     return isCoroutineStateMachineClassMap.computeIfAbsent(className) {
-        getSuperclassName(className) == "kotlin.coroutines.jvm.internal.ContinuationImpl"
+        val internalClassName = className.toInternalClassName()
+        val superclassName = getSuperclassName(internalClassName)
+        superclassName?.toCanonicalClassName() == "kotlin.coroutines.jvm.internal.ContinuationImpl"
     }
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -475,18 +475,18 @@ private const val JAVA_THREAD_CLASSNAME = "java.lang.Thread"
 /**
  * Determines whether the given class name corresponds to an internal coroutine-related class.
  */
-internal fun isCoroutineInternalClass(internalClassName: String): Boolean =
-    internalClassName == "kotlin/coroutines/intrinsics/IntrinsicsKt" ||
-    internalClassName == "kotlinx/coroutines/internal/StackTraceRecoveryKt"
+internal fun isCoroutineInternalClass(className: String): Boolean =
+    className == "kotlin.coroutines.intrinsics.IntrinsicsKt" ||
+    className == "kotlinx.coroutines.internal.StackTraceRecoveryKt"
 
 /**
  * Checks whether the given class name represents a coroutine state machine class.
  */
-internal fun isCoroutineStateMachineClass(internalClassName: String): Boolean {
-    if (internalClassName.startsWith("java/")) return false
-    if (internalClassName.startsWith("kotlin/") && !internalClassName.startsWith("kotlin/coroutines/")) return false
-    return isCoroutineStateMachineClassMap.computeIfAbsent(internalClassName) {
-        getSuperclassName(internalClassName) == "kotlin/coroutines/jvm/internal/ContinuationImpl"
+internal fun isCoroutineStateMachineClass(className: String): Boolean {
+    if (className.startsWith("java.")) return false
+    if (className.startsWith("kotlin.") && !className.startsWith("kotlin.coroutines.")) return false
+    return isCoroutineStateMachineClassMap.computeIfAbsent(className) {
+        getSuperclassName(className) == "kotlin.coroutines.jvm.internal.ContinuationImpl"
     }
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -473,11 +473,25 @@ private val isThreadSubclassMap = ConcurrentHashMap<String, Boolean>()
 private const val JAVA_THREAD_CLASSNAME = "java.lang.Thread"
 
 /**
+ * Tests if the provided [className] represents one of jdk internal [ThreadContainer] classes
+ * that use [JavaLangAccess.start] API to start threads.
+ */
+internal fun isThreadContainerClass(className: String): Boolean =
+    className == "jdk.internal.vm.SharedThreadContainer"  ||
+    className == "jdk.internal.misc.ThreadFlock"
+
+/**
  * Determines whether the given class name corresponds to an internal coroutine-related class.
  */
 internal fun isCoroutineInternalClass(className: String): Boolean =
     className == "kotlin.coroutines.intrinsics.IntrinsicsKt" ||
     className == "kotlinx.coroutines.internal.StackTraceRecoveryKt"
+
+/**
+ * Tests if the provided [className] represents an internal coroutine dispatcher class.
+ */
+internal fun isCoroutineDispatcherInternalClass(className: String): Boolean =
+    className.startsWith("kotlinx.coroutines.internal") && className.contains("DispatchedContinuation")
 
 /**
  * Checks whether the given class name represents a coroutine state machine class.
@@ -529,24 +543,11 @@ internal fun isStackTraceElementClass(className: String): Boolean =
     className == "java.lang.StackTraceElement"
 
 /**
- * Tests if the provided [className] represents one of jdk internal [ThreadContainer] classes
- * that use [JavaLangAccess.start] API to start threads.
- */
-internal fun isThreadContainerClass(className: String): Boolean =
-    className == "jdk.internal.vm.SharedThreadContainer"  ||
-    className == "jdk.internal.misc.ThreadFlock"
-
-/**
  * Checks if the provided class name matches the [JavaLangAccess] class.
  */
 internal fun isJavaLangAccessClass(className: String): Boolean =
     className == "jdk.internal.access.JavaLangAccess"
 
-/**
- * Tests if the provided [className] represents an internal coroutine dispatcher class.
- */
-internal fun isCoroutineDispatcherInternalClass(className: String): Boolean =
-    className.startsWith("kotlinx.coroutines.internal") && className.contains("DispatchedContinuation")
 
 /**
  * Extracts the simple class name from a fully qualified canonical class name.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -549,6 +549,12 @@ internal fun isCoroutineDispatcherInternalClass(className: String): Boolean =
     className.startsWith("kotlinx.coroutines.internal") && className.contains("DispatchedContinuation")
 
 /**
+ * Extracts the simple class name from a fully qualified canonical class name.
+ */
+internal fun String.toSimpleClassName() =
+    this.takeLastWhile { it != '.' }
+
+/**
  * Converts a string representing a class name in internal format (e.g., "com/example/MyClass")
  * into a canonical class name format with (e.g., "com.example.MyClass").
  */

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -109,7 +109,7 @@ internal fun GeneratorAdapter.storeLocals(
 
 /**
  * Duplicates the value on the top of the stack.
- * 
+ *
  * Before execution:
  * STACK: x
  *
@@ -524,6 +524,14 @@ internal fun isThreadContainerClass(className: String): Boolean =
  */
 internal fun isCoroutineDispatcherInternalClass(className: String): Boolean =
     className.startsWith("kotlinx.coroutines.internal") && className.contains("DispatchedContinuation")
+
+/**
+ * Converts a string representing a class name in internal format (e.g., "com/example/MyClass")
+ * into a canonical class name format with (e.g., "com.example.MyClass").
+ */
+internal fun String.toCanonicalClassName() =
+    this.replace('/', '.')
+
 
 internal const val ASM_API = Opcodes.ASM9
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
@@ -13,7 +13,6 @@ package org.jetbrains.kotlinx.lincheck.transformation.transformers
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.commons.AdviceAdapter
 import org.jetbrains.kotlinx.lincheck.transformation.*
-import org.jetbrains.kotlinx.lincheck.canonicalClassName
 import org.objectweb.asm.Type.getType
 import org.objectweb.asm.commons.GeneratorAdapter
 import sun.nio.ch.lincheck.*
@@ -38,7 +37,7 @@ internal class CoroutineCancellabilitySupportTransformer(
         if (isGetResult) {
             dup()
             invokeStatic(Injections::storeCancellableContinuation)
-            className?.canonicalClassName?.let { coroutineCallingClasses += it }
+            className?.toCanonicalClassName()?.let { coroutineCallingClasses += it }
         }
         super.visitMethodInsn(opcode, owner, name, desc, itf)
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -78,7 +78,7 @@ internal class MethodCallTransformer(
             null -> pushNull()
             else -> loadLocal(receiver)
         }
-        push(owner.canonicalClassName)
+        push(owner.toCanonicalClassName())
         push(name)
         loadNewCodeLocationId()
         // STACK [INVOKEVIRTUAL]: owner, owner, className, methodName, codeLocation
@@ -95,16 +95,16 @@ internal class MethodCallTransformer(
         storeLocal(argumentsArrayLocal)
         loadLocal(argumentsArrayLocal)
         invokeStatic(Injections::onMethodCall)
-        
+
         val deterministicMethodDescriptor = newLocal(OBJECT_TYPE)
         storeLocal(deterministicMethodDescriptor)
-        
+
         val deterministicCallIdLocal = newLocal(LONG_TYPE)
         pushDeterministicCallId(deterministicMethodDescriptor)
         storeLocal(deterministicCallIdLocal)
-        
+
         invokeBeforeEventIfPluginEnabled("method call $methodName", setMethodEventId = true)
-        
+
         tryCatchFinally(
             tryBlock = {
                 val returnType = getReturnType(desc)
@@ -143,7 +143,7 @@ internal class MethodCallTransformer(
             }
         )
     }
-    
+
     private fun GeneratorAdapter.pushDeterministicCallId(deterministicMethodDescriptor: Int) {
         if (!isInTraceDebuggerMode) {
             push(0L)
@@ -160,7 +160,7 @@ internal class MethodCallTransformer(
         push(0L)
         visitLabel(endIf)
     }
-    
+
     private fun GeneratorAdapter.invokeMethodOrDeterministicCall(
         deterministicMethodDescriptor: Int, deterministicCallIdLocal: Int, returnType: Type,
         receiverLocal: Int?, parametersLocal: Int,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -38,7 +38,7 @@ internal class MethodCallTransformer(
             visitMethodInsn(opcode, owner, name, desc, itf)
             return
         }
-        if (isCoroutineInternalClass(owner)) {
+        if (isCoroutineInternalClass(owner.toCanonicalClassName())) {
             invokeInIgnoredSection {
                 visitMethodInsn(opcode, owner, name, desc, itf)
             }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -10,7 +10,6 @@
 
 package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
-import org.jetbrains.kotlinx.lincheck.canonicalClassName
 import org.jetbrains.kotlinx.lincheck.isInTraceDebuggerMode
 import org.jetbrains.kotlinx.lincheck.transformation.*
 import org.objectweb.asm.Opcodes.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ObjectCreationTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ObjectCreationTransformer.kt
@@ -12,7 +12,6 @@ package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
 import sun.nio.ch.lincheck.*
 import org.jetbrains.kotlinx.lincheck.transformation.*
-import org.jetbrains.kotlinx.lincheck.*
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
 import org.objectweb.asm.commons.GeneratorAdapter
@@ -126,7 +125,7 @@ internal class ObjectCreationTransformer(
             invokeIfInTestingCode(
                 original = {},
                 code = {
-                    push(type.canonicalClassName)
+                    push(type.toCanonicalClassName())
                     invokeStatic(Injections::beforeNewObjectCreation)
                 }
             )

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
@@ -53,7 +53,7 @@ internal class SharedMemoryAccessTransformer(
                     code = {
                         // STACK: <empty>
                         pushNull()
-                        push(owner)
+                        push(owner.toCanonicalClassName())
                         push(fieldName)
                         loadNewCodeLocationId()
                         push(true) // isStatic
@@ -86,7 +86,7 @@ internal class SharedMemoryAccessTransformer(
                         // STACK: obj
                         dup()
                         // STACK: obj, obj
-                        push(owner)
+                        push(owner.toCanonicalClassName())
                         push(fieldName)
                         loadNewCodeLocationId()
                         push(false) // isStatic
@@ -122,7 +122,7 @@ internal class SharedMemoryAccessTransformer(
                         copyLocal(valueLocal)
                         // STACK: value
                         pushNull()
-                        push(owner)
+                        push(owner.toCanonicalClassName())
                         push(fieldName)
                         loadLocal(valueLocal)
                         box(valueType)
@@ -160,7 +160,7 @@ internal class SharedMemoryAccessTransformer(
                         // STACK: obj
                         dup()
                         // STACK: obj, obj
-                        push(owner)
+                        push(owner.toCanonicalClassName())
                         push(fieldName)
                         loadLocal(valueLocal)
                         box(valueType)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
@@ -34,8 +34,8 @@ internal class SharedMemoryAccessTransformer(
 
     override fun visitFieldInsn(opcode: Int, owner: String, fieldName: String, desc: String) = adapter.run {
         if (
-            isCoroutineInternalClass(owner) ||
-            isCoroutineStateMachineClass(owner) ||
+            isCoroutineInternalClass(owner.toCanonicalClassName()) ||
+            isCoroutineStateMachineClass(owner.toCanonicalClassName()) ||
             // when initializing our own fields in constructor, we do not want to track that;
             // otherwise `VerifyError` will be thrown, see https://github.com/JetBrains/lincheck/issues/424
             (methodName == "<init>" && className == owner)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/util/TestUtils.kt
@@ -204,7 +204,9 @@ fun checkTraceHasNoLincheckEvents(trace: String) {
 }
 
 fun checkFailureIsNotLincheckInternalBug(failure: LincheckFailure) {
-    check("You've caught a bug in Lincheck." !in failure.toString()) { "Internal Lincheck bug was detected\n$failure" }
+    check("You've caught a bug in Lincheck." !in failure.toString()) {
+        "Internal Lincheck bug was detected\n$failure"
+    }
 }
 
 /**


### PR DESCRIPTION
Currently in the code base two different formats of JVM class names are used: internal and canonical class names. 

Internal class names are primarily used in the `transformation` module in conjunctions with ASM library and other bytecode instrumentation facilities. Other modules of code actively use Java Reflection API and other APIs that expect class names to be given in canonical class names format. 

However, currently in the code base internal class names are leaked from `transformation` module, which sometimes leads to hard-to-spot bugs. 

The solution to the problem is to accept the convention to never leak class names in internal format beyond `transformation` module, and always perform the conversions on the boundaries of `transformation` module. This PR implements this policy. 

This PR addresses #328.

**Alternatives considered.**

There was an idea to use `typealias` or `inline value class` features of Kotlin to distinguish between internal and canonical class name types. After some considerations, it was decided to not implement these approaches. 

- `typealias`  can give more meaningful names to types and help to distinguish two class name formats for code reader. But it would not prevent bugs, e.g. passing `InternalClassName` into a function expecting `CanonicalClassName`. However it would still require substantial refactoring effort to change the type names in a lot of places. 

- `inline value class` would help to prevent accidental bugs. However, we need to interop with Java libraries such as ASM and ByteBuddy, which would not handle Kotlin's inline value classes out-of-the-box. Writing an integration-layer APIs to interop our value classes with these libraries also seems like a substantial effort. 