### PR TITLE
Ignored sections implementation cleanup

### DIFF
--- a/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
@@ -70,9 +70,11 @@ public interface EventTracker {
     void afterLocalRead(int codeLocation, String name, Object value);
     void afterLocalWrite(int codeLocation, String name, Object value);
 
-    Object onMethodCall(Object owner, String className, String methodName, int codeLocation, int methodId, MethodSignature methodSignature, Object[] params);
-    void onMethodCallReturn(long descriptorId, Object descriptor, Object receiver, Object[] params, Object result);
-    void onMethodCallException(long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t);
+    Object onMethodCall(String className, String methodName, int codeLocation, int methodId, MethodSignature methodSignature, Object receiver, Object[] params);
+    void onMethodCallReturn(String className, String methodName, long descriptorId, Object descriptor, Object receiver, Object[] params, Object result);
+    void onMethodCallException(String className, String methodName, long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t);
+
+    BootstrapResult<?> invokeDeterministicallyOrNull(long descriptorId, Object descriptor, Object receiver, Object[] params);
 
     InjectedRandom getThreadLocalRandom();
     int randomNextInt();
@@ -83,6 +85,4 @@ public interface EventTracker {
     void beforeEvent(int eventId, String type);
     int getEventId();
     void setLastMethodCallEventId();
-
-    BootstrapResult<?> invokeDeterministicallyOrNull(long descriptorId, Object descriptor, Object receiver, Object[] params);
 }

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -391,9 +391,7 @@ public class Injections {
      * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
      * @param result The call result.
      */
-    public static void onMethodCallReturn(
-            long descriptorId, Object descriptor, Object receiver, Object[] params, Object result
-    ) {
+    public static void onMethodCallReturn(long descriptorId, Object descriptor, Object receiver, Object[] params, Object result) {
         getEventTracker().onMethodCallReturn(descriptorId, descriptor, receiver, params, result);
     }
 
@@ -405,6 +403,17 @@ public class Injections {
      */
     public static void onMethodCallReturnVoid(long descriptorId, Object descriptor, Object receiver, Object[] params) {
         getEventTracker().onMethodCallReturn(descriptorId, descriptor, receiver, params, VOID_RESULT);
+    }
+
+    /**
+     * Called from the instrumented code after any method call threw an exception
+     *
+     * @param descriptor Deterministic call descriptor or null.
+     * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
+     * @param t Thrown exception.
+     */
+    public static void onMethodCallException(long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t) {
+        getEventTracker().onMethodCallException(descriptorId, descriptor, receiver, params, t);
     }
 
     /**
@@ -431,19 +440,6 @@ public class Injections {
      */
     public static Object getFromOrThrow(BootstrapResult<?> result) throws Throwable {
         return result.getOrThrow();
-    }
-
-    /**
-     * Called from the instrumented code after any method call threw an exception
-     * 
-     * @param descriptor Deterministic call descriptor or null.
-     * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
-     * @param t Thrown exception.
-     */
-    public static void onMethodCallException(
-            long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t
-    ) {
-        getEventTracker().onMethodCallException(descriptorId, descriptor, receiver, params, t);
     }
 
     /**

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -71,13 +71,13 @@ public class Injections {
     public static void enterTestingCode() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;
-        descriptor.enterTestingCode();
+        descriptor.enterAnalyzedCode();
     }
 
     public static void leaveTestingCode() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;
-        descriptor.leaveTestingCode();
+        descriptor.leaveAnalyzedCode();
     }
 
     /**
@@ -112,10 +112,10 @@ public class Injections {
      *
      * @return true if the current thread is inside an ignored section, false otherwise.
      */
-    public static boolean inIgnoredSection() {
+    public static boolean inAnalyzedCode() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
-        if (descriptor == null) return true;
-        return descriptor.inIgnoredSection();
+        if (descriptor == null) return false;
+        return descriptor.inAnalyzedCode();
     }
 
     /**

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -68,16 +68,16 @@ public class Injections {
         }
     }
 
-    public static void enterTestingCode() {
+    public static void enableAnalysis() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;
-        descriptor.enterAnalyzedCode();
+        descriptor.enableAnalysis();
     }
 
-    public static void leaveTestingCode() {
+    public static void disableAnalysis() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;
-        descriptor.leaveAnalyzedCode();
+        descriptor.disableAnalysis();
     }
 
     /**

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -68,12 +68,18 @@ public class Injections {
         }
     }
 
+    /**
+     * Enables analysis for the current thread.
+    */
     public static void enableAnalysis() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;
         descriptor.enableAnalysis();
     }
 
+    /**
+     * Disables analysis for the current thread.
+    */
     public static void disableAnalysis() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
         if (descriptor == null) return;

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -368,10 +368,10 @@ public class Injections {
     /**
      * Called from the instrumented code before any method call.
      *
-     * @param owner is `null` for public static methods.
+     * @param receiver is `null` for public static methods.
      * @return Deterministic call descriptor or null.
      */
-    public static Object onMethodCall(Object owner, String className, String methodName, int codeLocation, int methodId, String methodDesc, Object[] params) {
+    public static Object onMethodCall(String className, String methodName, int codeLocation, int methodId, String methodDesc, Object receiver, Object[] params) {
         // to safely construct the method signature we need to enter ignored section
         // because it internally calls code which has instrumentation
         boolean entered = enterIgnoredSection();
@@ -381,7 +381,7 @@ public class Injections {
         } finally {
             if (entered) leaveIgnoredSection();
         }
-        return getEventTracker().onMethodCall(owner, className, methodName, codeLocation, methodId, methodSignature, params);
+        return getEventTracker().onMethodCall(className, methodName, codeLocation, methodId, methodSignature, receiver, params);
     }
 
     /**
@@ -391,8 +391,8 @@ public class Injections {
      * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
      * @param result The call result.
      */
-    public static void onMethodCallReturn(long descriptorId, Object descriptor, Object receiver, Object[] params, Object result) {
-        getEventTracker().onMethodCallReturn(descriptorId, descriptor, receiver, params, result);
+    public static void onMethodCallReturn(String className, String methodName, long descriptorId, Object descriptor, Object receiver, Object[] params, Object result) {
+        getEventTracker().onMethodCallReturn(className, methodName, descriptorId, descriptor, receiver, params, result);
     }
 
     /**
@@ -401,8 +401,8 @@ public class Injections {
      * @param descriptor Deterministic call descriptor or null.
      * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
      */
-    public static void onMethodCallReturnVoid(long descriptorId, Object descriptor, Object receiver, Object[] params) {
-        getEventTracker().onMethodCallReturn(descriptorId, descriptor, receiver, params, VOID_RESULT);
+    public static void onMethodCallReturnVoid(String className, String methodName, long descriptorId, Object descriptor, Object receiver, Object[] params) {
+        getEventTracker().onMethodCallReturn(className, methodName, descriptorId, descriptor, receiver, params, VOID_RESULT);
     }
 
     /**
@@ -412,8 +412,8 @@ public class Injections {
      * @param descriptorId Deterministic call descriptor id when applicable, or any other value otherwise.
      * @param t Thrown exception.
      */
-    public static void onMethodCallException(long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t) {
-        getEventTracker().onMethodCallException(descriptorId, descriptor, receiver, params, t);
+    public static void onMethodCallException(String className, String methodName, long descriptorId, Object descriptor, Object receiver, Object[] params, Throwable t) {
+        getEventTracker().onMethodCallException(className, methodName, descriptorId, descriptor, receiver, params, t);
     }
 
     /**

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -91,8 +91,8 @@ public class Injections {
      * A code inside the ignored section is not analyzed by the Lincheck.
      *
      * <p>
-     * Has no effect on if the current thread is untracked,
-     * that is not registered in the Lincheck strategy.
+     * Does not affect the current thread if it is untracked
+     * (e.g. not registered in the Lincheck strategy).
      */
     public static void enterIgnoredSection() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
@@ -104,8 +104,8 @@ public class Injections {
      * Leaves an ignored section for the current thread.
      *
      * <p>
-     * Has no effect on if the current thread is untracked,
-     * that is not registered in the Lincheck strategy.
+     * Does not affect the current thread if it is untracked
+     * (e.g. not registered in the Lincheck strategy).
      */
     public static void leaveIgnoredSection() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -64,13 +64,16 @@ public class ThreadDescriptor {
     private boolean inTestingCode = false;
 
     /**
-     * This flag is used to disable tracking of all events.
+     * Counter keeping track of the ignored section re-entrance depth.
+     * <p>
+     *
+     * Ignored section is used to disable tracking of all events.
      *
      * <p>
-     * If Lincheck enters a code block for which analysis should be disabled, this flag is set to `true`.
-     * Notably, such code blocks can be nested, but only the outermost one changes the flag.
+     * If Lincheck enters a code block for which analysis should be disabled,
+     * it should increment the counter.
      */
-    private boolean inIgnoredSection = false;
+    private int ignoredSectionDepth = 0;
 
     public ThreadDescriptor(Thread thread) {
         if (thread == null) {
@@ -100,17 +103,25 @@ public class ThreadDescriptor {
     }
 
     public boolean inIgnoredSection() {
-        return !inTestingCode || inIgnoredSection;
+        return !inTestingCode || (ignoredSectionDepth > 0);
     }
 
-    public boolean enterIgnoredSection() {
-        if (inIgnoredSection) return false;
-        inIgnoredSection = true;
-        return true;
+    public void enterIgnoredSection() {
+        ignoredSectionDepth++;
     }
 
     public void leaveIgnoredSection() {
-        inIgnoredSection = false;
+        ignoredSectionDepth--;
+    }
+
+    public int saveIgnoredSectionDepth() {
+        int depth = ignoredSectionDepth;
+        ignoredSectionDepth = 0;
+        return depth;
+    }
+
+    public void restoreIgnoredSectionDepth(int depth) {
+        ignoredSectionDepth = depth;
     }
 
     public boolean inTestingCode() {

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -59,19 +59,13 @@ public class ThreadDescriptor {
     private WeakReference<Object> eventTrackerData = null;
 
     /**
-     * This flag indicates whether the Lincheck is currently running analyzed test code.
+     * This flag indicates whether the Lincheck is currently running analyzed code.
      */
-    private boolean inTestingCode = false;
+    private boolean inAnalyzedCode = false;
 
     /**
      * Counter keeping track of the ignored section re-entrance depth.
-     * <p>
-     *
-     * Ignored section is used to disable tracking of all events.
-     *
-     * <p>
-     * If Lincheck enters a code block for which analysis should be disabled,
-     * it should increment the counter.
+     * Ignored section is used to temporarily disable tracking of all events.
      */
     private int ignoredSectionDepth = 0;
 
@@ -102,8 +96,20 @@ public class ThreadDescriptor {
         this.eventTrackerData = new WeakReference<>(eventTrackerData);
     }
 
+    public boolean inAnalyzedCode() {
+        return inAnalyzedCode && (ignoredSectionDepth == 0);
+    }
+
+    public void enterAnalyzedCode() {
+        inAnalyzedCode = true;
+    }
+
+    public void leaveAnalyzedCode() {
+        inAnalyzedCode = false;
+    }
+
     public boolean inIgnoredSection() {
-        return !inTestingCode || (ignoredSectionDepth > 0);
+        return ignoredSectionDepth > 0;
     }
 
     public void enterIgnoredSection() {
@@ -122,18 +128,6 @@ public class ThreadDescriptor {
 
     public void restoreIgnoredSectionDepth(int depth) {
         ignoredSectionDepth = depth;
-    }
-
-    public boolean inTestingCode() {
-        return inTestingCode;
-    }
-
-    public void enterTestingCode() {
-        inTestingCode = true;
-    }
-
-    public void leaveTestingCode() {
-        inTestingCode = false;
     }
 
     /*

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -136,7 +136,7 @@ public class ThreadDescriptor {
      *
      * <p>
      * Ignored sections are re-entrant, meaning the thread may enter
-     * the ignored section multiple times before exiting it
+     * the ignored section multiple times before exiting it.
      */
     public void enterIgnoredSection() {
         ignoredSectionDepth++;

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/ExecutionClassLoader.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/ExecutionClassLoader.kt
@@ -11,6 +11,7 @@
 package org.jetbrains.kotlinx.lincheck
 
 import org.jetbrains.kotlinx.lincheck.runner.TestThreadExecution
+import org.jetbrains.kotlinx.lincheck.util.*
 
 /**
  * This classloader is mostly used by runner to separate parallel iterations,
@@ -22,11 +23,11 @@ class ExecutionClassLoader : ClassLoader() {
         return super.defineClass(className, bytecode, 0, bytecode.size) as Class<out TestThreadExecution?>
     }
 
-    override fun loadClass(name: String?): Class<*> = runInIgnoredSection {
+    override fun loadClass(name: String?): Class<*> = runInsideIgnoredSection {
         return super.loadClass(name)
     }
 
-    override fun loadClass(name: String?, resolve: Boolean): Class<*> = runInIgnoredSection {
+    override fun loadClass(name: String?, resolve: Boolean): Class<*> = runInsideIgnoredSection {
         return super.loadClass(name, resolve)
     }
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -268,14 +268,12 @@ internal inline fun<R> ExecutionClassLoader.runInIgnoredSection(block: () -> R):
     runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
 
 internal inline fun <R> runInIgnoredSection(descriptor: ThreadDescriptor?, block: () -> R): R {
-    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy)
-        return block()
-    if (descriptor.inIgnoredSection()) {
+    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
         return block()
     }
     descriptor.enterIgnoredSection()
-    return try {
-        block()
+    try {
+        return block()
     } finally {
         descriptor.leaveIgnoredSection()
     }
@@ -291,14 +289,15 @@ internal inline fun <R> ParallelThreadsRunner.runOutsideIgnoredSection(block: ()
  * This method **must** be called in an ignored section.
  */
 internal inline fun <R> runOutsideIgnoredSection(descriptor: ThreadDescriptor?, block: () -> R): R {
-    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy)
+    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
         return block()
+    }
     check(descriptor.inIgnoredSection()) {
         "Current thread must be in ignored section"
     }
     val depth = descriptor.saveIgnoredSectionDepth()
-    return try {
-        block()
+    try {
+        return block()
     } finally {
         descriptor.restoreIgnoredSectionDepth(depth)
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -294,7 +294,7 @@ internal inline fun <R> runOutsideIgnoredSection(descriptor: ThreadDescriptor?, 
     check(descriptor.inIgnoredSection()) {
         "Current thread must be in ignored section"
     }
-    val depth = descriptor.saveIgnoredSectionDepth()
+    val depth = descriptor.saveAndResetIgnoredSectionDepth()
     try {
         return block()
     } finally {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -152,7 +152,7 @@ internal class StoreExceptionHandler :
 internal fun <T> CancellableContinuation<T>.cancelByLincheck(promptCancellation: Boolean): CancellationResult {
     val exceptionHandler = context[CoroutineExceptionHandler] as StoreExceptionHandler
     exceptionHandler.exception = null
-    val cancelled = runOutsideIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor()) {
+    val cancelled = runOutsideIgnoredSection {
         cancel(cancellationByLincheckException)
     }
     exceptionHandler.exception?.let {
@@ -242,65 +242,6 @@ internal fun Class<*>.findField(fieldName: String): Field {
  * Thrown in case when `cause` exception is unexpected by Lincheck internal logic.
  */
 internal class LincheckInternalBugException(cause: Throwable): Exception(cause)
-
-// We use receivers for `runInIgnoredSection` to not use these functions
-// accidentally instead of `invokeInIgnoredSection` in the transformation logic.
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun<R> FixedActiveThreadsExecutor.runInIgnoredSection(block: () -> R): R =
-    runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun<R> ParallelThreadsRunner.runInIgnoredSection(block: () -> R): R =
-    runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun<R> LincheckClassFileTransformer.runInIgnoredSection(block: () -> R): R =
-    runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun<R> EventTracker.runInIgnoredSection(block: () -> R): R =
-    runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun<R> ExecutionClassLoader.runInIgnoredSection(block: () -> R): R =
-    runInIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-internal inline fun <R> runInIgnoredSection(descriptor: ThreadDescriptor?, block: () -> R): R {
-    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
-        return block()
-    }
-    descriptor.enterIgnoredSection()
-    try {
-        return block()
-    } finally {
-        descriptor.leaveIgnoredSection()
-    }
-}
-
-@Suppress("UnusedReceiverParameter")
-internal inline fun <R> ParallelThreadsRunner.runOutsideIgnoredSection(block: () -> R) =
-    runOutsideIgnoredSection(ThreadDescriptor.getCurrentThreadDescriptor(), block)
-
-/**
- * Exits the ignored section and invokes the provided [block] outside the ignored section,
- * entering the ignored section back after the [block] is executed.
- * This method **must** be called in an ignored section.
- */
-internal inline fun <R> runOutsideIgnoredSection(descriptor: ThreadDescriptor?, block: () -> R): R {
-    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
-        return block()
-    }
-    check(descriptor.inIgnoredSection()) {
-        "Current thread must be in ignored section"
-    }
-    val depth = descriptor.saveAndResetIgnoredSectionDepth()
-    try {
-        return block()
-    } finally {
-        descriptor.restoreIgnoredSectionDepth(depth)
-    }
-}
 
 internal const val LINCHECK_PACKAGE_NAME = "org.jetbrains.kotlinx.lincheck."
 internal const val LINCHECK_RUNNER_PACKAGE_NAME = "org.jetbrains.kotlinx.lincheck.runner."

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -273,7 +273,7 @@ internal inline fun <R> runInIgnoredSection(descriptor: ThreadDescriptor?, block
     if (descriptor.inIgnoredSection()) {
         return block()
     }
-    descriptor.enterIgnoredSection().ensureTrue()
+    descriptor.enterIgnoredSection()
     return try {
         block()
     } finally {
@@ -296,11 +296,11 @@ internal inline fun <R> runOutsideIgnoredSection(descriptor: ThreadDescriptor?, 
     check(descriptor.inIgnoredSection()) {
         "Current thread must be in ignored section"
     }
-    descriptor.leaveIgnoredSection()
+    val depth = descriptor.saveIgnoredSectionDepth()
     return try {
         block()
     } finally {
-        descriptor.enterIgnoredSection().ensureTrue()
+        descriptor.restoreIgnoredSectionDepth(depth)
     }
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.*
 import org.jetbrains.kotlinx.lincheck.runner.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckClassFileTransformer
-import org.jetbrains.kotlinx.lincheck.util.readFieldViaUnsafe
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.jetbrains.kotlinx.lincheck.util.*
 import sun.nio.ch.lincheck.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -10,7 +10,6 @@
 package org.jetbrains.kotlinx.lincheck.runner
 
 import kotlinx.atomicfu.*
-import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.util.*
 import sun.nio.ch.lincheck.TestThread
@@ -161,7 +160,7 @@ internal class FixedActiveThreadsExecutor(private val testName: String, private 
 
     private fun testThreadRunnable(iThread: Int) = Runnable {
         loop@ while (true) {
-            val task = runInIgnoredSection {
+            val task = runInsideIgnoredSection {
                 val task = getTask(iThread)
                 if (task === Shutdown) return@Runnable
                 tasks[iThread].value = null // reset task
@@ -171,10 +170,10 @@ internal class FixedActiveThreadsExecutor(private val testName: String, private 
             try {
                 task.run()
             } catch(e: Throwable) {
-                runInIgnoredSection { setResult(iThread, e) }
+                runInsideIgnoredSection { setResult(iThread, e) }
                 continue@loop
             }
-            runInIgnoredSection { setResult(iThread, Done) }
+            runInsideIgnoredSection { setResult(iThread, Done) }
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -101,7 +101,7 @@ internal open class ParallelThreadsRunner(
 
         // We need to run this code in an ignored section,
         // as it is called in the testing code but should not be analyzed.
-        override fun resumeWith(result: kotlin.Result<Any?>) = runInIgnoredSection {
+        override fun resumeWith(result: kotlin.Result<Any?>) = runInsideIgnoredSection {
             // decrement completed or suspended threads only if the operation was not cancelled and
             // the continuation was not intercepted; it was already decremented before writing `resWithCont` otherwise
             if (!result.cancelledByLincheck()) {
@@ -134,9 +134,9 @@ internal open class ParallelThreadsRunner(
 
             // We need to run this code in an ignored section,
             // as it is called in the testing code but should not be analyzed.
-            override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = runInIgnoredSection {
+            override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> = runInsideIgnoredSection {
                 return Continuation(StoreExceptionHandler() + Job()) { result ->
-                    runInIgnoredSection {
+                    runInsideIgnoredSection {
                         // decrement completed or suspended threads only if the operation was not cancelled
                         if (!result.cancelledByLincheck()) {
                             completedOrSuspendedThreads.decrementAndGet()
@@ -202,7 +202,7 @@ internal open class ParallelThreadsRunner(
      * Otherwise if the invoked actor completed without suspension, then it just writes it's final result.
      */
     @Suppress("unused")
-    fun processInvocationResult(res: Any?, iThread: Int, actorId: Int): Result = runInIgnoredSection {
+    fun processInvocationResult(res: Any?, iThread: Int, actorId: Int): Result = runInsideIgnoredSection {
         val actor = scenario.parallelExecution[iThread][actorId]
         val finalResult = if (res === COROUTINE_SUSPENDED) {
             val thread = Thread.currentThread() as TestThread
@@ -226,7 +226,7 @@ internal open class ParallelThreadsRunner(
 
     // We need to run this code in an ignored section,
     // as it is called in the testing code but should not be analyzed.
-    private fun waitAndInvokeFollowUp(thread: TestThread, actorId: Int): Result = runInIgnoredSection {
+    private fun waitAndInvokeFollowUp(thread: TestThread, actorId: Int): Result = runInsideIgnoredSection {
         val threadId = thread.threadId
         // Coroutine is suspended. Call method so that strategy can learn it.
         afterCoroutineSuspended(threadId)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/LoopDetector.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/LoopDetector.kt
@@ -119,9 +119,11 @@ internal class LoopDetector(
      * Should be called only in replay mode.
      */
     val replayModeCurrentlyInSpinCycle: Boolean get() =
-        replayModeLoopDetectorHelper!!.currentlyInSpinCycle
+        replayModeLoopDetectorHelper?.currentlyInSpinCycle ?: false
 
     fun enableReplayMode(failDueToDeadlockInTheEnd: Boolean) {
+        if (isInTraceDebuggerMode) return
+
         val contextSwitchesBeforeHalt =
             findMaxPrefixLengthWithNoCycleOnSuffix(currentInterleavingHistory)?.let { it.executionsBeforeCycle + it.cyclePeriod }
                 ?: currentInterleavingHistory.size

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -547,7 +547,7 @@ abstract class ManagedStrategy(
         // scenario threads are handled separately
         if (currentThreadId < scenario.nThreads) return
         onThreadStart(currentThreadId)
-        enterTestingCode()
+        enableAnalysis()
     }
 
     override fun afterThreadFinish() = runInIgnoredSection {
@@ -556,7 +556,7 @@ abstract class ManagedStrategy(
         if (currentThreadId < 0) return
         // scenario threads are handled separately by the runner itself
         if (currentThreadId < scenario.nThreads) return
-        leaveTestingCode()
+        disableAnalysis()
         onThreadFinish(currentThreadId)
     }
 
@@ -683,7 +683,7 @@ abstract class ManagedStrategy(
         check(isInternalException(exception))
         // This method is called only if the exception cannot be treated as a normal result,
         // so we exit testing code to avoid trace collection resume or some bizarre bugs
-        leaveTestingCode()
+        disableAnalysis()
         // suppress `ThreadAbortedError`
         if (exception is LincheckAnalysisAbortedError) return
         // Though the corresponding failure will be detected by the runner,
@@ -703,7 +703,7 @@ abstract class ManagedStrategy(
         callStackTrace[iThread]!!.clear()
         suspendedFunctionsStack[iThread]!!.clear()
         loopDetector.onActorStart(iThread)
-        enterTestingCode()
+        enableAnalysis()
     }
 
     override fun onActorFinish() {
@@ -711,7 +711,7 @@ abstract class ManagedStrategy(
         // When stepping out to the TestThreadExecution class, stepping continues unproductively.
         // With this method, we force the debugger to stop at the beginning of the next actor.
         onThreadSwitchesOrActorFinishes()
-        leaveTestingCode()
+        disableAnalysis()
     }
 
     /**
@@ -1200,12 +1200,12 @@ abstract class ManagedStrategy(
         return (threadDescriptor.eventTracker === this)
     }
 
-    protected fun enterTestingCode() {
-        return Injections.enterTestingCode()
+    protected fun enableAnalysis() {
+        return Injections.enableAnalysis()
     }
 
-    protected fun leaveTestingCode() {
-        return Injections.leaveTestingCode()
+    protected fun disableAnalysis() {
+        return Injections.disableAnalysis()
     }
 
     protected fun enterIgnoredSection() {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1208,10 +1208,6 @@ abstract class ManagedStrategy(
         return Injections.leaveTestingCode()
     }
 
-    protected fun inIgnoredSection(): Boolean {
-        return Injections.inIgnoredSection()
-    }
-
     protected fun enterIgnoredSection() {
         Injections.enterIgnoredSection()
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1336,7 +1336,7 @@ abstract class ManagedStrategy(
         deterministicMethodDescriptor: DeterministicMethodDescriptor<*, *>?,
     ): ManagedGuaranteeType? {
         if (atomicMethodDescriptor != null) {
-            return ManagedGuaranteeType.TREAT_AS_ATOMIC
+            return ManagedGuaranteeType.ATOMIC
         }
         // TODO: decide if we need to introduce special `DETERMINISTIC` guarantee?
         if (deterministicMethodDescriptor != null) {
@@ -1408,7 +1408,7 @@ abstract class ManagedStrategy(
         // in case of an atomic method, we create a switch point before the method call;
         // note that in case we resume atomic method there is no need to create the switch point,
         // since there is already a switch point between the suspension point and resumption
-        if (guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC &&
+        if (guarantee == ManagedGuaranteeType.ATOMIC &&
             // do not create a trace point on resumption
             !isResumptionMethodCall(threadId, className, methodName, params, atomicMethodDescriptor)
         ) {
@@ -1422,7 +1422,7 @@ abstract class ManagedStrategy(
         }
         // if the method is atomic or should be ignored, then we enter an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.ATOMIC) {
             enterIgnoredSection()
         }
         return deterministicMethodDescriptor
@@ -1472,7 +1472,7 @@ abstract class ManagedStrategy(
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.ATOMIC) {
             leaveIgnoredSection()
         }
     }
@@ -1515,7 +1515,7 @@ abstract class ManagedStrategy(
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.ATOMIC) {
             leaveIgnoredSection()
         }
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -649,6 +649,12 @@ abstract class ManagedStrategy(
     fun getRegisteredThreads(): ThreadMap<Thread> =
         threadScheduler.getRegisteredThreads()
 
+    protected fun isRegisteredThread(): Boolean {
+        val threadDescriptor = ThreadDescriptor.getCurrentThreadDescriptor()
+            ?: return false
+        return (threadDescriptor.eventTracker === this)
+    }
+
     /**
      * This method is executed as the first thread action.
      *
@@ -1000,7 +1006,7 @@ abstract class ManagedStrategy(
      * Returns `true` if a switch point is created.
      */
     override fun beforeReadField(obj: Any?, className: String, fieldName: String, codeLocation: Int,
-                                 isStatic: Boolean, isFinal: Boolean) = runInsideIgnoredSection {
+                                 isStatic: Boolean, isFinal: Boolean): Boolean = runInsideIgnoredSection {
         updateSnapshotOnFieldAccess(obj, className, fieldName)
         // We need to ensure all the classes related to the reading object are instrumented.
         // The following call checks all the static fields.
@@ -1009,11 +1015,11 @@ abstract class ManagedStrategy(
         }
         // Optimization: do not track final field reads
         if (isFinal) {
-            return@runInsideIgnoredSection false
+            return false
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackObjectAccess(obj)) {
-            return@runInsideIgnoredSection false
+            return false
         }
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
@@ -1034,14 +1040,14 @@ abstract class ManagedStrategy(
         }
         newSwitchPoint(iThread, codeLocation, tracePoint)
         loopDetector.beforeReadField(obj)
-        return@runInsideIgnoredSection true
+        return true
     }
 
     /** Returns <code>true</code> if a switch point is created. */
     override fun beforeReadArrayElement(array: Any, index: Int, codeLocation: Int): Boolean = runInsideIgnoredSection {
         updateSnapshotOnArrayElementAccess(array, index)
         if (!shouldTrackObjectAccess(array)) {
-            return@runInsideIgnoredSection false
+            return false
         }
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
@@ -1062,14 +1068,14 @@ abstract class ManagedStrategy(
         }
         newSwitchPoint(iThread, codeLocation, tracePoint)
         loopDetector.beforeReadArrayElement(array, index)
-        true
+        return true
     }
 
     override fun afterRead(value: Any?) = runInsideIgnoredSection {
         if (collectTrace) {
-                val iThread = threadScheduler.getCurrentThreadId()
-                lastReadTracePoint[iThread]?.initializeReadValue(adornedStringRepresentation(value), objectFqTypeName(value))
-                lastReadTracePoint[iThread] = null
+            val iThread = threadScheduler.getCurrentThreadId()
+            lastReadTracePoint[iThread]?.initializeReadValue(adornedStringRepresentation(value), objectFqTypeName(value))
+            lastReadTracePoint[iThread] = null
         }
         loopDetector.afterRead(value)
     }
@@ -1079,11 +1085,11 @@ abstract class ManagedStrategy(
         updateSnapshotOnFieldAccess(obj, className, fieldName)
         objectTracker?.registerObjectLink(fromObject = obj ?: StaticObject, toObject = value)
         if (!shouldTrackObjectAccess(obj)) {
-            return@runInsideIgnoredSection false
+            return false
         }
         // Optimization: do not track final field writes
         if (isFinal) {
-            return@runInsideIgnoredSection false
+            return false
         }
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
@@ -1103,14 +1109,14 @@ abstract class ManagedStrategy(
         }
         newSwitchPoint(iThread, codeLocation, tracePoint)
         loopDetector.beforeWriteField(obj, value)
-        return@runInsideIgnoredSection true
+        return true
     }
 
     override fun beforeWriteArrayElement(array: Any, index: Int, value: Any?, codeLocation: Int): Boolean = runInsideIgnoredSection {
         updateSnapshotOnArrayElementAccess(array, index)
         objectTracker?.registerObjectLink(fromObject = array, toObject = value)
         if (!shouldTrackObjectAccess(array)) {
-            return@runInsideIgnoredSection false
+            return false
         }
         val iThread = threadScheduler.getCurrentThreadId()
         val tracePoint = if (collectTrace) {
@@ -1193,28 +1199,6 @@ abstract class ManagedStrategy(
 
     override fun randomNextInt(): Int = runInsideIgnoredSection {
         getThreadLocalRandom().nextInt()
-    }
-
-    protected fun isRegisteredThread(): Boolean {
-        val threadDescriptor = ThreadDescriptor.getCurrentThreadDescriptor()
-            ?: return false
-        return (threadDescriptor.eventTracker === this)
-    }
-
-    protected fun enableAnalysis() {
-        return Injections.enableAnalysis()
-    }
-
-    protected fun disableAnalysis() {
-        return Injections.disableAnalysis()
-    }
-
-    protected fun enterIgnoredSection() {
-        Injections.enterIgnoredSection()
-    }
-
-    protected fun leaveIgnoredSection() {
-        Injections.leaveIgnoredSection()
     }
 
     override fun beforeNewObjectCreation(className: String) = runInsideIgnoredSection {
@@ -1372,72 +1356,67 @@ abstract class ManagedStrategy(
         methodSignature: MethodSignature,
         receiver: Any?,
         params: Array<Any?>
-    ): Any? {
-        val guarantee = runInsideIgnoredSection {
-            // process method effect on the static memory snapshot
-            processMethodEffectOnStaticSnapshot(receiver, params)
-            // re-throw abort error if the thread was aborted
-            val threadId = threadScheduler.getCurrentThreadId()
-            if (threadScheduler.isAborted(threadId)) {
-                threadScheduler.abortCurrentThread()
-            }
-            // check if the called method is an atomics API method
-            // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
-            val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
-            // get method's concurrency guarantee
-            val guarantee = when {
-                (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
-                else -> methodGuaranteeType(receiver, className, methodName)
-            }
-            // in case if a static method is called, ensure its class is instrumented
-            if (receiver == null && atomicMethodDescriptor == null && guarantee == null) { // static method
-                LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
-            }
-            // in case of atomics API setter method call, notify the object tracker about a new link between objects
-            if (atomicMethodDescriptor != null && atomicMethodDescriptor.kind.isSetter) {
-                objectTracker?.registerObjectLink(
-                    fromObject = atomicMethodDescriptor.getAccessedObject(receiver!!, params),
-                    toObject = atomicMethodDescriptor.getSetValue(receiver, params)
-                )
-            }
-            // check for livelock and create the method call trace point
-            if (collectTrace) {
-                traceCollector!!.checkActiveLockDetected()
-                addBeforeMethodCallTracePoint(threadId, receiver, codeLocation, methodId, className, methodName, params,
-                    atomicMethodDescriptor
-                )
-            }
-            // in case of an atomic method, we create a switch point before the method call;
-            // note that in case we resume atomic method there is no need to create the switch point,
-            // since there is already a switch point between the suspension point and resumption
-            if (guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC &&
-                // do not create a trace point on resumption
-                !isResumptionMethodCall(threadId, className, methodName, params, atomicMethodDescriptor)
-            ) {
-                // re-use last call trace point
-                newSwitchPoint(threadId, codeLocation, callStackTrace[threadId]!!.lastOrNull()?.tracePoint)
-                loopDetector.passParameters(params)
-            }
-            // notify loop detector about the method call
-            if (guarantee == null) {
-                loopDetector.beforeMethodCall(codeLocation, params)
-            }
-            // method's guarantee
-            guarantee
+    ): Any? = runInsideIgnoredSection {
+        // process method effect on the static memory snapshot
+        processMethodEffectOnStaticSnapshot(receiver, params)
+        // re-throw abort error if the thread was aborted
+        val threadId = threadScheduler.getCurrentThreadId()
+        if (threadScheduler.isAborted(threadId)) {
+            threadScheduler.abortCurrentThread()
         }
+        // check if the called method is an atomics API method
+        // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
+        val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
+        // get method's concurrency guarantee
+        val guarantee = when {
+            (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
+            else -> methodGuaranteeType(receiver, className, methodName)
+        }
+        // in case if a static method is called, ensure its class is instrumented
+        if (receiver == null && atomicMethodDescriptor == null && guarantee == null) { // static method
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
+        }
+        // in case of atomics API setter method call, notify the object tracker about a new link between objects
+        if (atomicMethodDescriptor != null && atomicMethodDescriptor.kind.isSetter) {
+            objectTracker?.registerObjectLink(
+                fromObject = atomicMethodDescriptor.getAccessedObject(receiver!!, params),
+                toObject = atomicMethodDescriptor.getSetValue(receiver, params)
+            )
+        }
+        // check for livelock and create the method call trace point
+        if (collectTrace) {
+            traceCollector!!.checkActiveLockDetected()
+            addBeforeMethodCallTracePoint(threadId, receiver, codeLocation, methodId, className, methodName, params,
+                atomicMethodDescriptor
+            )
+        }
+        // in case of an atomic method, we create a switch point before the method call;
+        // note that in case we resume atomic method there is no need to create the switch point,
+        // since there is already a switch point between the suspension point and resumption
+        if (guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC &&
+            // do not create a trace point on resumption
+            !isResumptionMethodCall(threadId, className, methodName, params, atomicMethodDescriptor)
+        ) {
+            // re-use last call trace point
+            newSwitchPoint(threadId, codeLocation, callStackTrace[threadId]!!.lastOrNull()?.tracePoint)
+            loopDetector.passParameters(params)
+        }
+        // notify loop detector about the method call
+        if (guarantee == null) {
+            loopDetector.beforeMethodCall(codeLocation, params)
+        }
+        // obtain deterministic method descriptor if required
+        val methodCallInfo = MethodCallInfo(
+            ownerType = Types.ObjectType(className),
+            methodSignature = methodSignature,
+            codeLocation = codeLocation,
+            methodId = methodId,
+        )
+        val deterministicMethodDescriptor = getDeterministicMethodDescriptorOrNull(methodCallInfo)
         // if the method is atomic or should be ignored, then we enter an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
             guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
             enterIgnoredSection()
-        }
-        val deterministicMethodDescriptor = runInsideIgnoredSection {
-            val methodCallInfo = MethodCallInfo(
-                ownerType = Types.ObjectType(className),
-                methodSignature = methodSignature,
-                codeLocation = codeLocation,
-                methodId = methodId,
-            )
-            getDeterministicMethodDescriptorOrNull(methodCallInfo)
         }
         return deterministicMethodDescriptor
     }
@@ -1450,31 +1429,29 @@ abstract class ManagedStrategy(
         receiver: Any?,
         params: Array<Any?>,
         result: Any?
-    ) {
-        val guarantee = runInsideIgnoredSection {
-            if (isInTraceDebuggerMode && isFirstReplay && descriptor != null) {
-                require(descriptor is DeterministicMethodDescriptor<*, *>)
-                descriptor.saveFirstResultWithCast(receiver, params, KResult.success(result)) {
-                    nativeMethodCallStatesTracker.setState(descriptorId, descriptor.methodCallInfo, it)
-                }
+    ) = runInsideIgnoredSection {
+        if (isInTraceDebuggerMode && isFirstReplay && descriptor != null) {
+            require(descriptor is DeterministicMethodDescriptor<*, *>)
+            descriptor.saveFirstResultWithCast(receiver, params, KResult.success(result)) {
+                nativeMethodCallStatesTracker.setState(descriptorId, descriptor.methodCallInfo, it)
             }
-            loopDetector.afterMethodCall()
-            val threadId = threadScheduler.getCurrentThreadId()
-            // check if the called method is an atomics API method
-            // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
-            val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
-            // get method's concurrency guarantee
-            val guarantee = when {
-                (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
-                else -> methodGuaranteeType(receiver, className, methodName)
-            }
-            if (collectTrace) {
-                // this case is possible and can occur when we resume the coroutine,
-                // and it results in a call to a top-level actor `suspend` function;
-                // currently top-level actor functions are not represented in the `callStackTrace`,
-                // we should probably refactor and fix that, because it is very inconvenient
-                if (callStackTrace[threadId]!!.isEmpty())
-                    return@runInsideIgnoredSection guarantee
+        }
+        loopDetector.afterMethodCall()
+        val threadId = threadScheduler.getCurrentThreadId()
+        // check if the called method is an atomics API method
+        // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
+        val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
+        // get method's concurrency guarantee
+        val guarantee = when {
+            (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
+            else -> methodGuaranteeType(receiver, className, methodName)
+        }
+        if (collectTrace) {
+            // an empty stack trace case is possible and can occur when we resume the coroutine,
+            // and it results in a call to a top-level actor `suspend` function;
+            // currently top-level actor functions are not represented in the `callStackTrace`,
+            // we should probably refactor and fix that, because it is very inconvenient
+            if (callStackTrace[threadId]!!.isNotEmpty()) {
                 val tracePoint = callStackTrace[threadId]!!.last().tracePoint
                 when (result) {
                     Unit -> tracePoint.initializeVoidReturnedValue()
@@ -1485,7 +1462,6 @@ abstract class ManagedStrategy(
                 afterMethodCall(threadId, tracePoint)
                 traceCollector!!.addStateRepresentation()
             }
-            guarantee
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
@@ -1502,39 +1478,33 @@ abstract class ManagedStrategy(
         receiver: Any?,
         params: Array<Any?>,
         throwable: Throwable
-    ) {
+    ) = runInsideIgnoredSection {
         if (isInTraceDebuggerMode && isFirstReplay && descriptor != null) {
             require(descriptor is DeterministicMethodDescriptor<*, *>)
-            runInsideIgnoredSection {
-                descriptor.saveFirstResult(receiver, params, KResult.failure(throwable)) {
-                    nativeMethodCallStatesTracker.setState(descriptorId, descriptor.methodCallInfo, it)
-                }
+            descriptor.saveFirstResult(receiver, params, KResult.failure(throwable)) {
+                nativeMethodCallStatesTracker.setState(descriptorId, descriptor.methodCallInfo, it)
             }
         }
-        val guarantee = runInsideIgnoredSection {
-            loopDetector.afterMethodCall()
-            val threadId = threadScheduler.getCurrentThreadId()
-            // check if the called method is an atomics API method
-            // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
-            val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
-            // get method's concurrency guarantee
-            val guarantee = when {
-                (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
-                else -> methodGuaranteeType(receiver, className, methodName)
-            }
-            if (collectTrace) {
-                // this case is possible and can occur when we resume the coroutine,
-                // and it results in a call to a top-level actor `suspend` function;
-                // currently top-level actor functions are not represented in the `callStackTrace`,
-                // we should probably refactor and fix that, because it is very inconvenient
-                if (callStackTrace[threadId]!!.isEmpty())
-                    return@runInsideIgnoredSection guarantee
-                val tracePoint = callStackTrace[threadId]!!.last().tracePoint
-                tracePoint.initializeThrownException(throwable)
-                afterMethodCall(threadId, tracePoint)
-                traceCollector!!.addStateRepresentation()
-            }
-            guarantee
+        loopDetector.afterMethodCall()
+        val threadId = threadScheduler.getCurrentThreadId()
+        // check if the called method is an atomics API method
+        // (e.g., Atomic classes, AFU, VarHandle memory access API, etc.)
+        val atomicMethodDescriptor = getAtomicMethodDescriptor(receiver, methodName)
+        // get method's concurrency guarantee
+        val guarantee = when {
+            (atomicMethodDescriptor != null) -> ManagedGuaranteeType.TREAT_AS_ATOMIC
+            else -> methodGuaranteeType(receiver, className, methodName)
+        }
+        if (collectTrace) {
+            // this case is possible and can occur when we resume the coroutine,
+            // and it results in a call to a top-level actor `suspend` function;
+            // currently top-level actor functions are not represented in the `callStackTrace`,
+            // we should probably refactor and fix that, because it is very inconvenient
+            if (callStackTrace[threadId]!!.isEmpty()) return
+            val tracePoint = callStackTrace[threadId]!!.last().tracePoint
+            tracePoint.initializeThrownException(throwable)
+            afterMethodCall(threadId, tracePoint)
+            traceCollector!!.addStateRepresentation()
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
@@ -1924,6 +1894,22 @@ abstract class ManagedStrategy(
             suspendedFunctionsStack[iThread]!!.add(callStackTrace.last())
         }
         callStackTrace.removeLast()
+    }
+
+    protected fun enableAnalysis() {
+        return Injections.enableAnalysis()
+    }
+
+    protected fun disableAnalysis() {
+        return Injections.disableAnalysis()
+    }
+
+    protected fun enterIgnoredSection() {
+        Injections.enterIgnoredSection()
+    }
+
+    protected fun leaveIgnoredSection() {
+        Injections.leaveIgnoredSection()
     }
 
     // == LOGGING METHODS ==

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1235,7 +1235,7 @@ abstract class ManagedStrategy(
     private fun Injections.HandlePojo.toAsmHandle(): Handle =
         Handle(tag, owner, name, desc, isInterface)
 
-    override fun getNextTraceDebuggerEventTrackerId(tracker: TraceDebuggerTracker): TraceDebuggerEventId =
+    override fun getNextTraceDebuggerEventTrackerId(tracker: TraceDebuggerTracker): TraceDebuggerEventId = runInsideIgnoredSection {
         traceDebuggerEventTrackers[tracker]?.getNextId() ?: 0
 
     override fun afterNewObjectCreation(obj: Any) {
@@ -1246,10 +1246,8 @@ abstract class ManagedStrategy(
         }
     }
 
-    private fun shouldTrackObjectAccess(obj: Any?): Boolean {
-        // by default, we track accesses to all objects
-        if (objectTracker == null) return true
-        return objectTracker!!.shouldTrackObjectAccess(obj ?: StaticObject)
+    override fun advanceCurrentTraceDebuggerEventTrackerId(tracker: TraceDebuggerTracker, oldId: TraceDebuggerEventId): Unit = runInsideIgnoredSection {
+        traceDebuggerEventTrackers[tracker]?.advanceCurrentId(oldId)
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -478,14 +478,7 @@ abstract class ManagedStrategy(
         // if any kind of live-lock was detected, check for obstruction-freedom violation
         if (decision.isLivelockDetected) {
             failIfObstructionFreedomIsRequired {
-                if (decision is LoopDetector.Decision.LivelockFailureDetected) {
-                    // if failure is detected, add a special obstruction-freedom violation
-                    // trace point to account for that
-                    traceCollector?.passObstructionFreedomViolationTracePoint(iThread, beforeMethodCall = tracePoint is MethodCallTracePoint)
-                } else {
-                    // otherwise log the last event that caused obstruction-freedom violation
-                    traceCollector?.passCodeLocation(tracePoint)
-                }
+                traceCollector?.passObstructionFreedomViolationTracePoint(iThread, beforeMethodCall = tracePoint is MethodCallTracePoint)
                 OBSTRUCTION_FREEDOM_SPINLOCK_VIOLATION_MESSAGE
             }
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1332,7 +1332,7 @@ abstract class ManagedStrategy(
         }
     }
 
-    private fun methodGuaranteeType(owner: Any?, className: String, methodName: String): ManagedGuaranteeType? = runInsideIgnoredSection {
+    private fun methodGuaranteeType(owner: Any?, className: String, methodName: String): ManagedGuaranteeType? {
         userDefinedGuarantees?.forEach { guarantee ->
             val ownerName = owner?.javaClass?.canonicalName ?: className
             if (guarantee.classPredicate(ownerName) && guarantee.methodPredicate(methodName)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1522,13 +1522,15 @@ abstract class ManagedStrategy(
         descriptor: Any?,
         receiver: Any?,
         params: Array<Any?>
-    ): BootstrapResult<*>? = when {
-        descriptor !is DeterministicMethodDescriptor<*, *> -> null
-        !isInTraceDebuggerMode -> descriptor.runFake(receiver, params).toBootstrapResult()
-        isFirstReplay -> null
-        else -> runInsideIgnoredSection {
-            val state = nativeMethodCallStatesTracker.getState(descriptorId, descriptor.methodCallInfo)
-            descriptor.runFromStateWithCast(receiver, params, state).toBootstrapResult()
+    ): BootstrapResult<*>? = runInsideIgnoredSection {
+        when {
+            descriptor !is DeterministicMethodDescriptor<*, *> -> null
+            !isInTraceDebuggerMode -> descriptor.runFake(receiver, params).toBootstrapResult()
+            isFirstReplay -> null
+            else -> {
+                val state = nativeMethodCallStatesTracker.getState(descriptorId, descriptor.methodCallInfo)
+                descriptor.runFromStateWithCast(receiver, params, state).toBootstrapResult()
+            }
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1416,7 +1416,8 @@ abstract class ManagedStrategy(
         val deterministicMethodDescriptor = getDeterministicMethodDescriptorOrNull(methodCallInfo)
         // if the method is atomic or should be ignored, then we enter an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC ||
+            deterministicMethodDescriptor != null) {
             enterIgnoredSection()
         }
         return deterministicMethodDescriptor
@@ -1466,7 +1467,8 @@ abstract class ManagedStrategy(
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC ||
+            descriptor != null) {
             leaveIgnoredSection()
         }
     }
@@ -1509,7 +1511,8 @@ abstract class ManagedStrategy(
         }
         // if the method is atomic or ignored, then we leave an ignored section
         if (guarantee == ManagedGuaranteeType.IGNORE ||
-            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC) {
+            guarantee == ManagedGuaranteeType.TREAT_AS_ATOMIC ||
+            descriptor != null) {
             leaveIgnoredSection()
         }
     }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1896,22 +1896,6 @@ abstract class ManagedStrategy(
         callStackTrace.removeLast()
     }
 
-    protected fun enableAnalysis() {
-        return Injections.enableAnalysis()
-    }
-
-    protected fun disableAnalysis() {
-        return Injections.disableAnalysis()
-    }
-
-    protected fun enterIgnoredSection() {
-        Injections.enterIgnoredSection()
-    }
-
-    protected fun leaveIgnoredSection() {
-        Injections.leaveIgnoredSection()
-    }
-
     // == LOGGING METHODS ==
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyGuarantee.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyGuarantee.kt
@@ -73,11 +73,11 @@ class ManagedStrategyGuarantee private constructor(
          * In contract with the [ignore] mode, switch points are added right before and after the
          * specified method calls.
          */
-        fun treatAsAtomic() = ManagedStrategyGuarantee(classPredicate, methodPredicate, ManagedGuaranteeType.TREAT_AS_ATOMIC)
+        fun treatAsAtomic() = ManagedStrategyGuarantee(classPredicate, methodPredicate, ManagedGuaranteeType.ATOMIC)
     }
 }
 
 internal enum class ManagedGuaranteeType {
     IGNORE,
-    TREAT_AS_ATOMIC
+    ATOMIC
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -243,23 +243,16 @@ private class WrapMethodInIgnoredSectionTransformer(
     methodName: String,
     adapter: GeneratorAdapter,
 ) : ManagedStrategyMethodVisitor(fileName, className, methodName, adapter) {
-    private var enteredInIgnoredSectionLocal = 0
 
     override fun visitCode() = adapter.run {
-        enteredInIgnoredSectionLocal = newLocal(BOOLEAN_TYPE)
-        invokeStatic(Injections::enterIgnoredSection)
-        storeLocal(enteredInIgnoredSectionLocal)
         visitCode()
+        invokeStatic(Injections::enterIgnoredSection)
     }
 
     override fun visitInsn(opcode: Int) = adapter.run {
         when (opcode) {
             ARETURN, DRETURN, FRETURN, IRETURN, LRETURN, RETURN -> {
-                ifStatement(
-                    condition = { loadLocal(enteredInIgnoredSectionLocal) },
-                    thenClause = { invokeStatic(Injections::leaveIgnoredSection) },
-                    elseClause = {}
-                )
+                invokeStatic(Injections::leaveIgnoredSection)
             }
         }
         visitInsn(opcode)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -82,6 +82,14 @@ internal class LincheckClassVisitor(
             mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             return mv
         }
+        // Wrap `ClassLoader::loadClass` calls into ignored sections
+        // to ensure their code is not analyzed by the Lincheck.
+        if (isClassLoaderClassName(className.toCanonicalClassName())) {
+            if (isLoadClassMethod(methodName, desc)) {
+                mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
+            }
+            return mv
+        }
         // In some newer versions of JDK, `ThreadPoolExecutor` uses
         // the internal `ThreadContainer` classes to manage threads in the pool;
         // This class, in turn, has the method `start,
@@ -93,14 +101,6 @@ internal class LincheckClassVisitor(
             if (methodName == "start") {
                 mv = ThreadTransformer(fileName, className, methodName, desc, mv.newAdapter())
             } else {
-                mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
-            }
-            return mv
-        }
-        // Wrap `ClassLoader::loadClass` calls into ignored sections
-        // to ensure their code is not analyzed by the Lincheck.
-        if (containsClassloaderInName(className.toCanonicalClassName())) {
-            if (methodName == "loadClass" && desc == "(Ljava/lang/String;)Ljava/lang/Class;") {
                 mv = WrapMethodInIgnoredSectionTransformer(fileName, className, methodName, mv.newAdapter())
             }
             return mv
@@ -269,6 +269,9 @@ private class WrapMethodInIgnoredSectionTransformer(
     }
 
 }
+
+private fun isLoadClassMethod(methodName: String, desc: String) =
+    methodName == "loadClass" && desc == "(Ljava/lang/String;)Ljava/lang/Class;"
 
 // Set storing canonical names of the classes that call internal coroutine functions;
 // it is used to optimize class re-transformation in stress mode by remembering

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -504,7 +504,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
     // We should always eagerly transform the following classes.
     internal fun isEagerlyInstrumentedClass(className: String): Boolean =
         // `ClassLoader` classes, to wrap `loadClass` methods in the ignored section.
-        containsClassloaderInName(className) ||
+        isClassLoaderClassName(className) ||
         // `MethodHandle` class, to wrap its methods (except `invoke` methods) in the ignored section.
         isMethodHandleRelatedClass(className) ||
         // `StackTraceElement` class, to wrap all its methods into the ignored section.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -11,8 +11,7 @@
 package org.jetbrains.kotlinx.lincheck.transformation
 
 import net.bytebuddy.agent.ByteBuddyAgent
-import org.jetbrains.kotlinx.lincheck.isInTraceDebuggerMode
-import org.jetbrains.kotlinx.lincheck.runInIgnoredSection
+import org.jetbrains.kotlinx.lincheck.util.runInsideIgnoredSection
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.MODEL_CHECKING
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.STRESS
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckClassFileTransformer.isEagerlyInstrumentedClass
@@ -23,7 +22,7 @@ import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumen
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent.instrumentedClasses
 import org.jetbrains.kotlinx.lincheck.transformation.transformers.LocalVariableInfo
 import org.jetbrains.kotlinx.lincheck.util.Logger
-import org.jetbrains.kotlinx.lincheck.util.readFieldViaUnsafe
+import org.jetbrains.kotlinx.lincheck.util.*
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Type
@@ -360,7 +359,7 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
         classBeingRedefined: Class<*>?,
         protectionDomain: ProtectionDomain?,
         classBytes: ByteArray
-    ): ByteArray? = runInIgnoredSection {
+    ): ByteArray? = runInsideIgnoredSection {
         if (classBeingRedefined != null) {
             require(internalClassName != null) {
                 "Internal class name of redefined class ${classBeingRedefined.name} must not be null"

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -505,7 +505,7 @@ private val isCoroutineStateMachineClassMap = ConcurrentHashMap<String, Boolean>
 /**
  * Tests if the provided [className] contains `"ClassLoader"` as a substring.
  */
-internal fun containsClassloaderInName(className: String): Boolean =
+internal fun isClassLoaderClassName(className: String): Boolean =
     className.contains("ClassLoader")
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -575,5 +575,6 @@ internal const val ASM_API = Opcodes.ASM9
 
 internal val STRING_TYPE = getType(String::class.java)
 internal val CLASS_TYPE = getType(Class::class.java)
+internal val THROWABLE_TYPE = getType(Throwable::class.java)
 
 internal val CLASS_FOR_NAME_METHOD = Method("forName", CLASS_TYPE, arrayOf(STRING_TYPE))

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -388,19 +388,10 @@ internal inline fun GeneratorAdapter.invokeIfInTestingCode(
 internal inline fun GeneratorAdapter.invokeInIgnoredSection(
     code: GeneratorAdapter.() -> Unit
 ) {
+    // TODO: wrap into try-finally
     invokeStatic(Injections::enterIgnoredSection)
-    val enteredIgnoredSection = newLocal(BOOLEAN_TYPE)
-    storeLocal(enteredIgnoredSection)
     code()
-    ifStatement(
-        condition = {
-            loadLocal(enteredIgnoredSection)
-        },
-        thenClause = {
-            invokeStatic(Injections::leaveIgnoredSection)
-        },
-        elseClause = {}
-    )
+    invokeStatic(Injections::leaveIgnoredSection)
 }
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -359,23 +359,23 @@ internal inline fun GeneratorAdapter.ifStatement(
 }
 
 /**
- * Generates an if-then-else statement, testing if the current execution point
- * is currently inside a Lincheck tested section
- * (i.e., not inside the ignored section of the analysis).
- * If so, the [original] bytecode sequence will be executed, otherwise
- * the instrumented [code] will be executed.
+ * Generates an if-then-else statement,
+ * testing if the current execution point is inside a Lincheck analyzed code
+ *
+ * If so, the [original] bytecode sequence will be executed,
+ * otherwise the [instrumented] bytecode will be executed.
  *
  * @param original the original code.
- * @param code the code to execute in the Lincheck's testing context.
+ * @param instrumented the code to execute in the Lincheck's analysis context.
  */
-internal inline fun GeneratorAdapter.invokeIfInTestingCode(
+internal inline fun GeneratorAdapter.invokeIfInAnalyzedCode(
     original: GeneratorAdapter.() -> Unit,
-    code: GeneratorAdapter.() -> Unit
+    instrumented: GeneratorAdapter.() -> Unit
 ) {
     ifStatement(
-        condition = { invokeStatic(Injections::inIgnoredSection) },
-        thenClause = original,
-        elseClause = code
+        condition = { invokeStatic(Injections::inAnalyzedCode) },
+        thenClause = instrumented,
+        elseClause = original,
     )
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -385,13 +385,16 @@ internal inline fun GeneratorAdapter.invokeIfInTestingCode(
  *
  * @param code A block of bytecode to be executed inside the ignored section.
  */
-internal inline fun GeneratorAdapter.invokeInIgnoredSection(
+internal fun GeneratorAdapter.invokeInIgnoredSection(
     code: GeneratorAdapter.() -> Unit
 ) {
-    // TODO: wrap into try-finally
     invokeStatic(Injections::enterIgnoredSection)
-    code()
-    invokeStatic(Injections::leaveIgnoredSection)
+    tryCatchFinally(
+        tryBlock = { code() },
+        finallyBlock = {
+            invokeStatic(Injections::leaveIgnoredSection)
+        },
+    )
 }
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -567,6 +567,7 @@ internal fun String.toInternalClassName() =
 
 internal const val ASM_API = Opcodes.ASM9
 
+internal val OBJECT_ARRAY_TYPE = getType(Array<Any>::class.java)
 internal val STRING_TYPE = getType(String::class.java)
 internal val CLASS_TYPE = getType(Class::class.java)
 internal val THROWABLE_TYPE = getType(Throwable::class.java)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -291,7 +291,7 @@ private val Type.requiresBoxing: Boolean
  *
  * @param setMethodEventId a flag that identifies that method call event id set is required
  */
-internal fun GeneratorAdapter.invokeBeforeEvent(debugMessage: String, setMethodEventId: Boolean) = invokeInIgnoredSection {
+internal fun GeneratorAdapter.invokeBeforeEvent(debugMessage: String, setMethodEventId: Boolean) = invokeInsideIgnoredSection {
     ifStatement(
         condition = {
             invokeStatic(Injections::shouldInvokeBeforeEvent)
@@ -385,7 +385,7 @@ internal inline fun GeneratorAdapter.invokeIfInAnalyzedCode(
  *
  * @param code A block of bytecode to be executed inside the ignored section.
  */
-internal fun GeneratorAdapter.invokeInIgnoredSection(
+internal fun GeneratorAdapter.invokeInsideIgnoredSection(
     code: GeneratorAdapter.() -> Unit
 ) {
     invokeStatic(Injections::enterIgnoredSection)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ConstantHashCodeTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ConstantHashCodeTransformer.kt
@@ -11,7 +11,7 @@
 package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
 import org.jetbrains.kotlinx.lincheck.transformation.ManagedStrategyMethodVisitor
-import org.jetbrains.kotlinx.lincheck.transformation.invokeIfInTestingCode
+import org.jetbrains.kotlinx.lincheck.transformation.invokeIfInAnalyzedCode
 import org.jetbrains.kotlinx.lincheck.transformation.invokeStatic
 import org.objectweb.asm.commons.GeneratorAdapter
 import sun.nio.ch.lincheck.Injections
@@ -33,16 +33,16 @@ internal class ConstantHashCodeTransformer(
     override fun visitMethodInsn(opcode: Int, owner: String, name: String, desc: String, itf: Boolean) = adapter.run {
         when {
             name == "hashCode" && desc == "()I" -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = { visitMethodInsn(opcode, owner, name, desc, itf) },
-                    code = { invokeStatic(Injections::hashCodeDeterministic) }
+                    instrumented = { invokeStatic(Injections::hashCodeDeterministic) }
                 )
             }
 
             owner == "java/lang/System" && name == "identityHashCode" && desc == "(Ljava/lang/Object;)I" -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = { visitMethodInsn(opcode, owner, name, desc, itf) },
-                    code = { invokeStatic(Injections::identityHashCodeDeterministic) }
+                    instrumented = { invokeStatic(Injections::identityHashCodeDeterministic) }
                 )
             }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ConstructorArgumentsSnapshotTrackerTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ConstructorArgumentsSnapshotTrackerTransformer.kt
@@ -11,7 +11,6 @@
 package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
 import org.jetbrains.kotlinx.lincheck.transformation.*
-import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type.*
 import org.objectweb.asm.commons.GeneratorAdapter
 import sun.nio.ch.lincheck.Injections
@@ -67,9 +66,9 @@ internal class ConstructorArgumentsSnapshotTrackerTransformer(
                 return
             }
 
-            invokeIfInTestingCode(
+            invokeIfInAnalyzedCode(
                 original = { visitMethodInsn(opcode, owner, name, desc, itf) },
-                code = {
+                instrumented = {
                     // STACK: args
                     val arguments = storeArguments(desc)
                     val matchedLocals = arguments.filterIndexed { index, _ -> matchedArguments.contains(index) }.toIntArray()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/CoroutineSupportTransformers.kt
@@ -64,11 +64,11 @@ internal class CoroutineDelaySupportTransformer(
             return
         }
 
-        invokeIfInTestingCode(
+        invokeIfInAnalyzedCode(
             original = {
                 visitMethodInsn(opcode, owner, name, desc, itf)
             },
-            code = {
+            instrumented = {
                 // STACK [INVOKESTATIC]: delay, <cont>
                 val contLocal = newLocal(getType("Lkotlin/coroutines/Continuation;"))
                 storeLocal(contLocal)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/DeterministicInvokeDynamicTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/DeterministicInvokeDynamicTransformer.kt
@@ -49,7 +49,7 @@ internal class DeterministicInvokeDynamicTransformer(
         bootstrapMethodHandle: Handle,
         vararg bootstrapMethodArguments: Any?
     ) = adapter.run {
-        invokeIfInTestingCode(
+        invokeIfInAnalyzedCode(
             original = { visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, *bootstrapMethodArguments) },
         ) {
             // Emulating invoke dynamic behaviour deterministically

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/DeterministicInvokeDynamicTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/DeterministicInvokeDynamicTransformer.kt
@@ -11,7 +11,6 @@
 package org.jetbrains.kotlinx.lincheck.transformation.transformers
 
 import org.jetbrains.kotlinx.lincheck.transformation.*
-import org.jetbrains.kotlinx.lincheck.transformation.invokeInIgnoredSection
 import org.objectweb.asm.Handle
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Opcodes.INVOKESTATIC
@@ -80,7 +79,7 @@ internal class DeterministicInvokeDynamicTransformer(
         putInvokeDynamicCallStaticArgumentsOnStack(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments)
 
         // Map.get(key)
-        invokeInIgnoredSection {
+        invokeInsideIgnoredSection {
             invokeStatic(Injections::getCachedInvokeDynamicCallSite)
         }
 
@@ -113,7 +112,7 @@ internal class DeterministicInvokeDynamicTransformer(
         loadLocal(callSite)
         
         // Map.set(key, value)
-        invokeInIgnoredSection {
+        invokeInsideIgnoredSection {
             invokeStatic(Injections::putCachedInvokeDynamicCallSite)
         }
         
@@ -161,7 +160,7 @@ internal class DeterministicInvokeDynamicTransformer(
         bootstrapMethodArguments: Array<out Any?>
     ) {
         putStackArgumentsForMetafactory(bootstrapMethodHandle, name, descriptor, bootstrapMethodArguments)
-        invokeInIgnoredSection {
+        invokeInsideIgnoredSection {
             visitMethodInsn(
                 INVOKESTATIC,
                 bootstrapMethodHandle.owner,
@@ -172,7 +171,7 @@ internal class DeterministicInvokeDynamicTransformer(
         }
     }
     
-    private fun GeneratorAdapter.getCallSiteTarget() = invokeInIgnoredSection {
+    private fun GeneratorAdapter.getCallSiteTarget() = invokeInsideIgnoredSection {
         invokeVirtual(callSiteType, callSiteTargetMethod)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/LocalVariablesAccessTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/LocalVariablesAccessTransformer.kt
@@ -54,11 +54,11 @@ internal class LocalVariablesAccessTransformer(
 
     @Suppress("UNUSED_PARAMETER")
     private fun visitWriteVarInsn(localVariableInfo: LocalVariableInfo, opcode: Int, varIndex: Int) = adapter.run {
-        invokeIfInTestingCode(
+        invokeIfInAnalyzedCode(
             original = {
                 visitVarInsn(opcode, varIndex)
             },
-            code = {
+            instrumented = {
                 // STACK: value
                 val type = getVarInsOpcodeType(opcode)
                 val local = newLocal(type)
@@ -80,11 +80,11 @@ internal class LocalVariablesAccessTransformer(
     }
 
     private fun visitReadVarInsn(localVariableInfo: LocalVariableInfo, opcode: Int, varIndex: Int) = adapter.run {
-        invokeIfInTestingCode(
+        invokeIfInAnalyzedCode(
             original = {
                 visitVarInsn(opcode, varIndex)
             },
-            code = {
+            instrumented = {
                 // STACK: <empty>
                 visitVarInsn(opcode, varIndex)
                 // STACK: value

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -52,11 +52,11 @@ internal class MethodCallTransformer(
             visitMethodInsn(opcode, owner, name, desc, itf)
             return
         }
-        invokeIfInTestingCode(
+        invokeIfInAnalyzedCode(
             original = {
                 visitMethodInsn(opcode, owner, name, desc, itf)
             },
-            code = {
+            instrumented = {
                 processMethodCall(desc, opcode, owner, name, itf)
             }
         )

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -38,7 +38,7 @@ internal class MethodCallTransformer(
             return
         }
         if (isCoroutineInternalClass(owner.toCanonicalClassName())) {
-            invokeInIgnoredSection {
+            invokeInsideIgnoredSection {
                 visitMethodInsn(opcode, owner, name, desc, itf)
             }
             return

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -183,29 +183,30 @@ internal class MethodCallTransformer(
         // STACK: <empty>
         loadLocal(deterministicMethodDescriptorLocal)
         ifNull(onDefaultMethodCallLabel) // If not deterministic call, we just call it regularly
+
         // STACK: <empty>
-        invokeInIgnoredSection {
-            loadLocal(deterministicCallIdLocal)
-            loadLocal(deterministicMethodDescriptorLocal)
-            pushReceiver(receiverLocal)
-            loadLocal(argumentsArrayLocal)
-            // STACK: deterministicCallId, deterministicMethodDescriptor, receiver, parameters
-            invokeStatic(Injections::invokeDeterministicallyOrNull)
-            // STACK: BootstrapResult
-            val resultLocal = newLocal(getType(BootstrapResult::class.java))
-            storeLocal(resultLocal)
-            // STACK: <empty>
-            loadLocal(resultLocal)
-            // STACK: BootstrapResult
-            ifNull(onDefaultMethodCallLabel)
-            // STACK: <empty>
-            loadLocal(resultLocal)
-            // STACK: BootstrapResult
-            invokeStatic(Injections::getFromOrThrow)
-            // STACK: result
-            if (returnType == VOID_TYPE) pop() else unbox(returnType)
-        }
+        loadLocal(deterministicCallIdLocal)
+        loadLocal(deterministicMethodDescriptorLocal)
+        pushReceiver(receiverLocal)
+        loadLocal(argumentsArrayLocal)
+        // STACK: deterministicCallId, deterministicMethodDescriptor, receiver, parameters
+        invokeStatic(Injections::invokeDeterministicallyOrNull)
+        // STACK: BootstrapResult
+        val resultLocal = newLocal(getType(BootstrapResult::class.java))
+        storeLocal(resultLocal)
+        // STACK: <empty>
+        loadLocal(resultLocal)
+        // STACK: BootstrapResult
+        ifNull(onDefaultMethodCallLabel)
+        // STACK: <empty>
+        loadLocal(resultLocal)
+        // STACK: BootstrapResult
+        invokeStatic(Injections::getFromOrThrow)
+        // STACK: result?
+        if (returnType == VOID_TYPE) pop() else unbox(returnType)
+        // STACK: boxedResult?
         goTo(endIfLabel)
+
         visitLabel(onDefaultMethodCallLabel)
         // STACK: <empty>
         invokeDefault()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MethodCallTransformer.kt
@@ -71,7 +71,7 @@ internal class MethodCallTransformer(
         val returnType = getReturnType(desc)
         // STACK: receiver?, arguments
         val argumentLocals = storeArguments(desc)
-        val argumentsArrayLocal = newLocal(OBJECT_TYPE).also {
+        val argumentsArrayLocal = newLocal(OBJECT_ARRAY_TYPE).also {
             pushArray(argumentLocals)
             storeLocal(it)
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MonitorTransformers.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/MonitorTransformers.kt
@@ -148,7 +148,7 @@ internal class SynchronizedMethodTransformer(
                 visitLdcInsn(classType)
             } else {
                 visitLdcInsn(classType.className)
-                invokeInIgnoredSection {
+                invokeInsideIgnoredSection {
                     invokeStatic(CLASS_TYPE, CLASS_FOR_NAME_METHOD)
                 }
             }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ParkingTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/ParkingTransformer.kt
@@ -29,11 +29,11 @@ internal class ParkingTransformer(
     override fun visitMethodInsn(opcode: Int, owner: String, name: String, desc: String, itf: Boolean) = adapter.run {
         when {
             isUnsafe(owner) && name == "park" -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitMethodInsn(opcode, owner, name, desc, itf)
                     },
-                    code = {
+                    instrumented = {
                         pop2() // time
                         pop() // isAbsolute
                         pop() // Unsafe
@@ -45,11 +45,11 @@ internal class ParkingTransformer(
             }
 
             isUnsafe(owner) && name == "unpark" -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitMethodInsn(opcode, owner, name, desc, itf)
                     },
-                    code = {
+                    instrumented = {
                         loadNewCodeLocationId()
                         invokeStatic(Injections::unpark)
                         pop() // pop Unsafe object

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/SharedMemoryAccessTransformer.kt
@@ -46,11 +46,11 @@ internal class SharedMemoryAccessTransformer(
         when (opcode) {
             GETSTATIC -> {
                 // STACK: <empty>
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitFieldInsn(opcode, owner, fieldName, desc)
                     },
-                    code = {
+                    instrumented = {
                         // STACK: <empty>
                         pushNull()
                         push(owner.toCanonicalClassName())
@@ -78,11 +78,11 @@ internal class SharedMemoryAccessTransformer(
 
             GETFIELD -> {
                 // STACK: obj
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitFieldInsn(opcode, owner, fieldName, desc)
                     },
-                    code = {
+                    instrumented = {
                         // STACK: obj
                         dup()
                         // STACK: obj, obj
@@ -112,11 +112,11 @@ internal class SharedMemoryAccessTransformer(
 
             PUTSTATIC -> {
                 // STACK: value
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitFieldInsn(opcode, owner, fieldName, desc)
                     },
-                    code = {
+                    instrumented = {
                         val valueType = getType(desc)
                         val valueLocal = newLocal(valueType) // we cannot use DUP as long/double require DUP2
                         copyLocal(valueLocal)
@@ -149,11 +149,11 @@ internal class SharedMemoryAccessTransformer(
 
             PUTFIELD -> {
                 // STACK: obj, value
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitFieldInsn(opcode, owner, fieldName, desc)
                     },
-                    code = {
+                    instrumented = {
                         val valueType = getType(desc)
                         val valueLocal = newLocal(valueType) // we cannot use DUP as long/double require DUP2
                         storeLocal(valueLocal)
@@ -197,11 +197,11 @@ internal class SharedMemoryAccessTransformer(
     override fun visitInsn(opcode: Int) = adapter.run {
         when (opcode) {
             AALOAD, LALOAD, FALOAD, DALOAD, IALOAD, BALOAD, CALOAD, SALOAD -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitInsn(opcode)
                     },
-                    code = {
+                    instrumented = {
                         // STACK: array: Array, index: Int
                         val arrayElementType = getArrayElementType(opcode)
                         dup2()
@@ -226,11 +226,11 @@ internal class SharedMemoryAccessTransformer(
             }
 
             AASTORE, IASTORE, FASTORE, BASTORE, CASTORE, SASTORE, LASTORE, DASTORE -> {
-                invokeIfInTestingCode(
+                invokeIfInAnalyzedCode(
                     original = {
                         visitInsn(opcode)
                     },
-                    code = {
+                    instrumented = {
                         // STACK: array: Array, index: Int, value: Object
                         val arrayElementType = getArrayElementType(opcode)
                         val valueLocal = newLocal(arrayElementType) // we cannot use DUP as long/double require DUP2

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
@@ -12,6 +12,41 @@ package org.jetbrains.kotlinx.lincheck.util
 
 import sun.nio.ch.lincheck.ThreadDescriptor
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy
+import sun.nio.ch.lincheck.Injections
+
+/**
+ * Enables analysis for the current thread.
+ */
+internal fun enableAnalysis() {
+    Injections.enableAnalysis()
+}
+
+/**
+ * Disables analysis for the current thread.
+ */
+internal fun disableAnalysis() {
+    Injections.disableAnalysis()
+}
+
+/**
+ * Enters an ignored section for the current thread.
+ *
+ * Has no effect on if the current thread is untracked,
+ * that is not registered in the Lincheck strategy.
+ */
+internal fun enterIgnoredSection() {
+    Injections.enterIgnoredSection()
+}
+
+/**
+ * Leaves an ignored section for the current thread.
+ *
+ * Has no effect on if the current thread is untracked,
+ * that is not registered in the Lincheck strategy.
+ */
+internal fun leaveIgnoredSection() {
+    Injections.leaveIgnoredSection()
+}
 
 /**
  * Executes a given block of code within an ignored section.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
@@ -1,0 +1,57 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.util
+
+import sun.nio.ch.lincheck.ThreadDescriptor
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy
+
+/**
+ * Executes a given block of code within an ignored section.
+ *
+ * @param block the code to execute within the ignored section.
+ * @return result of the [block] invocation.
+ */
+internal inline fun <R> runInsideIgnoredSection(block: () -> R): R {
+    val descriptor = ThreadDescriptor.getCurrentThreadDescriptor()
+    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
+        return block()
+    }
+    descriptor.enterIgnoredSection()
+    try {
+        return block()
+    } finally {
+        descriptor.leaveIgnoredSection()
+    }
+}
+
+/**
+ * Exits the ignored section and invokes the provided [block] outside an ignored section,
+ * restoring the ignored section back after the [block] is executed.
+ *
+ * @param block the code to execute outside the ignored section.
+ * @return result of [block] invocation.
+ * @throws IllegalStateException if the method is called not from an ignored section.
+ */
+internal inline fun <R> runOutsideIgnoredSection(block: () -> R): R {
+    val descriptor = ThreadDescriptor.getCurrentThreadDescriptor()
+    if (descriptor == null || descriptor.eventTracker !is ManagedStrategy) {
+        return block()
+    }
+    check(descriptor.inIgnoredSection()) {
+        "Current thread must be in ignored section"
+    }
+    val depth = descriptor.saveAndResetIgnoredSectionDepth()
+    try {
+        return block()
+    } finally {
+        descriptor.restoreIgnoredSectionDepth(depth)
+    }
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
@@ -31,8 +31,8 @@ internal fun disableAnalysis() {
 /**
  * Enters an ignored section for the current thread.
  *
- * Has no effect on if the current thread is untracked,
- * that is not registered in the Lincheck strategy.
+     * Does not affect the current thread if it is untracked
+     * (e.g. not registered in the Lincheck strategy).
  */
 internal fun enterIgnoredSection() {
     Injections.enterIgnoredSection()
@@ -41,8 +41,8 @@ internal fun enterIgnoredSection() {
 /**
  * Leaves an ignored section for the current thread.
  *
- * Has no effect on if the current thread is untracked,
- * that is not registered in the Lincheck strategy.
+     * Does not affect the current thread if it is untracked
+     * (e.g. not registered in the Lincheck strategy).
  */
 internal fun leaveIgnoredSection() {
     Injections.leaveIgnoredSection()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/AnalysisSections.kt
@@ -10,9 +10,9 @@
 
 package org.jetbrains.kotlinx.lincheck.util
 
-import sun.nio.ch.lincheck.ThreadDescriptor
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy
 import sun.nio.ch.lincheck.Injections
+import sun.nio.ch.lincheck.ThreadDescriptor
 
 /**
  * Enables analysis for the current thread.
@@ -50,6 +50,10 @@ internal fun leaveIgnoredSection() {
 
 /**
  * Executes a given block of code within an ignored section.
+ *
+ * NOTE: this method is intended to be used during runtime,
+ * *not* during bytecode instrumentation in the [org.jetbrains.kotlinx.lincheck.transformation] package.
+ * In that context, please use [org.jetbrains.kotlinx.lincheck.transformation.invokeInsideIgnoredSection] instead.
  *
  * @param block the code to execute within the ignored section.
  * @return result of the [block] invocation.

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/ModelCheckerTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/ModelCheckerTest.kt
@@ -77,7 +77,7 @@ private fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario): Mo
 
 private fun createConfiguration(testClass: Class<*>) =
     ModelCheckingOptions()
-        .invocationTimeout(20_000) // 20 sec
+        .invocationTimeout(30_000) // 30 sec
         .createTestConfigurations(testClass)
 
 private class CollectResultsVerifier : Verifier {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ObstructionFreedomRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ObstructionFreedomRepresentationTest.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinx.lincheck_test.util.*
 
 import java.util.concurrent.atomic.*
 import org.junit.*
+import org.junit.Assume.assumeFalse
 
 /**
  * This test checks that the last event in the case of an active lock
@@ -26,6 +27,9 @@ import org.junit.*
 class ObstructionFreedomActiveLockRepresentationTest : BaseTraceRepresentationTest(
     "obstruction_freedom_violation_with_no_detected_cycle"
 ) {
+    @Before // spin-loop detection is unsupported in trace debugger mode
+    fun setUp() = assumeFalse(isInTraceDebuggerMode)
+
     private val counter = AtomicInteger(0)
 
     override fun operation() {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/RunConcurrentRepresentationTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/RunConcurrentRepresentationTests.kt
@@ -316,6 +316,10 @@ class KotlinThreadRunConcurrentRepresentationTest : BaseRunConcurrentRepresentat
 
 // TODO investigate difference for trace debugger (Evgeniy Moiseenko)
 class LivelockRunConcurrentRepresentationTest : BaseRunConcurrentRepresentationTest<Unit>("run_concurrent_test/livelock") {
+
+    @Before // spin-loop detection is unsupported in trace debugger mode
+    fun setUp() = assumeFalse(isInTraceDebuggerMode)
+
     override fun block() {
         var counter = 0
         val lock1 = SpinLock()


### PR DESCRIPTION
This PR contains ignored sections implementation refactoring, needed as a preparation for implementing new silent sections feature: https://github.com/JetBrains/lincheck/issues/501

The most important change is that instead of boolean flag, now a re-entrance depth counter is used to maintain ignored sections information. This provides simpler mental model and API.

Now, instead of:
```java
public static boolean enterIgnoredSection() { ... }
```
we have:
```java
public static void enterIgnoredSection() { ... }
```
Meaning that there is no need to track the result of `enterIgnoredSection()`, wrap `leaveIgnoredSection()` into an `if`, etc. It is sufficient to just call `leaveIgnoredSection()` as many times as was called `enterIgnoredSection()`.

Moreover, now it is possible to write the following code:
```kotlin
runInsideIgnoredSection {
    ...
    enterIgnoredSection()
}
```

and it works as intended.
This simplifies implementation of methods `onMethodCall`, `onMethodCallReturn`, and `onMethodCallException`, allowing to wrap the whole method body into `runInsideIgnoredSection`.

Besides that, this PR has several minor renamings to improve consistency and clarity of the code.

1. `runInIgnoredSection` --> `runInsideIgnoredSection`: for consistency with `runOutsideIgnoredSection`

2. `enterTestingCode` and `leaveTestingCode` --> `enableAnalysis` and `disableAnalysis`: simpler and more meaningful names.

3. In method `invokeIfInAnalyzedCode` parameters were renamed: `original` and `code` --> `original` and `instrumented`: to highlight the second one provides instrumented version of the bytecode.