### PR TITLE
Clear all caches and global storages before loading trace.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/CodeLocations.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/CodeLocations.kt
@@ -59,6 +59,15 @@ internal object CodeLocations {
         return codeLocations[codeLocationId]
     }
 
+    /**
+     * Clear all saved code locations.
+     */
+    @JvmStatic
+    @Synchronized
+    fun clear() {
+        codeLocations.clear()
+    }
+
     val content: List<StackTraceElement> get() = codeLocations
 }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Descriptors.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Descriptors.kt
@@ -39,6 +39,12 @@ internal class IndexedPool<T> {
     }
 
     val content: List<T> = items
+
+    @Synchronized
+    fun clear() {
+        items.clear()
+        index.clear()
+    }
 }
 
 internal fun <T> IndexedPool<T>.getInterned(item: T) = get(getOrCreateId(item))

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Serialization.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/tracedata/Serialization.kt
@@ -79,6 +79,8 @@ private fun <V> saveCache(output: DataOutput, cache: IndexedPool<V>, writer: Dat
 
 
 private fun <V> loadCache(input: DataInput, cache: IndexedPool<V>, reader: DataInput.() -> V) {
+    cache.clear()
+
     val count = input.readInt()
     repeat(count) {
         cache.getOrCreateId(input.reader())
@@ -108,6 +110,8 @@ private fun saveCodeLocations(output: DataOutput, stringCache: IndexedPool<Strin
 }
 
 private fun loadCodeLocations(input: DataInput, stringCache: IndexedPool<String>) {
+    CodeLocations.clear()
+
     val count = input.readInt()
     repeat(count) {
         CodeLocations.newCodeLocation(input.readStackTraceElement(stringCache))


### PR DESCRIPTION
It allows loading multiple traces one by one (but each new load will invalidate the old one).