### PR TITLE
Fix issue DR-266 with non-transformed classes accessed from other constructors

### DIFF
--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassVisitor.kt
@@ -99,13 +99,18 @@ internal class LincheckClassVisitor(
         }
 
         if (instrumentationMode == TRACE_RECORDING) {
-            if (methodName == "<clinit>" || methodName == "<init>") return mv
+            if (methodName == "<clinit>") return mv
 
             mv = JSRInlinerAdapter(mv, access, methodName, desc, signature, exceptions)
             mv = TryCatchBlockSorter(mv, access, methodName, desc, signature, exceptions)
 
             val adapter = GeneratorAdapter(mv, access, methodName, desc)
             mv = adapter
+
+            if (methodName == "<init>") {
+                mv = ObjectCreationTransformer(fileName, className, methodName, adapter, mv)
+                return mv
+            }
 
             // If it is Thread don't instrument all other things in it
             if (isThreadSubClass(className)) {

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -540,7 +540,7 @@ class TraceCollectingEventTracker(
 
         val tracePoint = TRMethodCallTracePoint(
             threadId = threadData.threadId,
-            codeLocationId = -1,
+            codeLocationId = UNKNOWN_CODE_LOCATION_ID,
             methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, "()V"),
             obj = null,
             parameters = emptyList()

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderMethodTransformer.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderMethodTransformer.kt
@@ -52,10 +52,10 @@ internal class TraceRecorderMethodTransformer(
         visitLabel(startLabel)
      }
 
-     override fun onMethodExit(opcode: Int) {
+    override fun onMethodExit(opcode: Int) {
          invokeStatic(TraceRecorderInjections::stopTraceRecorderAndDumpTrace)
          super.onMethodExit(opcode)
-     }
+    }
 
     override fun visitMaxs(maxStack: Int, maxLocals: Int) {
         val endLabel = Label()


### PR DESCRIPTION
Minimal reproducing example for issue [DR-266](https://youtrack.jetbrains.com/agiles/153-5670/current?issue=DR-266), which was problematic when executed with trace recorder:
```kotlin
class A {
  val b = B()
  fun method() {
    b.method()
  }
}

class B {
  var x = 0
  fun method(): Int = x++
}

class Problem {
  @Test
  fun test() {
    val a = A()
    a.method()
  }
}
```

In this example the trace showed that `B.method()` had no children trace points, which is obviously false. The reason for that is the lazy bytecode transformation of the lincheck, which is also used in the trace recorder. Since the transformation was lazy, the classloading of `B` did not cause its instrumentation. In lincheck the instructmentation of `B` would be caused by the subsequent call to the `ensureClassHierarchyTransformer(B.javaClass.name.toCanonical())` in the `Injection::beforeObjectCreation(...)` hook.

This hook is defined for the trace recorder, but was not inserted into constructors' bodies, unlike in lincheck.

This PR fixes this problem.