### PR TITLE
Compare for `INJECTIONS_VOID_OBJECT` using reference equality

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -509,7 +509,7 @@ fun TRObjectOrNull(obj: Any?): TRObject? =
     obj?.let { TRObject(it) }
 
 fun TRObjectOrVoid(obj: Any?): TRObject? =
-    if (obj == INJECTIONS_VOID_OBJECT) TR_OBJECT_VOID
+    if (obj === INJECTIONS_VOID_OBJECT) TR_OBJECT_VOID
     else TRObjectOrNull(obj)
 
 


### PR DESCRIPTION
We stumbled upon a bug when `equals` implementation can throw an exception. Because of this we will end up with an exception in `onMethodCallReturn` and incorrect stack in the end.