### PR TITLE
Run code transformers against tree class representation.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -409,13 +409,14 @@ internal object LincheckClassFileTransformer : ClassFileTransformer {
 
         // the following code is required for local variables access tracking
         val classNode = ClassNode()
-        reader.accept(classNode, 0)
+        reader.accept(classNode, ClassReader.EXPAND_FRAMES)
+
         val methods = mapMethodsToLabels(classNode)
 
         val writer = SafeClassWriter(reader, loader, ClassWriter.COMPUTE_FRAMES)
         val visitor = LincheckClassVisitor(writer, instrumentationMode, methods)
         try {
-            reader.accept(visitor, ClassReader.EXPAND_FRAMES)
+            classNode.accept(visitor)
             writer.toByteArray().also {
                 if (dumpTransformedSources) {
                     val cr = ClassReader(it)


### PR DESCRIPTION
 Now all instrumented classes are processed twice: the first time the class is parsed to ClassNode ("tree") representation to extract local variables info, and the second one it is processed directly by lincheck-specific code visitors with the second call to reader.
 This causes two problems:
  (1) Labels between these parsings are not preserved and not all local variables information extracted at the first step could be used in the second step.
  (2) The same class is parsed twice, which is not effective.
 It happens to be that lincheck-specific class visitors can be called directly on tree representation (ClassNode) of class which is obtained on the first step.
 It solves both problems.

 All tests pass.