### PR TITLE
Fix the illegal `lookupClass` issue when using `MethodHandles.Lookup` on JDK 8

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1477,6 +1477,10 @@ abstract class ManagedStrategy(
         params: Array<Any?>,
         result: Any?
     ) = runInsideIgnoredSection {
+        if (deterministicMethodDescriptor != null) {
+            Logger.debug { "On method return with descriptor $deterministicMethodDescriptor: $result" }
+        }
+        
         require(deterministicMethodDescriptor is DeterministicMethodDescriptor<*, *>?)
         // process intrinsic candidate methods
         if (MethodIds.isIntrinsicMethod(methodId)) {
@@ -1531,6 +1535,9 @@ abstract class ManagedStrategy(
         params: Array<Any?>,
         throwable: Throwable
     ) = runInsideIgnoredSection {
+        if (deterministicMethodDescriptor != null) {
+            Logger.debug { "On method exception with descriptor $deterministicMethodDescriptor:\n${throwable.stackTraceToString()}" }
+        }
         require(deterministicMethodDescriptor is DeterministicMethodDescriptor<*, *>?)
         if (isInTraceDebuggerMode && isFirstReplay && deterministicMethodDescriptor != null) {
             deterministicMethodDescriptor.saveFirstResult(receiver, params, KResult.failure(throwable)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -140,7 +140,9 @@ internal class LincheckClassVisitor(
             if (isInTraceDebuggerMode) {
                 // Lincheck does not support true identity hash codes (it always uses zeroes),
                 // so there is no need for the `DeterministicInvokeDynamicTransformer` there.
-                mv = DeterministicInvokeDynamicTransformer(fileName, className, methodName, mv.newAdapter())
+                mv = DeterministicInvokeDynamicTransformer(
+                    fileName, className, methodName, classVersion, mv.newAdapter()
+                )
             }
             mv = run {
                 val st = ConstructorArgumentsSnapshotTrackerTransformer(fileName, className, methodName, mv.newAdapter(), classVisitor::isInstanceOf)
@@ -177,7 +179,7 @@ internal class LincheckClassVisitor(
         if (isInTraceDebuggerMode) {
             // Lincheck does not support true identity hash codes (it always uses zeroes),
             // so there is no need for the `DeterministicInvokeDynamicTransformer` there.
-            mv = DeterministicInvokeDynamicTransformer(fileName, className, methodName, mv.newAdapter())
+            mv = DeterministicInvokeDynamicTransformer(fileName, className, methodName, classVersion, mv.newAdapter())
         } else {
             // In trace debugger mode we record hash codes of tracked objects and substitute them on re-run,
             // otherwise, we track all hash code calls in the instrumented code

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -16,6 +16,7 @@ import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.commons.*
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.*
 import org.jetbrains.kotlinx.lincheck.transformation.transformers.*
+import org.jetbrains.kotlinx.lincheck.util.Logger
 import sun.nio.ch.lincheck.*
 
 internal class LincheckClassVisitor(
@@ -69,7 +70,10 @@ internal class LincheckClassVisitor(
         exceptions: Array<String>?
     ): MethodVisitor {
         var mv = super.visitMethod(access, methodName, desc, signature, exceptions)
-        if (access and ACC_NATIVE != 0) return mv
+        if (access and ACC_NATIVE != 0) {
+            Logger.debug { "Skipping transformation of the native method $className.$methodName" }
+            return mv
+        }
         if (instrumentationMode == STRESS) {
             return if (methodName != "<clinit>" && methodName != "<init>") {
                 CoroutineCancellabilitySupportTransformer(mv, access, className, methodName, desc)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/TransformationUtils.kt
@@ -184,7 +184,10 @@ internal fun GeneratorAdapter.storeArguments(methodDescriptor: String): IntArray
 /**
  * Executes a try-catch-finally block within the context of the GeneratorAdapter.
  * 
- * Attention: this method does not insert `finally` blocks before inner return and throw statements.
+ * **Attention**:
+ * * This method does not insert `finally` blocks before inner return and throw statements.
+ * * It is forbidden to jump from the blocks outside and between them.
+ * * The operand stack must be empty by the beginning of the [tryCatchFinally].
  *
  * @param tryBlock The code block to be executed in the try section.
  * @param exceptionType The type of exception to be caught in the `catch` section, or null to catch all exceptions.

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/CollectorsTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/CollectorsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.trace_debugger;
+
+import org.jetbrains.kotlinx.lincheck.annotations.Operation;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This test is intended to check that {@link MethodHandles} is successfully created even on Java 8.
+ * It is necessary for invokedynamic handling in the trace debugger.
+ * <p> 
+ * However, due to workaround for <a href="https://github.com/JetBrains/lincheck/issues/500">the issue</a>,
+ * the tests are actually run on the JDK 17.
+ * Nevertheless, when the issue is resolved,
+ * the tests will actually check the correct {@link MethodHandles.Lookup} creation.
+ */
+public class CollectorsTest extends AbstractDeterministicTest {
+    @Operation
+    public Object operation() {
+        return Arrays.stream(
+                new List[] {
+                    Arrays.stream(new String[]{"Hello ", "w"}).collect(Collectors.toList()),
+                    Arrays.stream(new String[]{"Hello ", "w"}).collect(Collectors.toList())
+                }
+        ).flatMap(Collection::stream).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
The issue was caused by the fact that `MethodHandles.lookup`, needed for custom handling of invoke-dynamic cannot be called from certain locations. In the case of Java > 8, the only limitation is `java.lang.invoke`, which is fine. While in Java 8 it also includes all Java stdlib packages. So the workaround was to call a private constructor of `MethodHandles` privately with reflection.

The issue was reproducible on one of the tests from Kotlin compiler repository.