### PR TITLE
Include spin-cycle replays in invocations count 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,7 @@ tasks {
         extraArgs.add("-Dlincheck.version=$version")
         findProperty("lincheck.logFile")?.let { extraArgs.add("-Dlincheck.logFile=${it as String}") }
         findProperty("lincheck.logLevel")?.let { extraArgs.add("-Dlincheck.logLevel=${it as String}") }
+        findProperty("lincheck.strictInvocationsBound")?.let { extraArgs.add("-Dlincheck.strictInvocationsBound=${it as String}") }
         jvmArgs(extraArgs)
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,6 @@ tasks {
         extraArgs.add("-Dlincheck.version=$version")
         findProperty("lincheck.logFile")?.let { extraArgs.add("-Dlincheck.logFile=${it as String}") }
         findProperty("lincheck.logLevel")?.let { extraArgs.add("-Dlincheck.logLevel=${it as String}") }
-        findProperty("lincheck.strictInvocationsBound")?.let { extraArgs.add("-Dlincheck.strictInvocationsBound=${it as String}") }
         jvmArgs(extraArgs)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/Strategy.kt
@@ -29,14 +29,6 @@ abstract class Strategy protected constructor(
 ) : Closeable {
 
     /**
-     * Strict invocations bound will treat spin cycle replays in [ManagedStrategy] as actual invocations.
-     *
-     * Setting this flag to `true` could lead to existing errors being undetected by the strategy
-     * when small number of invocations is set (like, 1) and spin cycle replay is required.
-     */
-    internal val strictInvocationsBound: Boolean = System.getProperty("lincheck.strictInvocationsBound").toBoolean()
-
-    /**
      * Runner used for executing the test scenario.
      */
     internal abstract val runner: Runner

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -156,6 +156,14 @@ abstract class ManagedStrategy(
     protected var replayNumber = 0L
 
     /**
+     * Strict invocations bound will treat spin cycle replays in [ManagedStrategy] as actual invocations.
+     *
+     * Setting this flag to `true` could lead to existing errors being undetected by the strategy
+     * when small number of invocations is set (like, 1) and spin cycle replay is required.
+     */
+    private val strictInvocationsBound: Boolean = System.getProperty("lincheck.strictInvocationsBound").toBoolean()
+
+    /**
      * For each thread, represents a shadow stack used to reflect the program's actual stack.
      *
      * Collected and used only in the trace collecting stage.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -272,33 +272,31 @@ abstract class ManagedStrategy(
      * Runs the current invocation.
      */
     override fun runInvocation(): InvocationResult {
-        while (true) {
-            initializeInvocation()
-            val result: InvocationResult = try {
-                runner.run()
-            } finally {
-                restoreStaticMemorySnapshot()
-            }
-            // In case the runner detects a deadlock, some threads can still manipulate the current strategy,
-            // so we're not interested in suddenInvocationResult in this case
-            // and immediately return RunnerTimeoutInvocationResult.
-            if (result is RunnerTimeoutInvocationResult) {
-                return result
-            }
-            // If strategy has not detected a sudden invocation result,
-            // then return, otherwise process the sudden result.
-            val suddenResult = suddenInvocationResult ?: return result
-            // Check if an invocation replay is required
-            val isReplayRequired = (suddenResult is SpinCycleFoundAndReplayRequired)
-            if (isReplayRequired) {
-                enableSpinCycleReplay()
-                continue
-            }
-            // Unexpected `ThreadAbortedError` should be thrown.
-            check(result is UnexpectedExceptionInvocationResult)
-            // Otherwise return the sudden result
+        initializeInvocation()
+        val result: InvocationResult = try {
+            runner.run()
+        } finally {
+            restoreStaticMemorySnapshot()
+        }
+        // In case the runner detects a deadlock, some threads can still manipulate the current strategy,
+        // so we're not interested in suddenInvocationResult in this case
+        // and immediately return RunnerTimeoutInvocationResult.
+        if (result is RunnerTimeoutInvocationResult) {
+            return result
+        }
+        // If strategy has not detected a sudden invocation result,
+        // then return, otherwise process the sudden result.
+        val suddenResult = suddenInvocationResult ?: return result
+        // Check if an invocation replay is required
+        val isReplayRequired = (suddenResult is SpinCycleFoundAndReplayRequired)
+        if (isReplayRequired) {
+            enableSpinCycleReplay()
             return suddenResult
         }
+        // Unexpected `ThreadAbortedError` should be thrown.
+        check(result is UnexpectedExceptionInvocationResult)
+        // Otherwise return the sudden result
+        return suddenResult
     }
 
     protected open fun enableSpinCycleReplay() {}


### PR DESCRIPTION
This PR adds a functionality which counts each spin-cycle replay as part of the total invocations count.

Examples of tests, where there is a significant difference between the specified invocations and actual run invocations for ModelChecking regime (among all iterations the biggest difference in invocations is specified):
1. CausesBlockingOperationTest: `15236 / 10000`
1. CyclicBarrierTest: `24162 / 10000`
1. ReentrantLockTest: `2314 / 500`
1. SpinLockTest: `1796 / 500`
1. CoroutineCancelTest::testCancel: `1482 / 100`
1. CoroutineJoinTest: `868 / 100`
1. ReentrantLockSetTest: `3868 / 1000`
... and a couple more tests with a smaller difference

All tests run locally with the same configuration (naive benchmarking, difference could be just an error):
- included spin-cycles replays: `9m 25s`
- excluded spin-cycle replays (old behaviour): `10m 33s`


---------
An issue, that describes a problem, introduces by this PR: https://github.com/JetBrains/lincheck/issues/590