### PR TITLE
Instrument `enclosingClass` of a given class

### DIFF
--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -362,6 +362,10 @@ object LincheckJavaAgent {
             if (it.name in instrumentedClasses) return // already instrumented
             ensureClassHierarchyIsTransformed(it, processedObjects)
         }
+        clazz.enclosingClass?.let {
+            if (it.name in instrumentedClasses) return // already instrumented
+            ensureClassHierarchyIsTransformed(it, processedObjects)
+        }
     }
 
     /**


### PR DESCRIPTION
If we meet a nested class, it will not be properly instrumented without this fix. We will see just a couple of top-level trace points.