### PR TITLE
Fix stack overflow error on object graph traversal in `ensureObjectIsTransformed`

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/util/AtomicMethods.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/AtomicMethods.kt
@@ -428,10 +428,10 @@ private val varHandleInstanceFieldExtractors = ConcurrentHashMap<Class<*>, VarHa
 
 
 internal fun isAtomic(receiver: Any?) =
-    isAtomicJava(receiver) ||
+    isJavaAtomic(receiver) ||
     isAtomicFU(receiver)
 
-internal fun isAtomicJava(receiver: Any?) =
+internal fun isJavaAtomic(receiver: Any?) =
     // java.util.concurrent
     receiver is AtomicReference<*> ||
     receiver is AtomicBoolean ||

--- a/common/src/main/org/jetbrains/lincheck/util/Boolean.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Boolean.kt
@@ -1,0 +1,21 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.lincheck.util
+
+infix fun Boolean.implies(other: Boolean): Boolean =
+    !this || other
+
+inline infix fun Boolean.implies(other: () -> Boolean): Boolean =
+    !this || other()
+
+internal infix fun <T> ((T) -> Boolean).and(other: (T) -> Boolean): (T) -> Boolean = { this(it) && other(it) }
+internal infix fun <T> ((T) -> Boolean).or(other: (T) -> Boolean): (T) -> Boolean = { this(it) || other(it) }
+internal fun <T> not(predicate: (T) -> Boolean): (T) -> Boolean = { !predicate(it) }

--- a/common/src/main/org/jetbrains/lincheck/util/Collections.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Collections.kt
@@ -10,6 +10,9 @@
 
 package org.jetbrains.lincheck.util
 
+import java.util.Collections
+import java.util.IdentityHashMap
+
 /**
  * Expands the list to the specified size by adding the given value
  * to the end of the list until it reaches the target size.
@@ -144,6 +147,25 @@ fun <T> MutableList<T>.move(from: IntRange, to: Int) {
     sublist.clear()
     addAll(adjustedTo, elements)
 }
+
+/**
+ * Creates a mutable set backed by an [IdentityHashMap].
+ * This set uses identity comparisons `===` to determine equality of elements, rather than the `equals` method.
+ *
+ * @return A new empty mutable identity hash set.
+ */
+fun <T> identityHashSetOf(): MutableSet<T> =
+    Collections.newSetFromMap(IdentityHashMap())
+
+/**
+ * Creates a mutable set backed by an [IdentityHashMap], initialized with the provided elements.
+ * This set uses identity comparisons (`===`) to determine equality of elements, rather than the `equals` method.
+ *
+ * @param elements Zero or more elements to initialize the set with.
+ * @return A new mutable identity hash set containing the provided elements.
+ */
+fun <T> identityHashSetOf(vararg elements: T): MutableSet<T> =
+    elements.toCollection(identityHashSetOf())
 
 fun <K, V> MutableMap<K, V>.update(key: K, default: V, transform: (V) -> V): V =
     compute(key) { _, current -> transform(current ?: default) }!!

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -98,8 +98,12 @@ internal fun traverseObjectGraph(
             else -> {
                 traverseObjectFields(
                     currentObj,
-                    fieldPredicate = {
-                        config.traverseStaticFields || !Modifier.isStatic(it.modifiers)
+                    fieldPredicate = { field ->
+                        // do not traverse static fields if static fields traversal is disabled
+                        (Modifier.isStatic(field.modifiers) implies config.traverseStaticFields) &&
+                        // do not traverse fields of primitive types if immutable objects traversal is disabled
+                        // (primitive types are a subset of immutable types)
+                        (field.type.isPrimitive implies config.traverseImmutableObjects)
                     }
                 ) { _ /* obj */, field, fieldValue ->
                     processNextObject(onField(currentObj, field, fieldValue))

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -41,7 +41,7 @@ private typealias ObjectExpansionCallback = (obj: Any) -> List<Any>
  *
  * @param root object to start the traversal from.
  * @param config configuration of the traversal, see [ObjectGraphTraversalConfig].
- * @param visitedObjects Optional set to track already visited objects during traversal.
+ * @param processedObjects Optional set to track already processed objects during traversal.
  *   Can be used to maintain object visit state across multiple traversal calls.
  *   If not provided, a new identity-based hash set will be created.
  *   Must use referential equality (identity-based comparison) for correct cycle detection in the traversal algorithm.
@@ -61,7 +61,7 @@ private typealias ObjectExpansionCallback = (obj: Any) -> List<Any>
  */
 internal fun traverseObjectGraph(
     root: Any,
-    visitedObjects: MutableSet<Any>? = null,
+    processedObjects: MutableSet<Any>? = null,
     config: ObjectGraphTraversalConfig = ObjectGraphTraversalConfig(),
     onField: FieldCallback = { _ /* obj */, _ /* field */, fieldValue -> fieldValue },
     onArrayElement: ArrayElementCallback = { _ /* array */, _ /* index */, elementValue -> elementValue },
@@ -72,7 +72,7 @@ internal fun traverseObjectGraph(
     if (!onObject(root)) return
 
     val queue = ArrayDeque<Any>()
-    val visitedObjects = visitedObjects ?: Collections.newSetFromMap(IdentityHashMap())
+    val visitedObjects = processedObjects ?: Collections.newSetFromMap(IdentityHashMap())
 
     queue.add(root)
     visitedObjects.add(root)

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -101,10 +101,7 @@ internal fun traverseObjectGraph(
                     currentObj,
                     fieldPredicate = { field ->
                         // do not traverse static fields if static fields traversal is disabled
-                        (Modifier.isStatic(field.modifiers) implies config.traverseStaticFields) &&
-                        // do not traverse fields of primitive types if immutable objects traversal is disabled
-                        // (primitive types are a subset of immutable types)
-                        (field.type.isPrimitive implies config.traverseImmutableObjects)
+                        (Modifier.isStatic(field.modifiers) implies config.traverseStaticFields)
                     }
                 ) { _ /* obj */, field, fieldValue ->
                     processNextObject(onField(currentObj, field, fieldValue))

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -41,32 +41,32 @@ private typealias ObjectExpansionCallback = (obj: Any) -> List<Any>
  *
  * @param root object to start the traversal from.
  * @param config configuration of the traversal, see [ObjectGraphTraversalConfig].
+ * @param visitedObjects Optional set to track already visited objects during traversal.
+ *   Can be used to maintain object visit state across multiple traversal calls.
+ *   If not provided, a new identity-based hash set will be created.
+ *   Must use referential equality (identity-based comparison) for correct cycle detection in the traversal algorithm.
  * @param onField callback for fields traversal, accepts `(fieldOwner, field, fieldValue)`.
  *   Returns an object to be traversed next, or null if the field value should not be traversed.
  *   If not passed, by default, all fields of objects are traversed.
  * @param onArrayElement callback for array elements traversal, accepts `(array, index, elementValue)`.
  *   Returns an object to be traversed next, or null if the array element should not be traversed.
  *   If not passed, by default, all array elements are traversed.
+ * @param expandObject Optional callback for custom object expansion during traversal,
+ *   beyond default fields and array elements traversal.
+ *   When provided, should return for an object a list of additional objects to be traversed.
  * @param onObject Optional callback invoked for each distinct object encountered during traversal
  *   before it is traversed recursively.
  *   Should return boolean indicating whether the object should be traversed recursively.
  *   If not provided, defaults to true, indicating that any reached objects should be traversed recursively.
- * @param expandObject Optional callback for custom object expansion during traversal,
- *   beyond default fields and array elements traversal.
- *   When provided, should return for an object a list of additional objects to be traversed.
- * @param visitedObjects Optional set to track already visited objects during traversal.
- *   Can be used to maintain object visit state across multiple traversal calls.
- *   If not provided, a new identity-based hash set will be created.
- *   Must use referential equality (identity-based comparison) for correct cycle detection in the traversal algorithm.
  */
 internal fun traverseObjectGraph(
     root: Any,
+    visitedObjects: MutableSet<Any>? = null,
     config: ObjectGraphTraversalConfig = ObjectGraphTraversalConfig(),
     onField: FieldCallback = { _ /* obj */, _ /* field */, fieldValue -> fieldValue },
     onArrayElement: ArrayElementCallback = { _ /* array */, _ /* index */, elementValue -> elementValue },
-    onObject: ObjectCallback = { _ /* obj */ -> true },
     expandObject: ObjectExpansionCallback? = null,
-    visitedObjects: MutableSet<Any>? = null
+    onObject: ObjectCallback = { _ /* obj */ -> true },
 ) {
     if (!shouldTraverseObject(root, config)) return
     if (!onObject(root)) return

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -72,7 +72,7 @@ internal fun traverseObjectGraph(
     if (!onObject(root)) return
 
     val queue = ArrayDeque<Any>()
-    val visitedObjects = processedObjects ?: Collections.newSetFromMap(IdentityHashMap())
+    val visitedObjects = processedObjects ?: identityHashSetOf()
 
     queue.add(root)
     visitedObjects.add(root)

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -69,6 +69,7 @@ internal fun traverseObjectGraph(
     onObject: ObjectCallback = { _ /* obj */ -> true },
 ) {
     if (!shouldTraverseObject(root, config)) return
+    if (processedObjects != null && root in processedObjects) return
     if (!onObject(root)) return
 
     val queue = ArrayDeque<Any>()

--- a/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/ObjectGraph.kt
@@ -75,8 +75,8 @@ internal fun traverseObjectGraph(
                 when {
                     // Special treatment for java atomic classes, because they can be extended but user classes,
                     // in case if a user extends java atomic class, we do not want to jump through it.
-                    (promotedObject?.javaClass?.name != null && isJavaAtomicClass(promotedObject.javaClass.name)) -> {
-                        val getMethod = promotedObject.javaClass.getMethod("get")
+                    (isJavaAtomic(promotedObject)) -> {
+                        val getMethod = promotedObject!!.javaClass.getMethod("get")
                         promotedObject = getMethod.invoke(promotedObject)
                     }
                     // atomicfu.AtomicBool is handled separately because its value field is named differently

--- a/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
@@ -19,11 +19,19 @@ import java.util.ArrayList
  * if they appear in the subclass and a parent class.
  */
 val Class<*>.allDeclaredFieldWithSuperclasses get(): List<Field> {
-    val fields: MutableList<Field> = ArrayList<Field>()
-    var currentClass: Class<*>? = this
-    while (currentClass != null) {
+    if (superclass == null && interfaces.isEmpty()) {
+        return this.declaredFields.asList()
+    }
+    val fields: MutableList<Field> = mutableListOf()
+    val queue: MutableList<Class<*>> = mutableListOf(this)
+    while (queue.isNotEmpty()) {
+        val currentClass = queue.removeLast()
         fields.addAll(currentClass.declaredFields)
-        currentClass = currentClass.superclass
+
+        queue.addAll(currentClass.interfaces)
+        if (currentClass.superclass != null) {
+            queue.add(currentClass.superclass)
+        }
     }
     return fields
 }

--- a/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
@@ -22,8 +22,7 @@ val Class<*>.allDeclaredFieldWithSuperclasses get(): List<Field> {
     val fields: MutableList<Field> = ArrayList<Field>()
     var currentClass: Class<*>? = this
     while (currentClass != null) {
-        val declaredFields: Array<Field> = currentClass.declaredFields
-        fields.addAll(declaredFields)
+        fields.addAll(currentClass.declaredFields)
         currentClass = currentClass.superclass
     }
     return fields

--- a/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
@@ -22,6 +22,7 @@ val Class<*>.allDeclaredFieldWithSuperclasses get(): List<Field> {
     if (superclass == null && interfaces.isEmpty()) {
         return this.declaredFields.asList()
     }
+
     val fields: MutableList<Field> = mutableListOf()
     val queue: MutableList<Class<*>> = mutableListOf(this)
     while (queue.isNotEmpty()) {

--- a/integration-test/lincheck/src/main/org/jetbrains/lincheck_test/datastructures/SingleWriterHashTableTest.kt
+++ b/integration-test/lincheck/src/main/org/jetbrains/lincheck_test/datastructures/SingleWriterHashTableTest.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
 import org.junit.Test
 
 class SingleWriterHashTableTest() {
-    val scenarios: Int = 100
+    val scenarios: Int = 300
     val threads: Int = 3
     val actorsBefore: Int = 1
 

--- a/integration-test/lincheck/src/main/org/jetbrains/lincheck_test/datastructures/SingleWriterHashTableTest.kt
+++ b/integration-test/lincheck/src/main/org/jetbrains/lincheck_test/datastructures/SingleWriterHashTableTest.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
 import org.junit.Test
 
 class SingleWriterHashTableTest() {
-    val scenarios: Int = 300
+    val scenarios: Int = 100
     val threads: Int = 3
     val actorsBefore: Int = 1
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassFileTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckClassFileTransformer.kt
@@ -181,7 +181,7 @@ object LincheckClassFileTransformer : ClassFileTransformer {
         }
         if (isEagerlyInstrumentedClass(className)) return true
 
-        return AnalysisProfile(analyzeStdLib = true).shouldTransform(className, "")
+        return AnalysisProfile.DEFAULT.shouldTransform(className, "")
     }
 
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -341,13 +341,16 @@ object LincheckJavaAgent {
             ),
         ) { obj ->
             val className = obj.javaClass.name
-            val shouldAnalyzeObject =
-                (shouldTransform(obj.javaClass, instrumentationMode) || isJavaLambdaClass(className))&&
+            val shouldTraverseObject = (
+                    obj is Array<*> ||
+                    isJavaLambdaClass(className) ||
+                    shouldTransform(obj.javaClass, instrumentationMode)
+                ) &&
                 // Optimization and safety net: do not analyze low-level
                 // class instances from the standard Java library.
                 !isLowLevelJavaClass(className)
 
-            return@traverseObjectGraph shouldAnalyzeObject
+            return@traverseObjectGraph shouldTraverseObject
         }
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -316,6 +316,9 @@ object LincheckJavaAgent {
      */
     private fun ensureObjectIsTransformed(obj: Any, processedObjects: MutableSet<Any>) {
 
+        // this function is used to transform traversed object's class
+        // and push additional objects-to-traverse to the queue
+        // (fields and array elements are traversed by default)
         fun expandObject(obj: Any): List<Any> {
             val clazz = obj.javaClass
             val className = clazz.name
@@ -338,6 +341,7 @@ object LincheckJavaAgent {
             return objectsToTransform
         }
 
+        // this function is used to decide what objects should be traversed further
         fun shouldTraverseObject(obj: Any): Boolean {
             val clazz = obj.javaClass
             val className = clazz.name

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -373,6 +373,9 @@ object LincheckJavaAgent {
         }
 
         // Traverse static fields.
+        //
+        // NOTE: traverses only current class' fields, as the loop below will process
+        //   all superclasses' and interfaces' fields as a part of `ensureClassHierarchyIsTransformed`
         clazz.declaredFields
             .filter { !it.type.isPrimitive && Modifier.isStatic(it.modifiers) }
             .mapNotNull { readFieldSafely(null, it).getOrNull() }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -333,9 +333,7 @@ object LincheckJavaAgent {
                 return
             }
             else -> {
-                if (instrumentation.isModifiableClass(clazz) &&
-                    shouldTransform(className, instrumentationMode)
-                ) {
+                if (shouldTransform(clazz, instrumentationMode)) {
                     ensureClassHierarchyIsTransformed(clazz)
                 } else {
                     // Optimization and safety net: do not analyze low-level

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -286,17 +286,6 @@ object LincheckJavaAgent {
     }
 
     /**
-     * Ensures that the given class and all its superclasses are transformed if necessary.
-     *
-     * @param clazz the class to transform
-     */
-    private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
-        if (INSTRUMENT_ALL_CLASSES) return
-        if (clazz.name in instrumentedClasses) return // already instrumented
-        ensureClassHierarchyIsTransformed(clazz, Collections.newSetFromMap(IdentityHashMap()))
-    }
-
-    /**
      * Ensures that the given object and all its referenced objects are transformed for Lincheck analysis.
      * If the INSTRUMENT_ALL_CLASSES_IN_MODEL_CHECKING_MODE flag is set to true, no transformation is performed.
      *
@@ -334,7 +323,7 @@ object LincheckJavaAgent {
             }
             else -> {
                 if (shouldTransform(clazz, instrumentationMode)) {
-                    ensureClassHierarchyIsTransformed(clazz)
+                    ensureClassHierarchyIsTransformed(clazz, processedObjects)
                 } else {
                     // Optimization and safety net: do not analyze low-level
                     // class instances from the standard Java library.
@@ -367,6 +356,8 @@ object LincheckJavaAgent {
      * @param processedObjects Set of objects that have already been processed to prevent duplicate transformation.
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, processedObjects: MutableSet<Any>) {
+        if (clazz.name in instrumentedClasses) return
+
         if (shouldTransform(clazz, instrumentationMode)) {
             instrumentedClasses += clazz.name
             retransformClass(clazz)

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -327,11 +327,7 @@ object LincheckJavaAgent {
                 } else {
                     // Optimization and safety net: do not analyze low-level
                     // class instances from the standard Java library.
-                    if (className.startsWith("jdk.") ||
-                        className.startsWith("java.lang.") ||
-                        className.startsWith("sun.misc.")) {
-                        return
-                    }
+                    if (isLowLevelJavaClass(className)) return
                 }
             }
         }
@@ -383,6 +379,11 @@ object LincheckJavaAgent {
             ensureClassHierarchyIsTransformed(it, processedObjects)
         }
     }
+
+    private fun isLowLevelJavaClass(className: String) =
+        className.startsWith("jdk.") ||
+        className.startsWith("sun.misc.") ||
+        className.startsWith("java.lang.")
 
     /**
      * FOR TEST PURPOSE ONLY!

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -187,14 +187,16 @@ object LincheckJavaAgent {
         try {
             instrumentation.retransformClasses(*classes.toTypedArray())
         } catch (_: Throwable) {
-            classes.forEach {
-                try {
-                    instrumentation.retransformClasses(it)
-                } catch (t: Throwable) {
-                    Logger.error { "Failed to retransform class ${it.name}" }
-                    Logger.error(t)
-                }
-            }
+            classes.forEach { retransformClass(it) }
+        }
+    }
+
+    private fun retransformClass(clazz: Class<*>) {
+        try {
+            instrumentation.retransformClasses(clazz)
+        } catch (t: Throwable) {
+            Logger.error { "Failed to retransform class ${clazz.name}" }
+            Logger.error(t)
         }
     }
 
@@ -371,11 +373,7 @@ object LincheckJavaAgent {
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, processedObjects: MutableSet<Any>) {
         if (shouldTransform(clazz, instrumentationMode)) {
             instrumentedClasses += clazz.name
-            try {
-                instrumentation.retransformClasses(clazz)
-            } catch (e: VerifyError) {
-                Logger.error { "Failed to retransform class ${clazz.name}" }
-            }
+            retransformClass(clazz)
         }
         // Traverse static fields.
         clazz.declaredFields

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -272,15 +272,15 @@ object LincheckJavaAgent {
      * thus, initializing it here, in an ignored section of the analysis, re-transforming
      * the class after that.
      *
-     * @param canonicalClassName The name of the class to be transformed.
+     * @param className The name of the class to be transformed.
      */
-    fun ensureClassHierarchyIsTransformed(canonicalClassName: String) {
+    fun ensureClassHierarchyIsTransformed(className: String) {
         if (INSTRUMENT_ALL_CLASSES) {
-            Class.forName(canonicalClassName)
+            Class.forName(className)
             return
         }
-        if (canonicalClassName in instrumentedClasses) return // already instrumented
-        ensureClassHierarchyIsTransformed(Class.forName(canonicalClassName), Collections.newSetFromMap(IdentityHashMap()))
+        if (className in instrumentedClasses) return // already instrumented
+        ensureClassHierarchyIsTransformed(Class.forName(className), Collections.newSetFromMap(IdentityHashMap()))
     }
 
     /**

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -313,8 +313,10 @@ object LincheckJavaAgent {
 
         when {
             isJavaLambdaClass(className) -> {
-                val enclosingClass = Class.forName(getJavaLambdaEnclosingClass(className))
-                ensureClassHierarchyIsTransformed(enclosingClass, processedObjects)
+                val enclosingClassName = getJavaLambdaEnclosingClass(className)
+                if (enclosingClassName !in instrumentedClasses) {
+                    ensureClassHierarchyIsTransformed(Class.forName(enclosingClassName), processedObjects)
+                }
             }
             obj is Array<*> -> {
                 obj.forEach {

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -309,6 +309,9 @@ object LincheckJavaAgent {
         var clazz: Class<*> = obj.javaClass
         val className = clazz.name
 
+        if (processedObjects.contains(obj)) return
+        processedObjects += obj
+
         when {
             isJavaLambdaClass(className) -> {
                 ensureClassHierarchyIsTransformed(getJavaLambdaEnclosingClass(className))
@@ -331,9 +334,6 @@ object LincheckJavaAgent {
                 }
             }
         }
-
-        if (processedObjects.contains(obj)) return
-        processedObjects += obj
 
         while (true) {
             clazz.declaredFields

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -352,7 +352,7 @@ object LincheckJavaAgent {
      * @param processedObjects Set of objects that have already been processed to prevent duplicate transformation.
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, processedObjects: MutableSet<Any>) {
-        if (clazz.name in instrumentedClasses) return
+        if (clazz.name in instrumentedClasses) return // already instrumented
 
         if (shouldTransform(clazz, instrumentationMode)) {
             instrumentedClasses += clazz.name
@@ -368,14 +368,13 @@ object LincheckJavaAgent {
             .mapNotNull { readFieldSafely(null, it).getOrNull() }
             .forEach { ensureObjectIsTransformed(it, processedObjects) }
 
-        // Traverse super classes, interfaces and enclosing class
+        // Traverse super classes, interfaces, and enclosing class
         val classesToTransform =
             listOfNotNull(clazz.superclass) +
             listOfNotNull(clazz.enclosingClass) +
             clazz.interfaces.asList()
 
         classesToTransform.forEach {
-            if (it.name in instrumentedClasses) return // already instrumented
             ensureClassHierarchyIsTransformed(it, processedObjects)
         }
     }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -280,8 +280,6 @@ object LincheckJavaAgent {
             return
         }
         if (canonicalClassName in instrumentedClasses) return // already instrumented
-        // TODO: remove this check, it already done in `ensureClassHierarchyIsTransformed`
-        if (!shouldTransform(canonicalClassName, instrumentationMode)) return
         ensureClassHierarchyIsTransformed(Class.forName(canonicalClassName), Collections.newSetFromMap(IdentityHashMap()))
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -369,8 +369,7 @@ object LincheckJavaAgent {
      * @param processedObjects Set of objects that have already been processed to prevent duplicate transformation.
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, processedObjects: MutableSet<Any>) {
-        if (!shouldTransform(clazz.name, instrumentationMode)) return
-        if (canRetransformClass(clazz)) {
+        if (shouldTransform(clazz.name, instrumentationMode) && canRetransformClass(clazz)) {
             instrumentedClasses += clazz.name
             try {
                 instrumentation.retransformClasses(clazz)

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -311,7 +311,8 @@ object LincheckJavaAgent {
     private fun ensureObjectIsTransformed(obj: Any, processedObjects: MutableSet<Any>) {
 
         fun expandObject(obj: Any): List<Any> {
-            val className = obj.javaClass.name
+            val clazz = obj.javaClass
+            val className = clazz.name
             val objectsToTransform = mutableListOf<Any>()
             when {
                 isJavaLambdaClass(className) -> {
@@ -323,7 +324,7 @@ object LincheckJavaAgent {
                     }
                 }
                 else -> {
-                    ensureClassHierarchyIsTransformed(obj.javaClass) {
+                    ensureClassHierarchyIsTransformed(clazz) {
                         objectsToTransform.add(it)
                     }
                 }
@@ -332,16 +333,14 @@ object LincheckJavaAgent {
         }
 
         traverseObjectGraph(obj, processedObjects, expandObject = ::expandObject) { obj ->
-            val className = obj.javaClass.name
             val shouldTraverseObject = (
                 // Optimization and safety net: do not analyze low-level
                 // class instances from the standard Java library.
-                (!isLowLevelJavaClass(className) ||
+                (!isLowLevelJavaClass(obj.javaClass.name) ||
                     // unless the low-level class needs to be transformed
                     shouldTransform(obj.javaClass, instrumentationMode)
                 )
             )
-
             return@traverseObjectGraph shouldTraverseObject
         }
     }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -379,10 +379,13 @@ object LincheckJavaAgent {
         //
         // NOTE: traverses only current class' fields, as the loop below will process
         //   all superclasses' and interfaces' fields as a part of `ensureClassHierarchyIsTransformed`
-        clazz.declaredFields
-            .filter { !it.type.isPrimitive && Modifier.isStatic(it.modifiers) }
-            .mapNotNull { readFieldSafely(null, it).getOrNull() }
-            .forEach { transformObjectCallback(it) }
+        for (field in clazz.declaredFields) {
+            // traverse only static non-primitive fields
+            if (!Modifier.isStatic(field.modifiers) || field.type.isPrimitive) continue
+            readFieldSafely(null, field).getOrNull()?.let {
+                transformObjectCallback(it)
+            }
+        }
 
         // Traverse super classes, interfaces, and enclosing class
         val classesToTransform =

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -217,21 +217,21 @@ object LincheckJavaAgent {
     }
 
     private fun getLoadedClassesToInstrument(): List<Class<*>> =
-        instrumentation.allLoadedClasses
-            // Filtering is done in the following order to hide lincheck source classes from
-            // `canRetransform` method which uses `TransformationUtilsKt::isJavaLambdaClass` internally.
-            // The other order causes class linkage error on double definition of `TransformationUtilsKt`
-            // when it itself is passed as argument to `canRetransformClass`.
-            .filter { shouldTransform(it.name, instrumentationMode) }
-            .filter(::canRetransformClass)
+        instrumentation.allLoadedClasses.filter { shouldTransform(it, instrumentationMode) }
 
-    private fun canRetransformClass(clazz: Class<*>): Boolean {
-        return instrumentation.isModifiableClass(clazz) &&
-               // Note: Java 8 has a bug and does not allow lambdas redefinition and retransformation
-               //  - https://bugs.openjdk.org/browse/JDK-8145964
-               //  - https://stackoverflow.com/questions/34162074/transforming-lambdas-in-java-8
-               (!isJdk8 || !isJavaLambdaClass(clazz.name))
-    }
+    private fun canRetransformClass(clazz: Class<*>): Boolean =
+        instrumentation.isModifiableClass(clazz) &&
+        // Note: Java 8 has a bug and does not allow lambdas redefinition and retransformation
+        //  - https://bugs.openjdk.org/browse/JDK-8145964
+        //  - https://stackoverflow.com/questions/34162074/transforming-lambdas-in-java-8
+        (!isJdk8 || !isJavaLambdaClass(clazz.name))
+
+    private fun shouldTransform(clazz: Class<*>, instrumentationMode: InstrumentationMode): Boolean =
+        // Filtering is done in the following order to hide lincheck source classes from
+        // the `canRetransform` method which uses `TransformationUtilsKt::isJavaLambdaClass` internally.
+        // The other order causes a class linkage error on double definition of `TransformationUtilsKt`
+        // when it itself is passed as an argument to `canRetransformClass`.
+        shouldTransform(clazz.name, instrumentationMode) && canRetransformClass(clazz)
 
     /**
      * Detaches [LincheckClassFileTransformer] from this JVM instance and re-transforms
@@ -369,7 +369,7 @@ object LincheckJavaAgent {
      * @param processedObjects Set of objects that have already been processed to prevent duplicate transformation.
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, processedObjects: MutableSet<Any>) {
-        if (shouldTransform(clazz.name, instrumentationMode) && canRetransformClass(clazz)) {
+        if (shouldTransform(clazz, instrumentationMode)) {
             instrumentedClasses += clazz.name
             try {
                 instrumentation.retransformClasses(clazz)

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -331,15 +331,7 @@ object LincheckJavaAgent {
             return objectsToTransform
         }
 
-        traverseObjectGraph(obj, processedObjects,
-            expandObject = ::expandObject,
-            config = ObjectGraphTraversalConfig(
-                traverseStaticFields = false,
-                traverseImmutableObjects = false,
-                traverseEnumObjects = true,
-                promoteAtomicObjects = false,
-            ),
-        ) { obj ->
+        traverseObjectGraph(obj, processedObjects, expandObject = ::expandObject) { obj ->
             val className = obj.javaClass.name
             val shouldTraverseObject = (
                     obj is Array<*> ||

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -348,7 +348,7 @@ object LincheckJavaAgent {
                 isJavaLambdaClass(className) ||
                 // traverse objects which classes should be instrumented
                 (shouldTransform(clazz, instrumentationMode) &&
-                    // Optimization and safety net: do not analyze low-level
+                    // optimization and safety net: do not traverse low-level
                     // class instances from the standard Java library.
                     !isLowLevelJavaClass(className)
                 )
@@ -364,7 +364,8 @@ object LincheckJavaAgent {
      * Ensures that the given class and all its superclasses are transformed.
      *
      * @param clazz The class to be transformed.
-     * @param processedObjects Set of objects that have already been processed to prevent duplicate transformation.
+     * @param transformObjectCallback A function called to transform objects discovered during
+     *   the traversal of class' static fields.
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>, transformObjectCallback: (Any) -> Unit) {
         if (clazz.name in instrumentedClasses) return // already instrumented

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -281,7 +281,7 @@ object LincheckJavaAgent {
         }
         if (className in instrumentedClasses) return // already instrumented
 
-        val processedObjects: MutableSet<Any> = Collections.newSetFromMap(IdentityHashMap())
+        val processedObjects: MutableSet<Any> = identityHashSetOf()
         ensureClassHierarchyIsTransformed(Class.forName(className)) { obj ->
             ensureObjectIsTransformed(obj, processedObjects)
         }
@@ -298,7 +298,7 @@ object LincheckJavaAgent {
      */
     fun ensureObjectIsTransformed(obj: Any) {
         if (INSTRUMENT_ALL_CLASSES) return
-        ensureObjectIsTransformed(obj, Collections.newSetFromMap(IdentityHashMap()))
+        ensureObjectIsTransformed(obj, identityHashSetOf())
     }
 
     /**

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -287,9 +287,10 @@ object LincheckJavaAgent {
 
     /**
      * Ensures that the given object and all its referenced objects are transformed for Lincheck analysis.
-     * If the INSTRUMENT_ALL_CLASSES_IN_MODEL_CHECKING_MODE flag is set to true, no transformation is performed.
+     * The function is called upon a test instance creation to ensure that
+     * all the classes related to it are transformed.
      *
-     * The function is called upon a test instance creation, to ensure that all the classes related to it are transformed.
+     * If the INSTRUMENT_ALL_CLASSES flag is set to true, no transformation is performed.
      *
      * @param obj the object to be transformed
      */

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -338,7 +338,9 @@ object LincheckJavaAgent {
                 } else {
                     // Optimization and safety net: do not analyze low-level
                     // class instances from the standard Java library.
-                    if (className.startsWith("jdk.") || className.startsWith("java.lang.") || className.startsWith("sun.misc.")) {
+                    if (className.startsWith("jdk.") ||
+                        className.startsWith("java.lang.") ||
+                        className.startsWith("sun.misc.")) {
                         return
                     }
                 }
@@ -353,9 +355,8 @@ object LincheckJavaAgent {
                 .filter { !it.type.isPrimitive }
                 .filter { !Modifier.isStatic(it.modifiers) }
                 .mapNotNull { readFieldSafely(obj, it).getOrNull() }
-                .forEach {
-                    ensureObjectIsTransformed(it, processedObjects)
-                }
+                .forEach { ensureObjectIsTransformed(it, processedObjects) }
+
             clazz = clazz.superclass ?: break
         }
     }
@@ -371,14 +372,15 @@ object LincheckJavaAgent {
             instrumentedClasses += clazz.name
             retransformClass(clazz)
         }
+
         // Traverse static fields.
         clazz.declaredFields
             .filter { !it.type.isPrimitive }
             .filter { Modifier.isStatic(it.modifiers) }
             .mapNotNull { readFieldSafely(null, it).getOrNull() }
-            .forEach {
-                ensureObjectIsTransformed(it, processedObjects)
-            }
+            .forEach { ensureObjectIsTransformed(it, processedObjects) }
+
+        // Traverse super classes, interfaces and enclosing class
         clazz.superclass?.let {
             if (it.name in instrumentedClasses) return // already instrumented
             ensureClassHierarchyIsTransformed(it, processedObjects)

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -279,7 +279,13 @@ object LincheckJavaAgent {
             Class.forName(className)
             return
         }
+
         if (className in instrumentedClasses) return // already instrumented
+
+        // this check is important for performance reasons,
+        // as it allows to avoid `Class.forName` in case when class is already instrumented
+        // TODO: replace with `Class.forName` caching, see `classCache` in `Utils.kt`
+        if (!shouldTransform(className, instrumentationMode)) return
 
         val processedObjects: MutableSet<Any> = identityHashSetOf()
         ensureClassHierarchyIsTransformed(Class.forName(className)) { obj ->

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -379,15 +379,12 @@ object LincheckJavaAgent {
             .forEach { ensureObjectIsTransformed(it, processedObjects) }
 
         // Traverse super classes, interfaces and enclosing class
-        clazz.superclass?.let {
-            if (it.name in instrumentedClasses) return // already instrumented
-            ensureClassHierarchyIsTransformed(it, processedObjects)
-        }
-        clazz.interfaces.forEach {
-            if (it.name in instrumentedClasses) return // already instrumented
-            ensureClassHierarchyIsTransformed(it, processedObjects)
-        }
-        clazz.enclosingClass?.let {
+        val classesToTransform =
+            listOfNotNull(clazz.superclass) +
+            listOfNotNull(clazz.enclosingClass) +
+            clazz.interfaces.asList()
+
+        classesToTransform.forEach {
             if (it.name in instrumentedClasses) return // already instrumented
             ensureClassHierarchyIsTransformed(it, processedObjects)
         }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -352,8 +352,7 @@ object LincheckJavaAgent {
 
         while (true) {
             clazz.declaredFields
-                .filter { !it.type.isPrimitive }
-                .filter { !Modifier.isStatic(it.modifiers) }
+                .filter { !it.type.isPrimitive && !Modifier.isStatic(it.modifiers) }
                 .mapNotNull { readFieldSafely(obj, it).getOrNull() }
                 .forEach { ensureObjectIsTransformed(it, processedObjects) }
 
@@ -375,8 +374,7 @@ object LincheckJavaAgent {
 
         // Traverse static fields.
         clazz.declaredFields
-            .filter { !it.type.isPrimitive }
-            .filter { Modifier.isStatic(it.modifiers) }
+            .filter { !it.type.isPrimitive && Modifier.isStatic(it.modifiers) }
             .mapNotNull { readFieldSafely(null, it).getOrNull() }
             .forEach { ensureObjectIsTransformed(it, processedObjects) }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -325,8 +325,10 @@ object LincheckJavaAgent {
                 ensureClassHierarchyIsTransformed(getJavaLambdaEnclosingClass(className))
             }
             obj is Array<*> -> {
-                obj.filterNotNull().forEach {
-                    ensureObjectIsTransformed(it, processedObjects)
+                obj.forEach {
+                    if (it !== null) {
+                        ensureObjectIsTransformed(it, processedObjects)
+                    }
                 }
                 return
             }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -334,13 +334,13 @@ object LincheckJavaAgent {
         traverseObjectGraph(obj, processedObjects, expandObject = ::expandObject) { obj ->
             val className = obj.javaClass.name
             val shouldTraverseObject = (
-                    obj is Array<*> ||
-                    isJavaLambdaClass(className) ||
-                    shouldTransform(obj.javaClass, instrumentationMode)
-                ) &&
                 // Optimization and safety net: do not analyze low-level
                 // class instances from the standard Java library.
-                !isLowLevelJavaClass(className)
+                (!isLowLevelJavaClass(className) ||
+                    // unless the low-level class needs to be transformed
+                    shouldTransform(obj.javaClass, instrumentationMode)
+                )
+            )
 
             return@traverseObjectGraph shouldTraverseObject
         }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -279,8 +279,9 @@ object LincheckJavaAgent {
             Class.forName(canonicalClassName)
             return
         }
-        if (!shouldTransform(canonicalClassName, instrumentationMode)) return
         if (canonicalClassName in instrumentedClasses) return // already instrumented
+        // TODO: remove this check, it already done in `ensureClassHierarchyIsTransformed`
+        if (!shouldTransform(canonicalClassName, instrumentationMode)) return
         ensureClassHierarchyIsTransformed(Class.forName(canonicalClassName), Collections.newSetFromMap(IdentityHashMap()))
     }
 
@@ -290,9 +291,7 @@ object LincheckJavaAgent {
      * @param clazz the class to transform
      */
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
-        if (INSTRUMENT_ALL_CLASSES) {
-            return
-        }
+        if (INSTRUMENT_ALL_CLASSES) return
         if (clazz.name in instrumentedClasses) return // already instrumented
         ensureClassHierarchyIsTransformed(clazz, Collections.newSetFromMap(IdentityHashMap()))
     }
@@ -306,9 +305,7 @@ object LincheckJavaAgent {
      * @param obj the object to be transformed
      */
     fun ensureObjectIsTransformed(obj: Any) {
-        if (INSTRUMENT_ALL_CLASSES) {
-            return
-        }
+        if (INSTRUMENT_ALL_CLASSES) return
         ensureObjectIsTransformed(obj, Collections.newSetFromMap(IdentityHashMap()))
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -314,7 +314,8 @@ object LincheckJavaAgent {
 
         when {
             isJavaLambdaClass(className) -> {
-                ensureClassHierarchyIsTransformed(getJavaLambdaEnclosingClass(className))
+                val enclosingClass = Class.forName(getJavaLambdaEnclosingClass(className))
+                ensureClassHierarchyIsTransformed(enclosingClass, processedObjects)
             }
             obj is Array<*> -> {
                 obj.forEach {

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -284,6 +284,18 @@ object LincheckJavaAgent {
         ensureClassHierarchyIsTransformed(Class.forName(canonicalClassName), Collections.newSetFromMap(IdentityHashMap()))
     }
 
+    /**
+     * Ensures that the given class and all its superclasses are transformed if necessary.
+     *
+     * @param clazz the class to transform
+     */
+    private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
+        if (INSTRUMENT_ALL_CLASSES) {
+            return
+        }
+        if (clazz.name in instrumentedClasses) return // already instrumented
+        ensureClassHierarchyIsTransformed(clazz, Collections.newSetFromMap(IdentityHashMap()))
+    }
 
     /**
      * Ensures that the given object and all its referenced objects are transformed for Lincheck analysis.
@@ -298,19 +310,6 @@ object LincheckJavaAgent {
             return
         }
         ensureObjectIsTransformed(obj, Collections.newSetFromMap(IdentityHashMap()))
-    }
-
-    /**
-     * Ensures that the given class and all its superclasses are transformed if necessary.
-     *
-     * @param clazz the class to transform
-     */
-    private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
-        if (INSTRUMENT_ALL_CLASSES) {
-            return
-        }
-        if (clazz.name in instrumentedClasses) return // already instrumented
-        ensureClassHierarchyIsTransformed(clazz, Collections.newSetFromMap(IdentityHashMap()))
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -12,8 +12,7 @@ package org.jetbrains.kotlinx.lincheck
 import kotlinx.coroutines.*
 import org.jetbrains.kotlinx.lincheck.annotations.DummySequentialSpecification
 import org.jetbrains.kotlinx.lincheck.runner.*
-import org.jetbrains.kotlinx.lincheck.util.*
-import org.jetbrains.lincheck.util.runOutsideIgnoredSection
+import org.jetbrains.lincheck.util.*
 import sun.nio.ch.lincheck.*
 import java.io.PrintWriter
 import java.io.StringWriter

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/OwnerNames.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/OwnerNames.kt
@@ -12,9 +12,9 @@ package org.jetbrains.kotlinx.lincheck.strategy.managed
 
 import org.jetbrains.lincheck.descriptors.*
 import org.jetbrains.lincheck.analysis.*
-import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.lincheck.trace.isThisName
 import org.jetbrains.kotlinx.lincheck.transformation.toSimpleClassName
+import org.jetbrains.lincheck.util.*
 
 internal fun findOwnerName(
     className: String,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
@@ -13,11 +13,7 @@ package org.jetbrains.kotlinx.lincheck.strategy.managed
 import org.jetbrains.kotlinx.lincheck.classCache
 import org.jetbrains.kotlinx.lincheck.findField
 import org.jetbrains.kotlinx.lincheck.strategy.managed.SnapshotTracker.MemoryNode.*
-import org.jetbrains.kotlinx.lincheck.util.*
-import org.jetbrains.lincheck.util.readArrayElementViaUnsafe
-import org.jetbrains.lincheck.util.readFieldSafely
-import org.jetbrains.lincheck.util.writeArrayElementViaUnsafe
-import org.jetbrains.lincheck.util.writeFieldViaUnsafe
+import org.jetbrains.lincheck.util.*
 import java.lang.Class
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
@@ -115,7 +115,7 @@ class SnapshotTracker {
     }
 
     fun restoreValues() {
-        val visitedObjects = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+        val visitedObjects = identityHashSetOf<Any>()
         trackedObjects.keys.forEach { restoreValues(it, visitedObjects) }
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
@@ -191,7 +191,7 @@ class SnapshotTracker {
             },
             onField = { owner, field, fieldValue ->
                 // optimization to track only `value` field of java atomic classes
-                if (isAtomicJava(owner) && field.name != "value") null
+                if (isJavaAtomic(owner) && field.name != "value") null
                 // do not traverse fields of var-handles
                 else if (owner.javaClass.typeName == "java.lang.invoke.VarHandle") null
                 else {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -14,8 +14,7 @@ import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.runner.ExecutionPart.*
 import org.jetbrains.kotlinx.lincheck.util.*
-import org.jetbrains.lincheck.util.isInTraceDebuggerMode
-import org.jetbrains.lincheck.util.isJavaLambdaClass
+import org.jetbrains.lincheck.util.*
 import java.lang.ref.WeakReference
 import java.lang.reflect.*
 import java.util.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/nativecalls/io/JavaStandardLibrary.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/nativecalls/io/JavaStandardLibrary.kt
@@ -12,7 +12,7 @@ package org.jetbrains.kotlinx.lincheck.strategy.nativecalls.io
 
 import org.jetbrains.lincheck.descriptors.MethodSignature
 import org.jetbrains.lincheck.descriptors.Types
-import org.jetbrains.kotlinx.lincheck.util.and
+import org.jetbrains.lincheck.util.*
 import org.jetbrains.kotlinx.lincheck.util.getMethods
 import org.jetbrains.kotlinx.lincheck.util.isInstance
 import org.jetbrains.kotlinx.lincheck.util.isPublic

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/KotlinReflection.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/KotlinReflection.kt
@@ -17,6 +17,7 @@ import java.lang.reflect.Executable
 import kotlin.coroutines.Continuation
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import kotlin.reflect.jvm.jvmName
 
 
 /**
@@ -90,6 +91,12 @@ private fun getCachedFilteredDeclaredMethods(className: String, methodName: Stri
         val declaredMethods = getCachedDeclaredMethods(className)
         declaredMethods.filter { it.name == methodName }
     }
+
+/**
+ * Extension property to determine if the given object is a [kotlinx.coroutines] symbol.
+ */
+internal val Any?.isCoroutinesSymbol get() =
+    this != null && this::class.jvmName == "kotlinx.coroutines.internal.Symbol"
 
 internal infix fun <T> ((T) -> Boolean).and(other: (T) -> Boolean): (T) -> Boolean = { this(it) && other(it) }
 internal infix fun <T> ((T) -> Boolean).or(other: (T) -> Boolean): (T) -> Boolean = { this(it) || other(it) }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/KotlinReflection.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/util/KotlinReflection.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlinx.lincheck.util
 import org.jetbrains.kotlinx.lincheck.isSuspendable
 import org.jetbrains.lincheck.descriptors.MethodSignature
 import org.jetbrains.lincheck.descriptors.toMethodSignature
+import org.jetbrains.lincheck.util.*
 import java.lang.reflect.Executable
 import kotlin.coroutines.Continuation
 import java.lang.reflect.Method
@@ -97,10 +98,6 @@ private fun getCachedFilteredDeclaredMethods(className: String, methodName: Stri
  */
 internal val Any?.isCoroutinesSymbol get() =
     this != null && this::class.jvmName == "kotlinx.coroutines.internal.Symbol"
-
-internal infix fun <T> ((T) -> Boolean).and(other: (T) -> Boolean): (T) -> Boolean = { this(it) && other(it) }
-internal infix fun <T> ((T) -> Boolean).or(other: (T) -> Boolean): (T) -> Boolean = { this(it) || other(it) }
-internal fun <T> not(predicate: (T) -> Boolean): (T) -> Boolean = { !predicate(it) }
 
 internal val isPublic: (Executable) -> Boolean = { it.modifiers and Modifier.PUBLIC != 0 }
 internal val isProtected: (Executable) -> Boolean = { it.modifiers and Modifier.PROTECTED != 0 }


### PR DESCRIPTION
Avoid recursive graph traversal in `ensureObjectIsTransformed` and use queue-based DFS instead. 
Re-use the implementation from `ObjectGraph.kt` for this purpose. 

Also had to move `ObjectGraph.kt` and few other things to `common` module in the process.