### PR TITLE
SeekableChannelBufferedInputStream.position() can be wrong …

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/Streams.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Streams.kt
@@ -89,7 +89,10 @@ internal class SeekableChannelBufferedInputStream(
             buffer.clear()
             // Mark as empty for reading
             buffer.position(buffer.capacity())
+
             channel.position(pos)
+            // To support call of [position()] right after this seek() without buffer reading
+            bufferStartPosition = pos - buffer.position()
         } else {
             buffer.position((pos - bufferStartPosition).toInt())
         }


### PR DESCRIPTION
…right after SeekableChannelBufferedInputStream.seek() without read() in between.