### PR TITLE
Hotfixes for livelock detection inside validation function

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/LoopDetector.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/LoopDetector.kt
@@ -69,7 +69,7 @@ import org.jetbrains.lincheck.datastructures.ManagedCTestConfiguration
  * Note: An example of this behavior is detailed in the comments of the code itself.
  */
 internal class LoopDetector(
-    private var hangingDetectionThreshold: Int
+    private val hangingDetectionThreshold: Int
 ) {
     /**
      * Current mode.
@@ -85,6 +85,13 @@ internal class LoopDetector(
      * Tracks the count of total thread execution points handled by the loop detector.
      */
     private var totalExecutionsCount = 0
+
+    /**
+     * Current threshold for detecting possible livelock conditions during execution.
+     * It is initialized with the [hangingDetectionThreshold] value
+     * and can be adjusted dynamically to influence the sensitivity of the spin-loop detection logic.
+     */
+    private var currentHangingDetectionThreshold = hangingDetectionThreshold
 
     /**
      * Map, which helps us to determine how many times the current thread visits some code location.
@@ -141,6 +148,7 @@ internal class LoopDetector(
     fun reset() {
         currentThreadId = -1
         totalExecutionsCount = 0
+        currentHangingDetectionThreshold = hangingDetectionThreshold
         currentThreadCodeLocationVisitCountMap.clear()
         currentThreadCodeLocationsHistory.clear()
         currentInterleavingHistory.clear()
@@ -262,8 +270,8 @@ internal class LoopDetector(
         if (isInTraceDebuggerMode) {
             return when {
                 // spin-loop detected - switch
-                count > hangingDetectionThreshold ->
-                    Decision.LivelockThreadSwitch(hangingDetectionThreshold)
+                count > currentHangingDetectionThreshold ->
+                    Decision.LivelockThreadSwitch(currentHangingDetectionThreshold)
                 // live-lock detected - fail
                 totalExecutionsCount > ManagedCTestConfiguration.DEFAULT_LIVELOCK_EVENTS_THRESHOLD ->
                     Decision.EventsThresholdReached
@@ -271,7 +279,7 @@ internal class LoopDetector(
                 else -> Decision.Idle
             }
         }
-        val detectedFirstTime = count > hangingDetectionThreshold
+        val detectedFirstTime = count > currentHangingDetectionThreshold
         val detectedEarly = loopTrackingCursor.isInCycle
         // detectedFirstTime and detectedEarly can both sometimes be true
         // when we can't find a cycle period and can't switch to another thread.
@@ -292,7 +300,7 @@ internal class LoopDetector(
             return Decision.LivelockReplayRequired
         }
         if (!detectedFirstTime && detectedEarly) {
-            totalExecutionsCount += hangingDetectionThreshold
+            totalExecutionsCount += currentHangingDetectionThreshold
             val lastNode = currentInterleavingHistory.last()
             // spinCyclePeriod may be not 0 only we tried to switch
             // from the current thread but no available threads were available to switch
@@ -454,7 +462,7 @@ internal class LoopDetector(
             // - in our use cases of concurrent algorithms, many typical validation functions contain
             //   long-running for-loops iterating over large pre-allocated arrays,
             //   which size exceeds the default value of `hangingDetectionThreshold`.
-            hangingDetectionThreshold = ManagedCTestConfiguration.DEFAULT_LIVELOCK_EVENTS_THRESHOLD
+            currentHangingDetectionThreshold = ManagedCTestConfiguration.DEFAULT_LIVELOCK_EVENTS_THRESHOLD + 1
         }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -352,7 +352,7 @@ internal abstract class ManagedStrategy(
             POST        -> 0
             VALIDATION  -> 0
         }
-        loopDetector.beforePart(nextThread)
+        loopDetector.beforePart(part, nextThread)
         threadScheduler.scheduleThread(nextThread)
     }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
@@ -9,11 +9,14 @@
  */
 package org.jetbrains.kotlinx.lincheck_test.representation
 
-import org.jetbrains.lincheck.datastructures.Operation
+import org.jetbrains.kotlinx.lincheck.check
 import org.jetbrains.kotlinx.lincheck.checkImpl
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
+import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
+import org.jetbrains.lincheck.datastructures.Operation
+import org.jetbrains.lincheck.datastructures.Validate
 import org.jetbrains.lincheck.datastructures.ModelCheckingOptions
 import org.jetbrains.kotlinx.lincheck_test.util.*
-import org.jetbrains.lincheck.datastructures.Validate
 import org.junit.*
 import java.lang.IllegalStateException
 
@@ -107,4 +110,39 @@ class MoreThenOneValidationFunctionFailureTest {
     @Test
     fun test() = ModelCheckingOptions()
         .checkFailsWithException<IllegalStateException>(this::class.java, "two_validation_functions_exception")
+}
+
+class ValidationFunctionLongLoopTest {
+    var a = 0
+
+    val loopCount = 1024
+
+    init {
+        check(loopCount > ManagedCTestConfiguration.DEFAULT_HANGING_DETECTION_THRESHOLD)
+        check(loopCount < ManagedCTestConfiguration.DEFAULT_LIVELOCK_EVENTS_THRESHOLD)
+    }
+
+    @Operation
+    fun operation() {
+        a++
+    }
+
+    @Validate
+    fun validate() {
+        // check that long-running loops inside a validation function
+        // do not trigger active-lock failure
+        repeat(loopCount) {
+            a++
+        }
+    }
+
+    @Test
+    fun test() = ModelCheckingOptions()
+        .iterations(1)
+        .actorsBefore(0)
+        .actorsAfter(0)
+        .actorsPerThread(1)
+        .logLevel(LoggingLevel.INFO)
+        .minimizeFailedScenario(false)
+        .check(this::class.java)
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/ValidationFunctionTests.kt
@@ -9,10 +9,8 @@
  */
 package org.jetbrains.kotlinx.lincheck_test.representation
 
-import org.jetbrains.kotlinx.lincheck.check
 import org.jetbrains.kotlinx.lincheck.checkImpl
-import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
-import org.jetbrains.kotlinx.lincheck.util.LoggingLevel
+import org.jetbrains.lincheck.datastructures.ManagedCTestConfiguration
 import org.jetbrains.lincheck.datastructures.Operation
 import org.jetbrains.lincheck.datastructures.Validate
 import org.jetbrains.lincheck.datastructures.ModelCheckingOptions
@@ -142,7 +140,6 @@ class ValidationFunctionLongLoopTest {
         .actorsBefore(0)
         .actorsAfter(0)
         .actorsPerThread(1)
-        .logLevel(LoggingLevel.INFO)
         .minimizeFailedScenario(false)
         .check(this::class.java)
 }


### PR DESCRIPTION
- Fix out-of-bounds exceptions. 
- Effectively disable spin-lock detection inside validation functions (but not total events count check!) --- to support cases of validation functions iterating over large arrays in the concurrent algorithms course. 