### PR TITLE
Add support for human-readable output.

### DIFF
--- a/.idea/runConfigurations/Trace_debugger_Remote.xml
+++ b/.idea/runConfigurations/Trace_debugger_Remote.xml
@@ -1,17 +1,13 @@
-<!--
-This file set-ups a remote debug configuration to add a possibility to debug Lincheck code
-when its JVM agent is attached to another application.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Trace-debugger Remote" type="Remote">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
-    <option name="SERVER_MODE" value="true" />
+    <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
-    <option name="PORT" value="5005" />
-    <option name="AUTO_RESTART" value="true" />
+    <option name="PORT" value="8000" />
+    <option name="AUTO_RESTART" value="false" />
     <RunnerSettings RunnerId="Debug">
-      <option name="DEBUG_PORT" value="5005" />
+      <option name="DEBUG_PORT" value="8000" />
       <option name="LOCAL" value="false" />
     </RunnerSettings>
     <method v="2" />

--- a/.idea/runConfigurations/Trace_debugger_Remote.xml
+++ b/.idea/runConfigurations/Trace_debugger_Remote.xml
@@ -1,13 +1,17 @@
+<!--
+This file set-ups a remote debug configuration to add a possibility to debug Lincheck code
+when its JVM agent is attached to another application.
+-->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Trace-debugger Remote" type="Remote">
     <option name="USE_SOCKET_TRANSPORT" value="true" />
-    <option name="SERVER_MODE" value="false" />
+    <option name="SERVER_MODE" value="true" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
-    <option name="PORT" value="8000" />
-    <option name="AUTO_RESTART" value="false" />
+    <option name="PORT" value="5005" />
+    <option name="AUTO_RESTART" value="true" />
     <RunnerSettings RunnerId="Debug">
-      <option name="DEBUG_PORT" value="8000" />
+      <option name="DEBUG_PORT" value="5005" />
       <option name="LOCAL" value="false" />
     </RunnerSettings>
     <method v="2" />

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
@@ -357,7 +357,7 @@ class TraceCollectingEventTracker(
         val methodDescriptor = methodCache[methodId]
 
         val tracePoint = threadHandle.popStackFrame()
-        tracePoint.result = TRObjectOrNull(result)
+        tracePoint.result = TRObjectOrVoid(result)
 
         val methodSection = methodAnalysisSectionType(receiver, methodDescriptor.className, methodDescriptor.methodName)
         threadHandle.leaveAnalysisSection(methodSection)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
@@ -115,6 +115,7 @@ class TraceCollectingEventTracker(
             obj = TRObject(Thread.currentThread()),
             parameters = emptyList()
         )
+        tracePoint.result = TR_OBJECT_VOID
         threadHandle.pushStackFrame(tracePoint, Thread.currentThread())
     }
 
@@ -467,6 +468,7 @@ class TraceCollectingEventTracker(
             obj = null,
             parameters = emptyList()
         )
+        tracePoint.result = TR_OBJECT_VOID
         threadHandle.pushStackFrame(tracePoint, null)
 
         startTime = System.currentTimeMillis()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceCollectingEventTracker.kt
@@ -74,10 +74,23 @@ private class ThreadData(
     }
 }
 
+enum class TraceCollectorOutputType {
+    BINARY, TEXT, VERBOSE
+}
+
+fun String?.toTraceCollectorOutputType(): TraceCollectorOutputType {
+    if (this == null) return TraceCollectorOutputType.BINARY
+    for (v in TraceCollectorOutputType.entries) {
+        if (this.equals(v.name, ignoreCase = true)) return v
+    }
+    return TraceCollectorOutputType.BINARY
+}
+
 class TraceCollectingEventTracker(
     private val className: String,
     private val methodName: String,
-    private val traceDumpPath: String?
+    private val traceDumpPath: String?,
+    private val outputType: TraceCollectorOutputType
 ) :  EventTracker {
     // We don't want to re-create this object each time we need it
     private val analysisProfile: AnalysisProfile = AnalysisProfile(false)
@@ -210,13 +223,13 @@ class TraceCollectingEventTracker(
             threadId = threadHandle.threadId,
             codeLocationId = codeLocation,
             fieldId = fieldId,
-            obj = TRObject(obj),
-            value = TRObject(value)
+            obj = TRObjectOrNull(obj),
+            value = TRObjectOrNull(value)
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
     }
 
-    override fun afterReadArrayElement(array: Any?, index: Int, codeLocation: Int, value: Any?) {
+    override fun afterReadArrayElement(array: Any, index: Int, codeLocation: Int, value: Any?) {
         val threadHandle = threads[Thread.currentThread()] ?: return
 
         val tracePoint = TRReadArrayTracePoint(
@@ -246,8 +259,8 @@ class TraceCollectingEventTracker(
             threadId = threadHandle.threadId,
             codeLocationId = codeLocation,
             fieldId = fieldId,
-            obj = TRObject(obj),
-            value = TRObject(value)
+            obj = TRObjectOrNull(obj),
+            value = TRObjectOrNull(value)
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
         return false
@@ -265,7 +278,7 @@ class TraceCollectingEventTracker(
             codeLocationId = codeLocation,
             array = TRObject(array),
             index = index,
-            value = TRObject(value)
+            value = TRObjectOrNull(value)
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
         return false
@@ -280,7 +293,7 @@ class TraceCollectingEventTracker(
             threadId = threadHandle.threadId,
             codeLocationId = codeLocation,
             localVariableId = variableId,
-            value = TRObject(value)
+            value = TRObjectOrNull(value)
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
 
@@ -295,7 +308,7 @@ class TraceCollectingEventTracker(
             threadId = threadHandle.threadId,
             codeLocationId = codeLocation,
             localVariableId = variableId,
-            value = TRObject(value)
+            value = TRObjectOrNull(value)
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
 
@@ -321,8 +334,8 @@ class TraceCollectingEventTracker(
             threadId = threadHandle.threadId,
             codeLocationId = codeLocation,
             methodId = methodId,
-            obj = TRObject(receiver),
-            parameters = params.map { TRObject(it) }
+            obj = TRObjectOrNull(receiver),
+            parameters = params.map { TRObjectOrNull(it) }
         )
         threadHandle.currentMethodCallTracePoint().events.add(tracePoint)
         threadHandle.pushStackFrame(tracePoint, receiver)
@@ -344,7 +357,7 @@ class TraceCollectingEventTracker(
         val methodDescriptor = methodCache[methodId]
 
         val tracePoint = threadHandle.popStackFrame()
-        tracePoint.result = TRObject(result)
+        tracePoint.result = TRObjectOrNull(result)
 
         val methodSection = methodAnalysisSectionType(receiver, methodDescriptor.className, methodDescriptor.methodName)
         threadHandle.leaveAnalysisSection(methodSection)
@@ -495,7 +508,11 @@ class TraceCollectingEventTracker(
                     roots.add(st.first())
                 }
             }
-            saveRecorderTrace(output, roots)
+            when (outputType) {
+                TraceCollectorOutputType.BINARY -> saveRecorderTrace(output, roots)
+                TraceCollectorOutputType.TEXT -> printRecorderTrace(output, roots, false)
+                TraceCollectorOutputType.VERBOSE -> printRecorderTrace(output, roots, true)
+            }
         } catch (t: Throwable) {
             System.err.println("TraceRecorder: Cannot write output file $traceDumpPath: ${t.message}")
             return

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceRecorder.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceRecorder.kt
@@ -41,9 +41,9 @@ import sun.nio.ch.lincheck.ThreadDescriptor
 object TraceRecorder {
     private var eventTracker: TraceCollectingEventTracker? = null
 
-    fun installAndStartTrace(className: String, methodName: String, traceFileName: String?) {
+    fun installAndStartTrace(className: String, methodName: String, traceFileName: String?, outputMode: String?) {
         // this method does need 'runInsideIgnoredSection' because analysis is not enabled until its completion
-        eventTracker = TraceCollectingEventTracker(className, methodName, traceFileName)
+        eventTracker = TraceCollectingEventTracker(className, methodName, traceFileName, outputMode.toTraceCollectorOutputType())
         val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: ThreadDescriptor(Thread.currentThread()).also {
             ThreadDescriptor.setCurrentThreadDescriptor(it)
         }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceRecorder.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/tracerecorder/TraceRecorder.kt
@@ -10,7 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck.strategy.tracerecorder
 
-import org.jetbrains.kotlinx.lincheck.util.runInsideIgnoredSection
+import org.jetbrains.kotlinx.lincheck.tracedata.INJECTIONS_VOID_OBJECT
 import sun.nio.ch.lincheck.Injections
 import sun.nio.ch.lincheck.ThreadDescriptor
 
@@ -42,6 +42,9 @@ object TraceRecorder {
     private var eventTracker: TraceCollectingEventTracker? = null
 
     fun installAndStartTrace(className: String, methodName: String, traceFileName: String?, outputMode: String?) {
+        // Set signal "void" object from Injections for better text output
+        INJECTIONS_VOID_OBJECT = Injections.VOID_RESULT
+
         // this method does need 'runInsideIgnoredSection' because analysis is not enabled until its completion
         eventTracker = TraceCollectingEventTracker(className, methodName, traceFileName, outputMode.toTraceCollectorOutputType())
         val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: ThreadDescriptor(Thread.currentThread()).also {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgentParameters.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgentParameters.kt
@@ -46,7 +46,7 @@ internal object TraceAgentParameters {
     }
 
     @JvmStatic
-    fun getResatOfArgs(): List<String> = restOfArgs
+    fun getRestOfArgs(): List<String> = restOfArgs
 
     @JvmStatic
     fun getClassAndMethod(): Pair<Class<*>, Method> {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgentParameters.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgentParameters.kt
@@ -28,6 +28,9 @@ internal object TraceAgentParameters {
     var traceDumpFilePath: String? = null
 
     @JvmStatic
+    private var restOfArgs: MutableList<String> = mutableListOf()
+
+    @JvmStatic
     fun parseArgs(args: String?) {
         if (args == null) {
             error("Please provide class and method names as arguments")
@@ -37,7 +40,13 @@ internal object TraceAgentParameters {
         classUnderTraceDebugging = actualArguments.getOrNull(0) ?: error("Class name was not provided")
         methodUnderTraceDebugging = actualArguments.getOrNull(1) ?: error("Method name was not provided")
         traceDumpFilePath = actualArguments.getOrNull(2)
+        if (actualArguments.size > 3) {
+            restOfArgs.addAll(actualArguments.subList(3, actualArguments.size))
+        }
     }
+
+    @JvmStatic
+    fun getResatOfArgs(): List<String> = restOfArgs
 
     @JvmStatic
     fun getClassAndMethod(): Pair<Class<*>, Method> {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceRecorderInjections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceRecorderInjections.kt
@@ -31,7 +31,7 @@ internal object TraceRecorderInjections {
             className = TraceAgentParameters.classUnderTraceDebugging,
             methodName = TraceAgentParameters.methodUnderTraceDebugging,
             traceFileName = TraceAgentParameters.traceDumpFilePath,
-            outputMode = TraceAgentParameters.getResatOfArgs().firstOrNull()
+            outputMode = TraceAgentParameters.getRestOfArgs().firstOrNull()
         )
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceRecorderInjections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceRecorderInjections.kt
@@ -30,7 +30,8 @@ internal object TraceRecorderInjections {
         TraceRecorder.installAndStartTrace(
             className = TraceAgentParameters.classUnderTraceDebugging,
             methodName = TraceAgentParameters.methodUnderTraceDebugging,
-            traceFileName = TraceAgentParameters.traceDumpFilePath
+            traceFileName = TraceAgentParameters.traceDumpFilePath,
+            outputMode = TraceAgentParameters.getResatOfArgs().firstOrNull()
         )
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Printing.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Printing.kt
@@ -1,0 +1,35 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck.tracedata
+
+import java.io.OutputStream
+import java.io.PrintStream
+
+private const val OUTPUT_BUFFER_SIZE: Int = 16*1024*1024
+
+fun printRecorderTrace(output: OutputStream, rootCallsPerThread: List<TRTracePoint>, verbose: Boolean) {
+    PrintStream(output.buffered(OUTPUT_BUFFER_SIZE)).use { output ->
+        rootCallsPerThread.forEachIndexed { i, root ->
+            output.println("# Thread ${i+1}")
+            printTRPoint(output, root, 0, verbose)
+        }
+    }
+}
+
+private fun printTRPoint(output: PrintStream, node: TRTracePoint, depth: Int, verbose: Boolean) {
+    output.print(" ".repeat(depth * 2))
+    output.println(node.toText(verbose))
+    if (node is TRMethodCallTracePoint) {
+        node.events.forEach {
+            printTRPoint(output, it, depth + 1, verbose)
+        }
+    }
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Serialization.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Serialization.kt
@@ -12,7 +12,8 @@ package org.jetbrains.kotlinx.lincheck.tracedata
 
 import java.io.*
 
-const val OUTPUT_BUFFER_SIZE: Int = 16*1024*1024
+private const val OUTPUT_BUFFER_SIZE: Int = 16*1024*1024
+
 const val TRACE_MAGIC : Long = 0x706e547124ee5f70L
 const val TRACE_VERSION : Long = 4
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/TraceRecorderTracePoints.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/TraceRecorderTracePoints.kt
@@ -38,7 +38,7 @@ class TRMethodCallTracePoint(
     val obj: TRObject?,
     val parameters: List<TRObject?>,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     var result: TRObject? = null
     var exceptionClassName: String? = null
     @Transient
@@ -93,7 +93,7 @@ class TRMethodCallTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRMethodCallTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRMethodCallTracePoint {
             val methodId = inp.readInt()
             val obj = inp.readTRObject()
             val pcount = inp.readInt()
@@ -134,7 +134,7 @@ class TRReadTracePoint(
     val obj: TRObject?,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeInt(fieldId)
@@ -162,7 +162,7 @@ class TRReadTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRReadTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRReadTracePoint {
             return TRReadTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -182,7 +182,7 @@ class TRWriteTracePoint(
     val obj: TRObject?,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeInt(fieldId)
@@ -210,7 +210,7 @@ class TRWriteTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRWriteTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRWriteTracePoint {
             return TRWriteTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -229,7 +229,7 @@ class TRReadLocalVariableTracePoint(
     val localVariableId: Int,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeInt(localVariableId)
@@ -248,7 +248,7 @@ class TRReadLocalVariableTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRReadLocalVariableTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRReadLocalVariableTracePoint {
             return TRReadLocalVariableTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -266,7 +266,7 @@ class TRWriteLocalVariableTracePoint(
     val localVariableId: Int,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeInt(localVariableId)
@@ -285,7 +285,7 @@ class TRWriteLocalVariableTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRWriteLocalVariableTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRWriteLocalVariableTracePoint {
             return TRWriteLocalVariableTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -304,7 +304,7 @@ class TRReadArrayTracePoint(
     val index: Int,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeTRObject(array)
@@ -327,7 +327,7 @@ class TRReadArrayTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRReadArrayTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRReadArrayTracePoint {
             return TRReadArrayTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -347,7 +347,7 @@ class TRWriteArrayTracePoint(
     val index: Int,
     val value: TRObject?,
     eventId: Int = EVENT_ID_GENERATOR.getAndIncrement()
-) : TRTracePoint(threadId, codeLocationId, eventId) {
+) : TRTracePoint(codeLocationId, threadId, eventId) {
     override fun save(out: DataOutput) {
         super.save(out)
         out.writeTRObject(array)
@@ -370,7 +370,7 @@ class TRWriteArrayTracePoint(
     }
 
     internal companion object {
-        fun load(inp: DataInput, threadId: Int, codeLocationId: Int, eventId: Int): TRWriteArrayTracePoint {
+        fun load(inp: DataInput, codeLocationId: Int, threadId: Int, eventId: Int): TRWriteArrayTracePoint {
             return TRWriteArrayTracePoint(
                 threadId = threadId,
                 codeLocationId = codeLocationId,
@@ -384,11 +384,11 @@ class TRWriteArrayTracePoint(
 }
 
 fun loadTRTracePoint(inp: DataInput): TRTracePoint {
-    val loader = getLoaderBy(inp.readByte())
-    val threadId = inp.readInt()
+    val loader = getLoaderByClassId(inp.readByte())
     val codeLocationId = inp.readInt()
+    val threadId = inp.readInt()
     val eventId = inp.readInt()
-    return loader(inp, threadId, codeLocationId, eventId)
+    return loader(inp, codeLocationId, threadId, eventId)
 }
 
 internal val classNameCache = IndexedPool<String>()
@@ -455,7 +455,7 @@ private fun getClassId(point: TRTracePoint): Int {
     }
 }
 
-private fun getLoaderBy(id: Byte): TRLoader {
+private fun getLoaderByClassId(id: Byte): TRLoader {
     return when (id.toInt()) {
         0 -> TRMethodCallTracePoint::load
         1 -> TRReadArrayTracePoint::load

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/TraceRecorderTracePoints.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/TraceRecorderTracePoints.kt
@@ -437,7 +437,7 @@ private fun DataInput.readTRObject(): TRObject? {
 private fun <V: Appendable> V.append(codeLocationId: Int, verbose: Boolean): V {
     if (!verbose) return this
     val cl = CodeLocations.stackTrace(codeLocationId)
-    append(" at [$codeLocationId] ").append(cl.fileName).append(':').append(cl.lineNumber.toString())
+    append(" at ").append(cl.fileName).append(':').append(cl.lineNumber.toString())
     return this
 }
 


### PR DESCRIPTION
Now Agent can take the 4th parameter (after class, method and file): type of output.

Valid values are: `binary`, `text` and `verbose`.

- `binary` is default if no parameter was given or the wrong name was given.
- `text` is simple text output without locations.
- `verbose` is simple text output with locations.

Example of verbose output (double-accesses to arguments looks like Instrumentation problem — local variable `t` is tracked without duplication).
```
# Thread 1
GuavaImmutableListTest.list() at :0
  GuavaImmutableListTest@990684641.run() at GuavaImmutableListTest.kt:72
    t ← Thread@886004375 at GuavaImmutableListTest.kt:58
    t → Thread@886004375 at GuavaImmutableListTest.kt:61
    Thread@886004375.start() at GuavaImmutableListTest.kt:61
    GuavaImmutableListTest@990684641.setY(String@1243350866) at GuavaImmutableListTest.kt:63
      value → String@1243350866 at GuavaImmutableListTest.kt:0
      value → String@1243350866 at GuavaImmutableListTest.kt:54
      GuavaImmutableListTest@990684641.y ← String@1243350866 at GuavaImmutableListTest.kt:54
    t → Thread@886004375 at GuavaImmutableListTest.kt:65
    GuavaImmutableListTest@990684641.setY(String@138933223) at GuavaImmutableListTest.kt:67
      value → String@138933223 at GuavaImmutableListTest.kt:0
      value → String@138933223 at GuavaImmutableListTest.kt:54
      GuavaImmutableListTest@990684641.y ← String@138933223 at GuavaImmutableListTest.kt:54
    GuavaImmutableListTest@990684641.setX(String@1774897456) at GuavaImmutableListTest.kt:68
      value → String@1774897456 at GuavaImmutableListTest.kt:0
      value → String@1774897456 at GuavaImmutableListTest.kt:50
      GuavaImmutableListTest@990684641.x ← String@1774897456 at GuavaImmutableListTest.kt:50
```

*Update:* This code fixes big problem with messed up codeLocationId / threadId.