### PR TITLE
Hotfixes for artifact publication and plugin integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -398,5 +398,6 @@ publishing {
 }
 
 tasks.named("generateMetadataFileForMavenPublication") {
+    dependsOn(jar)
     dependsOn(sourcesJar)
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -12,6 +12,8 @@ package org.jetbrains.kotlinx.lincheck
 import org.jetbrains.lincheck.LincheckAssertionError
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategySettings
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.jetbrains.kotlinx.lincheck.transformation.withLincheckJavaAgent
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingCTestConfiguration
@@ -131,7 +133,7 @@ constructor(private val testClass: Class<*>, options: Options<*, *>?) {
      * as the failing scenario might need to be minimized first.
      */
     private fun CTestConfiguration.runReplayForPlugin(failure: LincheckFailure, verifier: Verifier) {
-        if (ideaPluginEnabled && this is ModelCheckingCTestConfiguration) {
+        if (ideaPluginEnabled && this is ManagedCTestConfiguration) {
             runPluginReplay(
                 settings = this.createSettings(),
                 testClass = testClass,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyConfiguration.kt
@@ -105,7 +105,8 @@ abstract class ManagedCTestConfiguration(
     minimizeFailedScenario: Boolean,
     sequentialSpecification: Class<*>,
     timeoutMs: Long,
-    customScenarios: List<ExecutionScenario>
+    customScenarios: List<ExecutionScenario>,
+    internal val stdLibAnalysisEnabled: Boolean,
 ) : CTestConfiguration(
     testClass = testClass,
     iterations = iterations,
@@ -121,6 +122,15 @@ abstract class ManagedCTestConfiguration(
     timeoutMs = timeoutMs,
     customScenarios = customScenarios
 ) {
+    internal fun createSettings(): ManagedStrategySettings =
+        ManagedStrategySettings(
+            timeoutMs = this.timeoutMs,
+            hangingDetectionThreshold = this.hangingDetectionThreshold,
+            checkObstructionFreedom = this.checkObstructionFreedom,
+            analyzeStdLib = this.stdLibAnalysisEnabled,
+            guarantees = this.guarantees.ifEmpty { null },
+        )
+
     companion object {
         const val DEFAULT_CHECK_OBSTRUCTION_FREEDOM = false
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategyConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategyConfiguration.kt
@@ -77,7 +77,7 @@ class ModelCheckingCTestConfiguration(
     sequentialSpecification: Class<*>,
     timeoutMs: Long,
     customScenarios: List<ExecutionScenario>,
-    internal val stdLibAnalysisEnabled: Boolean,
+    stdLibAnalysisEnabled: Boolean,
 ) : ManagedCTestConfiguration(
     testClass = testClass,
     iterations = iterations,
@@ -94,7 +94,8 @@ class ModelCheckingCTestConfiguration(
     minimizeFailedScenario = minimizeFailedScenario,
     sequentialSpecification = sequentialSpecification,
     timeoutMs = timeoutMs,
-    customScenarios = customScenarios
+    customScenarios = customScenarios,
+    stdLibAnalysisEnabled = stdLibAnalysisEnabled,
 ) {
 
     override val instrumentationMode: InstrumentationMode get() = MODEL_CHECKING
@@ -111,13 +112,4 @@ class ModelCheckingCTestConfiguration(
         stateRepresentationMethod,
         createSettings()
     )
-
-    internal fun createSettings(): ManagedStrategySettings =
-        ManagedStrategySettings(
-            timeoutMs = this.timeoutMs,
-            hangingDetectionThreshold = this.hangingDetectionThreshold,
-            checkObstructionFreedom = this.checkObstructionFreedom,
-            analyzeStdLib = this.stdLibAnalysisEnabled,
-            guarantees = this.guarantees.ifEmpty { null },
-        )
 }

--- a/src/jvm/main/org/jetbrains/lincheck/datastructures/ModelCheckingStrategyConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/lincheck/datastructures/ModelCheckingStrategyConfiguration.kt
@@ -73,7 +73,7 @@ class ModelCheckingCTestConfiguration(
     sequentialSpecification: Class<*>,
     timeoutMs: Long,
     customScenarios: List<ExecutionScenario>,
-    internal val stdLibAnalysisEnabled: Boolean,
+    stdLibAnalysisEnabled: Boolean,
 ) : ManagedCTestConfiguration(
     testClass = testClass,
     iterations = iterations,
@@ -90,7 +90,8 @@ class ModelCheckingCTestConfiguration(
     minimizeFailedScenario = minimizeFailedScenario,
     sequentialSpecification = sequentialSpecification,
     timeoutMs = timeoutMs,
-    customScenarios = customScenarios
+    customScenarios = customScenarios,
+    stdLibAnalysisEnabled = stdLibAnalysisEnabled,
 ) {
 
     override val instrumentationMode: InstrumentationMode get() = MODEL_CHECKING
@@ -107,13 +108,4 @@ class ModelCheckingCTestConfiguration(
         stateRepresentationMethod,
         createSettings()
     )
-
-    internal fun createSettings(): ManagedStrategySettings =
-        ManagedStrategySettings(
-            timeoutMs = this.timeoutMs,
-            hangingDetectionThreshold = this.hangingDetectionThreshold,
-            checkObstructionFreedom = this.checkObstructionFreedom,
-            analyzeStdLib = this.stdLibAnalysisEnabled,
-            guarantees = this.guarantees.ifEmpty { null },
-        )
 }


### PR DESCRIPTION
- Explicitly add `jar` to publication dependencies to ensure `.class` files are generated and added to the artifact.
- Fix accidental bug in `runReplayForPlugin` introduced in https://github.com/JetBrains/lincheck/pull/695 during API migration.