### PR TITLE
Support character escaping for args passed to javaagent

### DIFF
--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/trace/agent/TraceAgentParameters.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/trace/agent/TraceAgentParameters.kt
@@ -51,6 +51,17 @@ object TraceAgentParameters {
     }
 }
 
+/**
+ * Splits a given string of arguments into a list, using a comma as a delimiter.
+ * Supports escaping of commas and other characters using a backslash.
+ *
+ * Example:
+ * Input: "org.example.Test,testMethod\,with\,commas,path"
+ * Output: ["org.example.Test", "testMethod,with,commas", "path"]
+ *
+ * @param args the string containing arguments to be split, with commas as delimiters
+ * @return a list of strings after splitting the input, with escaped characters processed correctly
+ */
 private fun splitArgs(args: String): List<String> {
     val splitArgs = mutableListOf<String>()
     var currentArg = ""

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/trace/agent/TraceAgentParameters.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/trace/agent/TraceAgentParameters.kt
@@ -30,8 +30,7 @@ object TraceAgentParameters {
         if (args == null) {
             error("Please provide class and method names as arguments")
         }
-
-        val actualArguments = args.split(",")
+        val actualArguments = splitArgs(args)
         classUnderTraceDebugging = actualArguments.getOrNull(0) ?: error("Class name was not provided")
         methodUnderTraceDebugging = actualArguments.getOrNull(1) ?: error("Method name was not provided")
         traceDumpFilePath = actualArguments.getOrNull(2)
@@ -50,4 +49,26 @@ object TraceAgentParameters {
             ?: error("Method \"${methodUnderTraceDebugging}\" was not found in class \"${classUnderTraceDebugging}\". Check that method exists and it is public.")
         return testClass to testMethod
     }
+}
+
+private fun splitArgs(args: String): List<String> {
+    val splitArgs = mutableListOf<String>()
+    var currentArg = ""
+    var escaping = false
+    args.forEach { char ->
+        when {
+            escaping -> {
+                escaping = false
+                currentArg += char
+            }
+            char == ',' -> {
+                splitArgs.add(currentArg)
+                currentArg = ""
+            }
+            char == '\\' && !escaping -> escaping = true
+            else -> currentArg += char
+        }
+    }
+    splitArgs.add(currentArg)
+    return splitArgs
 }


### PR DESCRIPTION
Kotlin function names can contain spaces commas quotes etc which can mess up argument passing.

Parsing is updated to unescape everything that is escaped and properly split the string into args.

It is backwards compatible aka without escaping logic it should work normally.