### PR TITLE
Support for aborting parked/livelocked user threads when test thread are finished

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -206,10 +206,19 @@ open class ThreadScheduler {
      * Checks if the thread is currently live-locked.
      *
      * @param threadId The identifier of the thread to check.
-     * @return `true` if the thread is blocked, `false` otherwise.
+     * @return `true` if the thread is live-locked, `false` otherwise.
      */
     fun isLiveLocked(threadId: ThreadId) =
         getBlockingReason(threadId) is BlockingReason.LiveLocked
+
+    /**
+     * Checks if the thread is currently parked.
+     *
+     * @param threadId The identifier of the thread to check.
+     * @return `true` if the thread is parked, `false` otherwise.
+     */
+    fun isParked(threadId: ThreadId) =
+        getBlockingReason(threadId) is BlockingReason.Parked
 
     /**
      * Checks if the thread was aborted.
@@ -236,6 +245,16 @@ open class ThreadScheduler {
      */
     fun areAllThreadsFinished() =
         threads.values.all { it.state == ThreadState.FINISHED }
+
+    /**
+     * Checks if all threads managed by the scheduler have finished or aborted.
+     * @return `true` if all threads are finished or aborted, otherwise `false`.
+     */
+    fun areAllThreadsFinishedOrAborted() =
+        threads.values.all {
+            it.state == ThreadState.FINISHED ||
+            it.state == ThreadState.ABORTED
+        }
 
     /**
      * Registers a new thread in the scheduler and assigns it a unique identifier.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -203,6 +203,15 @@ open class ThreadScheduler {
         getThreadState(threadId) == ThreadState.BLOCKED
 
     /**
+     * Checks if the thread is currently live-locked.
+     *
+     * @param threadId The identifier of the thread to check.
+     * @return `true` if the thread is blocked, `false` otherwise.
+     */
+    fun isLiveLocked(threadId: ThreadId) =
+        getBlockingReason(threadId) is BlockingReason.LiveLocked
+
+    /**
      * Checks if the thread was aborted.
      *
      * @param threadId The identifier of the thread to check.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -99,6 +99,8 @@ internal class ModelCheckingStrategy(
     override fun onSwitchPoint(iThread: Int) {
         check(iThread == -1 /* initial thread choice */ || iThread == threadScheduler.scheduledThreadId)
         if (runner.currentExecutionPart != PARALLEL) return
+        // unblock interrupted threads
+        unblockInterruptedThreads()
         if (loopDetector.replayModeEnabled) return
         currentInterleaving.onSwitchPoint(iThread)
     }
@@ -343,6 +345,7 @@ internal class ModelCheckingStrategy(
         }
 
         fun chooseThread(iThread: Int): Int {
+            val availableThreads = availableThreads(iThread)
             val nextThread = if (currentInterleavingPosition < threadSwitchChoices.size) {
                 // Use the predefined choice.
                 val nextThread = threadSwitchChoices[currentInterleavingPosition++]
@@ -355,6 +358,12 @@ internal class ModelCheckingStrategy(
                     // we reached the next `SwitchChoosingNode` node, so mark it as initialized
                     currentInterleavingNode.initialize()
                 }
+                check(nextThread in availableThreads) {
+                    """
+                        Trying to switch the execution to thread $nextThread,
+                        but only the following threads are eligible to switch: $availableThreads
+                    """.trimIndent()
+                }
                 nextThread
             } else {
                 // There is no predefined choice.
@@ -363,7 +372,11 @@ internal class ModelCheckingStrategy(
                 // We use a deterministic random here to choose the next thread.
                 // end of tracked execution positions, so tell strategy not to generate switch points any further
                 shouldAddNewSwitchPoints = false
-                switchableThreads(iThread).random(interleavingFinishingRandom)
+                // in case no switchable thread available we return -1, this way
+                // the strategy will either report an error or stay on the calling
+                // thread if the switch was not mandatory
+                if (availableThreads.isEmpty()) -1
+                else availableThreads.random(interleavingFinishingRandom)
             }
             if (currentInterleavingPosition == threadSwitchChoices.size) {
                 shouldMoveCurrentNode = false
@@ -382,8 +395,7 @@ internal class ModelCheckingStrategy(
             executionPosition++
             if (shouldAddNewSwitchPoints && executionPosition > (switchPositions.lastOrNull() ?: -1)) {
                 // Add a new thread choosing node corresponding to the switch at the current execution position.
-                val availableThreads = switchableThreads(iThread)
-                val choice = Choice(ThreadChoosingNode(availableThreads), executionPosition)
+                val choice = Choice(ThreadChoosingNode(availableThreads(iThread)), executionPosition)
                 currentInterleavingNode.addChoice(choice)
             }
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -99,6 +99,9 @@ internal class ModelCheckingStrategy(
     override fun onSwitchPoint(iThread: Int) {
         check(iThread == -1 /* initial thread choice */ || iThread == threadScheduler.scheduledThreadId)
         if (runner.currentExecutionPart != PARALLEL) return
+        // in case if `tryAbortingUserThreads` succeeded in aborting execution,
+        // we should not insert switch points after it
+        if (threadScheduler.areAllThreadsFinishedOrAborted()) return
         // unblock interrupted threads
         unblockInterruptedThreads()
         if (loopDetector.replayModeEnabled) return

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/coroutines/DaemonThreadPoolTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/coroutines/DaemonThreadPoolTest.kt
@@ -11,24 +11,158 @@
 package org.jetbrains.kotlinx.lincheck_test.gpmc.coroutines
 
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import org.jetbrains.kotlinx.lincheck.ExperimentalModelCheckingAPI
+import org.jetbrains.kotlinx.lincheck.LincheckAssertionError
+import org.jetbrains.kotlinx.lincheck.isInTraceDebuggerMode
 import org.jetbrains.kotlinx.lincheck.runConcurrentTest
-import org.junit.Ignore
+import org.junit.Assume.assumeFalse
+import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 
 @OptIn(ExperimentalModelCheckingAPI::class)
 class DaemonThreadPoolTest {
 
-    @Ignore("Daemon threads are treated as active, see https://github.com/JetBrains/lincheck/issues/542")
+    @Before // spin-loop detection is unsupported in trace debugger mode
+    fun setUp() = assumeFalse(isInTraceDebuggerMode)
+
     @Test
     fun testUselessThreadPool() {
         runConcurrentTest(1000) {
             val pool = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
             runBlocking(pool) { /* do nothing */ }
-            // pool.close() -- this call tells gpmc that threads are not in infinite spinning,
-            //                 but interleavings exploration still happens
+            // pool.close() -- we do not need this call, because lincheck will
+            //                 abort background threads, when main is finished
+        }
+    }
+
+    @Test
+    fun testUselessThreadPoolWithMultipleCoroutines() {
+        runConcurrentTest(1000) {
+            val pool = Executors.newFixedThreadPool(5).asCoroutineDispatcher()
+            runBlocking(pool) {
+                val c1 = launch(pool) {}
+                val c2 = launch(pool) {}
+                val c3 = launch(pool) {}
+                val c4 = launch(pool) {}
+                val c5 = launch(pool) {}
+
+                c1.join()
+                c2.join()
+                c3.join()
+                c4.join()
+                c5.join()
+            }
+            // pool.close() -- no manual closing
+        }
+    }
+
+    @Test
+    fun testInfiniteBackgroundThreads() {
+        runConcurrentTest(1000) {
+            val atomic = AtomicInteger(0)
+            thread {
+                while (true) atomic.incrementAndGet()
+            }
+            thread(isDaemon = true) {
+                while (true) atomic.decrementAndGet()
+            }
+        }
+    }
+
+    @Test
+    fun testManyInfiniteBackgroundThreads() {
+        runConcurrentTest(1000) {
+            val atomic = AtomicInteger(0)
+            thread {
+                while (true) atomic.incrementAndGet()
+            }
+            thread {
+                while (true) atomic.incrementAndGet()
+            }
+            thread {
+                while (true) atomic.incrementAndGet()
+            }
+            thread {
+                while (true) atomic.incrementAndGet()
+            }
+        }
+    }
+
+    @Test(expected = LincheckAssertionError::class)
+    fun testBackgroundThreadsDeadlock() {
+        runConcurrentTest(1000) {
+            val a = AtomicInteger(0)
+            val sync1 = Any()
+            val sync2 = Any()
+
+            thread {
+                synchronized(sync1) {
+                    synchronized(sync2) {
+                        a.incrementAndGet()
+                    }
+                }
+            }
+            thread {
+                synchronized(sync2) {
+                    synchronized(sync1) {
+                        a.incrementAndGet()
+                    }
+                }
+            }
+
+            check(a.get() in (0..2))
+        }
+    }
+
+    @Test(expected = LincheckAssertionError::class)
+    fun testBackgroundCoroutinesDeadlock() {
+        runConcurrentTest(10000) {
+            Executors.newFixedThreadPool(2).asCoroutineDispatcher().use { pool ->
+                val m = Mutex()
+                runBlocking(pool) {
+                    launch(pool) {
+                        m.lock()
+                    }
+                    launch(pool) {
+                        m.lock()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testJavaThreadPoolFutures() {
+        runConcurrentTest(1000) {
+            val a = AtomicInteger(0)
+            val pool = Executors.newFixedThreadPool(3)
+            val f1 = pool.submit { a.incrementAndGet() }
+            val f2 = pool.submit { a.incrementAndGet() }
+            val f3 = pool.submit { a.incrementAndGet() }
+
+            f1.get()
+            f2.get()
+            f3.get()
+            // no explicit shutdown
+        }
+    }
+
+    @Test
+    fun testJavaThreadPoolAsyncTasks() {
+        runConcurrentTest(1000) {
+            val a = AtomicInteger(0)
+            val pool = Executors.newFixedThreadPool(3)
+            // fire and forget
+            pool.execute { a.incrementAndGet() }
+            pool.execute { a.incrementAndGet() }
+            pool.execute { a.incrementAndGet() }
+            // no explicit shutdown
         }
     }
 }


### PR DESCRIPTION
Resolves issue https://github.com/JetBrains/lincheck/issues/542 (instead of this PR https://github.com/JetBrains/lincheck/pull/585)
