### PR TITLE
Quickfix for `ClassReader` error

### DIFF
--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/SafeClassWriter.java
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/SafeClassWriter.java
@@ -102,8 +102,13 @@ public class SafeClassWriter extends ClassWriter {
                     return result;
                 }
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e.toString());
+        } catch (IOException ignored) {
+            try {
+                // try to fallback to the default implementation
+                return super.getCommonSuperClass(type1, type2);
+            } catch (Exception e) {
+                throw new RuntimeException(e.toString());
+            }
         }
     }
 


### PR DESCRIPTION
In `SafeClassWriter::getCommonSuperClass` try to fallback to default implementation to avoid `ClassReader` errors