### PR TITLE
Enable inline calls.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -125,7 +125,7 @@ internal class LincheckClassVisitor(
             // Inline method call transformer relies on the original variables' indices, so it should go before (in FIFO order)
             // all transformers which can create local variables.
             // All visitors created AFTER InlineMethodCallTransformer must use a non-remapping Generator adapter.
-            // mv = InlineMethodCallTransformer(fileName, className, methodName, desc, mv.newNonRemappingAdapter(), methods[methodName + desc] ?: MethodVariables(), mv)
+            mv = InlineMethodCallTransformer(fileName, className, methodName, desc, mv.newNonRemappingAdapter(), methods[methodName + desc] ?: MethodVariables(), mv)
             return mv
         }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InlineMethodCallTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/transformation/transformers/InlineMethodCallTransformer.kt
@@ -104,6 +104,16 @@ internal class InlineMethodCallTransformer(
         super.visitLabel(label)
     }
 
+    override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+        super.visitMaxs(maxStack, maxLocals)
+        if (inlineStack.isNotEmpty()) {
+            System.err.println("Inline methods calls are not balanced at $className.$methodName:")
+            inlineStack.reversed().forEach {
+                System.err.println("  ${it.name} (slot ${it.index}) called at label ${it.labelIndexRange.first}")
+            }
+        }
+    }
+
     @Suppress("UNUSED_PARAMETER")
     private fun processInlineMethodCall(className: String, inlineMethodName: String, ownerType: org.objectweb.asm.Type?, owner: Int?, startLabel: Label) = adapter.run {
         // Create a fake method descriptor


### PR DESCRIPTION
Cannot reproduce a problem with unbalanced calls to call/return.

Add more diagnostics.