### PR TITLE
Group all trace-recorder related classes (but not trace data classes) into separate package.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgent.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/traceagent/TraceAgent.kt
@@ -10,6 +10,8 @@
 
 package org.jetbrains.kotlinx.lincheck.traceagent
 
+import org.jetbrains.kotlinx.lincheck.tracerecorder.agent.TraceRecorderInjections
+import org.jetbrains.kotlinx.lincheck.tracerecorder.agent.TraceRecorderMethodTransformer
 import org.jetbrains.kotlinx.lincheck.transformation.ASM_API
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode.MODEL_CHECKING
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/TraceCollectingEventTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/TraceCollectingEventTracker.kt
@@ -8,7 +8,7 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.strategy.tracerecorder
+package org.jetbrains.kotlinx.lincheck.tracerecorder
 
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ShadowStackFrame
 import org.jetbrains.kotlinx.lincheck.tracedata.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/TraceRecorder.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/TraceRecorder.kt
@@ -8,7 +8,7 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.strategy.tracerecorder
+package org.jetbrains.kotlinx.lincheck.tracerecorder
 
 import org.jetbrains.kotlinx.lincheck.tracedata.INJECTIONS_VOID_OBJECT
 import sun.nio.ch.lincheck.Injections

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/agent/TraceRecorderInjections.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/agent/TraceRecorderInjections.kt
@@ -8,12 +8,12 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.traceagent
+package org.jetbrains.kotlinx.lincheck.tracerecorder.agent
 
-import org.jetbrains.kotlinx.lincheck.strategy.tracerecorder.TraceRecorder
+import org.jetbrains.kotlinx.lincheck.tracerecorder.TraceRecorder
+import org.jetbrains.kotlinx.lincheck.traceagent.TraceAgentParameters
 import org.jetbrains.kotlinx.lincheck.transformation.InstrumentationMode
 import org.jetbrains.kotlinx.lincheck.transformation.LincheckJavaAgent
-import org.objectweb.asm.commons.Method
 
 internal object TraceRecorderInjections {
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/agent/TraceRecorderMethodTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/agent/TraceRecorderMethodTransformer.kt
@@ -8,10 +8,9 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.traceagent
+package org.jetbrains.kotlinx.lincheck.tracerecorder.agent
 
 import org.jetbrains.kotlinx.lincheck.transformation.ASM_API
-import org.jetbrains.kotlinx.lincheck.transformation.invokeInsideIgnoredSection
 import org.jetbrains.kotlinx.lincheck.transformation.invokeStatic
 import org.objectweb.asm.commons.AdviceAdapter
 import org.objectweb.asm.commons.GeneratorAdapter

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/transformers/MethodCallMinimalTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/transformers/MethodCallMinimalTransformer.kt
@@ -1,18 +1,19 @@
 /*
  * Lincheck
  *
- * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
  *
  * This Source Code Form is subject to the terms of the
  * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.transformation.transformers
+package org.jetbrains.kotlinx.lincheck.tracerecorder.transformers
 
 import org.jetbrains.kotlinx.lincheck.transformation.*
 import org.jetbrains.kotlinx.lincheck.tracedata.MethodDescriptor
 import org.jetbrains.kotlinx.lincheck.tracedata.methodCache
+import org.jetbrains.kotlinx.lincheck.transformation.transformers.MethodCallTransformerBase
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type.*
 import org.objectweb.asm.commons.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/transformers/ObjectCreationMinimalTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracerecorder/transformers/ObjectCreationMinimalTransformer.kt
@@ -8,7 +8,7 @@
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.transformation.transformers
+package org.jetbrains.kotlinx.lincheck.tracerecorder.transformers
 
 import sun.nio.ch.lincheck.*
 import org.jetbrains.kotlinx.lincheck.transformation.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.traceagent.isInTraceDebuggerMode
 import org.jetbrains.kotlinx.lincheck.tracedata.CodeLocations
 import org.jetbrains.kotlinx.lincheck.tracedata.FinalFields
+import org.jetbrains.kotlinx.lincheck.tracerecorder.transformers.MethodCallMinimalTransformer
+import org.jetbrains.kotlinx.lincheck.tracerecorder.transformers.ObjectCreationMinimalTransformer
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.commons.*


### PR DESCRIPTION
It allows to extract it as separate module in the future.