### PR TITLE
Fix timeout in deterministic time tests

### DIFF
--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/AbstractDeterministicTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/AbstractDeterministicTest.kt
@@ -45,7 +45,7 @@ abstract class AbstractDeterministicTest {
             ModelCheckingOptions()
                 .actorsBefore(0)
                 .actorsAfter(0)
-                .iterations(1)
+                .iterations(30)
                 .threads(2)
                 .minimizeFailedScenario(false)
                 .actorsPerThread(1)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/AbstractDeterministicTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/AbstractDeterministicTest.kt
@@ -45,7 +45,7 @@ abstract class AbstractDeterministicTest {
             ModelCheckingOptions()
                 .actorsBefore(0)
                 .actorsAfter(0)
-                .iterations(30)
+                .iterations(1)
                 .threads(2)
                 .minimizeFailedScenario(false)
                 .actorsPerThread(1)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/CurrentTimeTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/trace_debugger/CurrentTimeTests.kt
@@ -11,8 +11,12 @@
 package org.jetbrains.kotlinx.lincheck_test.trace_debugger
 
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
 
-abstract class CurrentTimeTest : AbstractDeterministicTest()
+abstract class CurrentTimeTest : AbstractDeterministicTest() {
+    override fun ModelCheckingOptions.customize(): ModelCheckingOptions = this
+        .invocationTimeout(30_000) // 30 sec
+}
 
 class ActualTimeMillisTest : CurrentTimeTest() {
     @Operation


### PR DESCRIPTION
Tests `ActualTimeMillisTest` and `ActualTimeNanosTest` fail with:

```
= The execution has hung, see the thread dump =
```

instead of normal completion. 

The bug was missed by `AbstractDeterministicTest`. 

This PR fixes the tests by increasing the timeout for them. 
