### PR TITLE
Lev serebryakov/tr bugfixes on kotlin tests

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
@@ -99,12 +99,12 @@ internal interface TraceWriter : DataOutput, Closeable {
     /**
      * Mark the beginning of container tracepoint's footer (After all children are saved).
      */
-    fun startWriteContainerTracepointFooter(id: Int)
+    fun startWriteContainerTracepointFooter()
 
     /**
      * Marks the end of container tracepoint's footer.
      */
-    fun endWriteContainerTracepointFooter()
+    fun endWriteContainerTracepointFooter(id: Int)
 
     /**
      * Write [ClassDescriptor] from context referred by given `id`, if needed.
@@ -173,6 +173,7 @@ private sealed class TraceWriterBase(
     private val containerStack = mutableListOf<Pair<Int, Long>>()
 
     private var inTracepointBody = false
+    private var footerPosition: Long = -1
 
     protected abstract val currentDataPosition: Long
     protected abstract val writerId: Int
@@ -214,26 +215,31 @@ private sealed class TraceWriterBase(
         containerStack.add(id to currentDataPosition)
     }
 
-    override fun startWriteContainerTracepointFooter(id: Int) {
+    override fun startWriteContainerTracepointFooter() {
         check(!inTracepointBody) { "Cannot start nested tracepoint footer" }
         inTracepointBody = true
+        footerPosition = currentDataPosition
 
         check(containerStack.isNotEmpty()) {
-            "Calls endWriteContainerTracepointHeader(?) / startWriteContainerTracepointFooter($id) are not balanced"
+            "Calls endWriteContainerTracepointHeader() / startWriteContainerTracepointFooter() are not balanced"
         }
-        val (storedId, startPos) = containerStack.removeLast()
-        check(id == storedId) {
-            "Calls endWriteContainerTracepointHeader($storedId) / startWriteContainerTracepointFooter($id) are not balanced"
-        }
-        writeIndexCell(ObjectKind.TRACEPOINT, id, startPos, currentDataPosition)
 
         // Start object
         data.writeKind(ObjectKind.TRACEPOINT_FOOTER)
     }
 
-    override fun endWriteContainerTracepointFooter() {
+    override fun endWriteContainerTracepointFooter(id: Int) {
         check(inTracepointBody) { "Cannot end tracepoint footer not in tracepoint" }
+        check(footerPosition >= 0) { "Cannot end tracepoint footer not in tracepoint footer" }
+
+        val (storedId, startPos) = containerStack.removeLast()
+        check(id == storedId) {
+            "Calls endWriteContainerTracepointHeader($storedId) / startWriteContainerTracepointFooter($id) are not balanced"
+        }
+        writeIndexCell(ObjectKind.TRACEPOINT, id, startPos, footerPosition)
+
         inTracepointBody = false
+        footerPosition = -1
     }
 
     override fun writeClassDescriptor(id: Int) {
@@ -337,6 +343,12 @@ private sealed class TraceWriterBase(
         return -id
     }
 
+    protected fun resetTracepointState() {
+        inTracepointBody = false
+        footerPosition = -1
+    }
+
+
     protected abstract fun writeIndexCell(kind: ObjectKind, id: Int, startPos: Long, endPos: Long)
 }
 
@@ -377,13 +389,25 @@ private class BufferedTraceWriter (
         maybeFlushData()
     }
 
-    override fun endWriteContainerTracepointFooter() {
-        super.endWriteContainerTracepointFooter()
+    override fun endWriteContainerTracepointFooter(id: Int) {
+        super.endWriteContainerTracepointFooter(id)
         maybeFlushData()
     }
 
     override fun writeIndexCell(kind: ObjectKind, id: Int, startPos: Long, endPos: Long) {
         index.add(IndexCell(kind, id, startPos, endPos))
+        // Rollback to here in case of overflow, as the index cell is written after all
+        // object data, it means that object is in data buffer completely.
+        dataStream.mark()
+    }
+
+    fun mark() {
+        dataStream.mark()
+    }
+
+    fun rollback() {
+        resetTracepointState()
+        dataStream.rollback()
     }
 
     fun flush() {
@@ -613,9 +637,11 @@ class FileStreamingTraceCollecting(
     ) {
         val writer = writers[Thread.currentThread()] ?: return
         try {
+            writer.mark()
             created.save(writer)
         } catch (_: BufferOverflowException) {
             // Flush current buffers, start over
+            writer.rollback()
             writer.flush()
             created.save(writer)
         }
@@ -624,9 +650,11 @@ class FileStreamingTraceCollecting(
     override fun callEnded(callTracepoint: TRMethodCallTracePoint) {
         val writer = writers[Thread.currentThread()] ?: return
         try {
+            writer.mark()
             callTracepoint.saveFooter(writer)
         } catch (_: BufferOverflowException) {
             // Flush current buffers, start over
+            writer.rollback()
             writer.flush()
             callTracepoint.saveFooter(writer)
         }

--- a/trace/src/main/org/jetbrains/lincheck/trace/Streams.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Streams.kt
@@ -157,6 +157,14 @@ internal class ByteBufferOutputStream(
         buffer.clear()
     }
 
+    fun mark() {
+        buffer.mark()
+    }
+
+    fun rollback() {
+        buffer.reset()
+    }
+
     fun position(): Int = buffer.position()
 }
 

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -575,8 +575,9 @@ fun TRObjectOrVoid(obj: Any?): TRObject? =
     else TRObjectOrNull(obj)
 
 
-private fun trimString(s: CharSequence): String = s.take(min(50, s.length)).toString()
+const val MAX_TROBJECT_STRING_LENGTH = 50
 
+private fun trimString(s: CharSequence): String = s.take(MAX_TROBJECT_STRING_LENGTH).toString()
 
 fun TRObject(obj: Any): TRObject {
     return when (obj) {

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -138,11 +138,11 @@ class TRMethodCallTracePoint(
     internal fun saveFooter(out: TraceWriter) {
         out.preWriteTRObject(result)
 
-        // Mark this as container tracepoint which could have children and will have footer
-        out.startWriteContainerTracepointFooter(eventId)
+        // Mark this as a container tracepoint footer
+        out.startWriteContainerTracepointFooter()
         out.writeTRObject(result)
         out.writeUTF(exceptionClassName ?: "")
-        out.endWriteContainerTracepointFooter()
+        out.endWriteContainerTracepointFooter(eventId)
     }
 
     internal fun loadFooter(inp: DataInput) {

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -22,6 +22,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 private val EVENT_ID_GENERATOR = AtomicInteger(0)
@@ -573,6 +574,10 @@ fun TRObjectOrVoid(obj: Any?): TRObject? =
     if (obj == INJECTIONS_VOID_OBJECT) TR_OBJECT_VOID
     else TRObjectOrNull(obj)
 
+
+private fun trimString(s: CharSequence): String = s.take(min(50, s.length)).toString()
+
+
 fun TRObject(obj: Any): TRObject {
     return when (obj) {
         is Byte -> TRObject(TR_OBJECT_P_BYTE, 0, obj)
@@ -582,8 +587,8 @@ fun TRObject(obj: Any): TRObject {
         is Float -> TRObject(TR_OBJECT_P_FLOAT, 0, obj)
         is Double -> TRObject(TR_OBJECT_P_DOUBLE, 0, obj)
         is Char -> TRObject(TR_OBJECT_P_CHAR, 0, obj)
-        is String -> TRObject(TR_OBJECT_P_STRING, 0, obj)
-        is CharSequence -> TRObject(TR_OBJECT_P_STRING, 0, obj.toString())
+        is String -> TRObject(TR_OBJECT_P_STRING, 0, trimString(obj))
+        is CharSequence -> TRObject(TR_OBJECT_P_STRING, 0, trimString(obj))
         is Unit -> TRObject(TR_OBJECT_P_UNIT, 0, obj)
         is Boolean -> TRObject(TR_OBJECT_P_BOOLEAN, 0, obj)
         // Render these types to strings for simplicity


### PR DESCRIPTION
Fix problems when thread buffer is overflown.

Limit string size to buffer size, too.

This fix Kotlin's `:compiler:tests-integration:test --tests "org.jetbrains.kotlin.cli.CliTestGenerated$Jvm.testExtraHelp" `

But this test generates 10GiB of Strings, so it will need A LOT of memory to load trace.