### PR TITLE
Minimize the static field traversals during lazy re-transformation 

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Reflection.kt
@@ -11,7 +11,28 @@
 package org.jetbrains.lincheck.util
 
 import java.lang.reflect.Field
-import java.util.ArrayList
+import java.util.concurrent.ConcurrentHashMap
+
+
+// We store the class references in a local map to avoid repeated Class.forName calls and reflection overhead
+
+/**
+ * Provides a thread-safe caching mechanism for [Class] lookup by its fully qualified class name.
+ */
+object ClassCache {
+    private val cache = ConcurrentHashMap<String, Class<*>>()
+
+    /**
+     * Retrieves the [Class] object associated with the given fully qualified class name.
+     * The method caches the result to avoid redundant lookups for the same class name.
+     *
+     * @param className the fully qualified name of the desired class
+     * @return the [Class] object representing the desired class
+     * @throws ClassNotFoundException if the class cannot be located by its name
+     */
+    fun forName(className: String): Class<*> =
+        cache.getOrPut(className) { Class.forName(className) }
+}
 
 /**
  * Returns all found fields in the hierarchy.

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty.txt
@@ -4,18 +4,34 @@ ImmutableListTest.empty() at :0
     UtilsKt.persistentVectorOf(): SmallPersistentVector@1 at extensions.kt:452
       SmallPersistentVector.Companion ➜ SmallPersistentVector.Companion@1 at Utils.kt:18
       SmallPersistentVector.Companion.getEMPTY(): SmallPersistentVector@1 at Utils.kt:18
+        SmallPersistentVector.access$getEMPTY$cp(): SmallPersistentVector@1 at SmallPersistentVector.kt:163
+          SmallPersistentVector.EMPTY ➜ SmallPersistentVector@1 at SmallPersistentVector.kt:15
   ExtensionsKt.persistentListOf(): SmallPersistentVector@1 at ImmutableListTest.kt:21
     UtilsKt.persistentVectorOf(): SmallPersistentVector@1 at extensions.kt:452
       SmallPersistentVector.Companion ➜ SmallPersistentVector.Companion@1 at Utils.kt:18
       SmallPersistentVector.Companion.getEMPTY(): SmallPersistentVector@1 at Utils.kt:18
+        SmallPersistentVector.access$getEMPTY$cp(): SmallPersistentVector@1 at SmallPersistentVector.kt:163
+          SmallPersistentVector.EMPTY ➜ SmallPersistentVector@1 at SmallPersistentVector.kt:15
   AssertionsKt.assertEquals$default(SmallPersistentVector@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:22
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:23
   AssertionsKt.assertEquals$default(EmptyList@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:23
+    buffer ➜ Object;@1 at SmallPersistentVector.kt:22
   AssertionsKt.assertTrue$default(true, null, 2, null) at ImmutableListTest.kt:24
   Reflection.getOrCreateKotlinClass(Class@1): KClassImpl@1 at ImmutableListTest.kt:26
   Result.Companion ➜ Result.Companion@1 at ImmutableListTest.kt:26
   empty1.iterator(): BufferIterator@1 at ImmutableListTest.kt:26
+    listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
+      listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
+        size(): 0 at SmallPersistentVector.kt:143
+          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+        ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+        buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+        size(): 0 at SmallPersistentVector.kt:145
+          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
   BufferIterator@1.next(): threw java.util.NoSuchElementException at ImmutableListTest.kt:26
+    hasNext(): false at BufferIterator.kt:14
+      index ➜ 0 at AbstractListIterator.kt:10
+      size ➜ 0 at AbstractListIterator.kt:10
   Result.Companion ➜ Result.Companion@1 at ImmutableListTest.kt:26
   ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ImmutableListTest.kt:26
   Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ImmutableListTest.kt:26
@@ -35,6 +51,7 @@ ImmutableListTest.empty() at :0
                 expected ➜ EmptyList@1 at ComparisonDSL.kt:18
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:18
                 AssertionsKt.assertEquals(EmptyList@1, SmallPersistentVector@1, "") at ComparisonDSL.kt:18
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
               "".append(""): "" at CollectionBehaviors.kt:98
               "".append("hashCode"): "hashCode" at CollectionBehaviors.kt:98
               "hashCode".toString(): "hashCode" at CollectionBehaviors.kt:98
@@ -45,6 +62,16 @@ ImmutableListTest.empty() at :0
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                 getter.invoke(SmallPersistentVector@1): 1 at ComparisonDSL.kt:21
                   propertyEquals.hashCode(): 1 at CollectionBehaviors.kt:98
+                    listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
+                      listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
+                        size(): 0 at SmallPersistentVector.kt:143
+                          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                        ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                        size(): 0 at SmallPersistentVector.kt:145
+                          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                    index ➜ 0 at AbstractListIterator.kt:10
+                    size ➜ 0 at AbstractListIterator.kt:10
                 AssertionsKt.assertEquals(1, 1, "hashCode") at ComparisonDSL.kt:21
               "".append(""): "" at CollectionBehaviors.kt:100
               "".append("toString"): "toString" at CollectionBehaviors.kt:100
@@ -54,6 +81,16 @@ ImmutableListTest.empty() at :0
                 getter.invoke(EmptyList@1): "[]" at ComparisonDSL.kt:21
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                 getter.invoke(SmallPersistentVector@1): "[]" at ComparisonDSL.kt:21
+                  listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
+                    listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
+                      size(): 0 at SmallPersistentVector.kt:143
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                      buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                      size(): 0 at SmallPersistentVector.kt:145
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                  index ➜ 0 at AbstractListIterator.kt:10
+                  size ➜ 0 at AbstractListIterator.kt:10
                 AssertionsKt.assertEquals("[]", "[]", "toString") at ComparisonDSL.kt:21
           CollectionBehaviorsKt.collectionBehavior$default(CompareContext@1, null, false, 3, null) at CollectionBehaviors.kt:10
             CollectionBehaviorsKt.collectionBehavior(CompareContext@1, "", true) at CollectionBehaviors.kt:104
@@ -71,6 +108,7 @@ ImmutableListTest.empty() at :0
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                 getter.invoke(SmallPersistentVector@1): 0 at ComparisonDSL.kt:21
                   propertyEquals.size(): 0 at CollectionBehaviors.kt:106
+                    buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 AssertionsKt.assertEquals(0, 0, "size") at ComparisonDSL.kt:21
               "".append(""): "" at CollectionBehaviors.kt:107
               "".append("isEmpty"): "isEmpty" at CollectionBehaviors.kt:107
@@ -82,6 +120,7 @@ ImmutableListTest.empty() at :0
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                 getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
                   propertyEquals.isEmpty(): true at CollectionBehaviors.kt:107
+                    buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 AssertionsKt.assertEquals(true, true, "isEmpty") at ComparisonDSL.kt:21
               CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:109
                 CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -91,6 +130,9 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                   getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
                     CollectionsKt.contains(SmallPersistentVector@1, CollectionBehaviorsKt$collectionBehavior$3@1): false at CollectionBehaviors.kt:109
+                      indexOf(CollectionBehaviorsKt$collectionBehavior$3@1): -1 at AbstractPersistentList.kt:52
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:135
+                        ArraysKt.indexOf(Object;@1, CollectionBehaviorsKt$collectionBehavior$3@1): -1 at SmallPersistentVector.kt:135
                   AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
               CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:110
                 CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -101,7 +143,11 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                   getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
                     CollectionsKt.firstOrNull(SmallPersistentVector@1): null at CollectionBehaviors.kt:110
+                      buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                     CollectionsKt.contains(SmallPersistentVector@1, null): false at CollectionBehaviors.kt:110
+                      indexOf(null): -1 at AbstractPersistentList.kt:52
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:135
+                        ArraysKt.indexOf(Object;@1, null): -1 at SmallPersistentVector.kt:135
                   AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
               CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:111
                 CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -111,6 +157,9 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
                   getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
                     propertyEquals.containsAll(SmallPersistentVector@1): true at CollectionBehaviors.kt:111
+                      SmallPersistentVector@1.all() at AbstractPersistentList.kt:56
+                        isEmpty(): true at AbstractPersistentList.kt:69
+                          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                   AssertionsKt.assertEquals(true, true, "") at ComparisonDSL.kt:21
               collectionBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:113
                 expected ➜ EmptyList@1 at ComparisonDSL.kt:27
@@ -119,6 +168,14 @@ ImmutableListTest.empty() at :0
                 actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:27
                 getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
                   compareProperty.iterator(): BufferIterator@1 at CollectionBehaviors.kt:113
+                    listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
+                      listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
+                        size(): 0 at SmallPersistentVector.kt:143
+                          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                        ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                        size(): 0 at SmallPersistentVector.kt:145
+                          buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
                   block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
                     CollectionBehaviorsKt.iteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:113
@@ -130,6 +187,8 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                           getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                             propertyEquals.hasNext(): false at CollectionBehaviors.kt:55
+                              index ➜ 0 at AbstractListIterator.kt:10
+                              size ➜ 0 at AbstractListIterator.kt:10
                           AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                       iteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:57
                         expected ➜ EmptyIterator@1 at ComparisonDSL.kt:15
@@ -151,6 +210,9 @@ ImmutableListTest.empty() at :0
                               actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                               getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                                 propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:61
+                                  hasNext(): false at BufferIterator.kt:14
+                                    index ➜ 0 at AbstractListIterator.kt:10
+                                    size ➜ 0 at AbstractListIterator.kt:10
                             Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                             ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                             Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -167,6 +229,13 @@ ImmutableListTest.empty() at :0
             actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:27
             getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(): BufferIterator@1 at CollectionBehaviors.kt:11
+                listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
+                  size(): 0 at SmallPersistentVector.kt:143
+                    buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                  ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                  size(): 0 at SmallPersistentVector.kt:145
+                    buffer ➜ Object;@1 at SmallPersistentVector.kt:22
             ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
                 CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:11
@@ -179,6 +248,8 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
+                            index ➜ 0 at AbstractListIterator.kt:10
+                            size ➜ 0 at AbstractListIterator.kt:10
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:49
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -188,6 +259,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
+                            index ➜ 0 at AbstractListIterator.kt:14
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:50
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -197,6 +269,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
                           propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
+                            index ➜ 0 at AbstractListIterator.kt:18
                         AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:51
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -206,6 +279,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
                           propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
+                            index ➜ 0 at AbstractListIterator.kt:22
                         AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                     expected ➜ EmptyIterator@1 at ComparisonDSL.kt:15
@@ -227,6 +301,9 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
+                              hasNext(): false at BufferIterator.kt:14
+                                index ➜ 0 at AbstractListIterator.kt:10
+                                size ➜ 0 at AbstractListIterator.kt:10
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -255,6 +332,8 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
+                              hasPrevious(): false at BufferIterator.kt:21
+                                index ➜ 0 at AbstractListIterator.kt:14
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -271,6 +350,12 @@ ImmutableListTest.empty() at :0
             actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:27
             getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:12
+                size(): 0 at SmallPersistentVector.kt:143
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                size(): 0 at SmallPersistentVector.kt:145
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
             ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
                 CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:12
@@ -283,6 +368,8 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
+                            index ➜ 0 at AbstractListIterator.kt:10
+                            size ➜ 0 at AbstractListIterator.kt:10
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:49
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -292,6 +379,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
+                            index ➜ 0 at AbstractListIterator.kt:14
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:50
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -301,6 +389,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
                           propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
+                            index ➜ 0 at AbstractListIterator.kt:18
                         AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:51
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -310,6 +399,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
                           propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
+                            index ➜ 0 at AbstractListIterator.kt:22
                         AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                     expected ➜ EmptyIterator@1 at ComparisonDSL.kt:15
@@ -331,6 +421,9 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
+                              hasNext(): false at BufferIterator.kt:14
+                                index ➜ 0 at AbstractListIterator.kt:10
+                                size ➜ 0 at AbstractListIterator.kt:10
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -359,6 +452,8 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
+                              hasPrevious(): false at BufferIterator.kt:21
+                                index ➜ 0 at AbstractListIterator.kt:14
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -376,7 +471,14 @@ ImmutableListTest.empty() at :0
             actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:27
             getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.size(): 0 at CollectionBehaviors.kt:13
+                buffer ➜ Object;@1 at SmallPersistentVector.kt:22
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:13
+                size(): 0 at SmallPersistentVector.kt:143
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+                buffer ➜ Object;@1 at SmallPersistentVector.kt:145
+                size(): 0 at SmallPersistentVector.kt:145
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
             ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
                 CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:13
@@ -389,6 +491,8 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
+                            index ➜ 0 at AbstractListIterator.kt:10
+                            size ➜ 0 at AbstractListIterator.kt:10
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:49
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -398,6 +502,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
                           propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
+                            index ➜ 0 at AbstractListIterator.kt:14
                         AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:50
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -407,6 +512,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
                           propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
+                            index ➜ 0 at AbstractListIterator.kt:18
                         AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
                     CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:51
                       CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -416,6 +522,7 @@ ImmutableListTest.empty() at :0
                         actual ➜ BufferIterator@1 at ComparisonDSL.kt:21
                         getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
                           propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
+                            index ➜ 0 at AbstractListIterator.kt:22
                         AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                     expected ➜ EmptyIterator@1 at ComparisonDSL.kt:15
@@ -437,6 +544,9 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
+                              hasNext(): false at BufferIterator.kt:14
+                                index ➜ 0 at AbstractListIterator.kt:10
+                                size ➜ 0 at AbstractListIterator.kt:10
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -465,6 +575,8 @@ ImmutableListTest.empty() at :0
                           actual ➜ BufferIterator@1 at ComparisonDSL.kt:23
                           getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
+                              hasPrevious(): false at BufferIterator.kt:21
+                                index ➜ 0 at AbstractListIterator.kt:14
                         Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -491,6 +603,14 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:23
                   getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                     propertyFails.listIterator(-1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:15
+                      size(): 0 at SmallPersistentVector.kt:143
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(-1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
+                        "".append("index: "): "index: " at ListImplementation.kt:22
+                        "index: ".append(-1): "index: -1" at ListImplementation.kt:22
+                        "index: -1".append(", size: "): "index: -1, size: " at ListImplementation.kt:22
+                        "index: -1, size: ".append(0): "index: -1, size: 0" at ListImplementation.kt:22
+                        "index: -1, size: 0".toString(): "index: -1, size: 0" at ListImplementation.kt:22
                 Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                 ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
                 Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -517,7 +637,16 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:23
                   getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                     propertyFails.size(): 0 at CollectionBehaviors.kt:16
+                      buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                     propertyFails.listIterator(1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:16
+                      size(): 0 at SmallPersistentVector.kt:143
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
+                        "".append("index: "): "index: " at ListImplementation.kt:22
+                        "index: ".append(1): "index: 1" at ListImplementation.kt:22
+                        "index: 1".append(", size: "): "index: 1, size: " at ListImplementation.kt:22
+                        "index: 1, size: ".append(0): "index: 1, size: 0" at ListImplementation.kt:22
+                        "index: 1, size: 0".toString(): "index: 1, size: 0" at ListImplementation.kt:22
                 Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                 ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
                 Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -548,14 +677,25 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:25
                   getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
                     propertyFailsWith.size(): 0 at CollectionBehaviors.kt:21
+                      buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                     propertyFailsWith.get(0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:21
+                      size(): 0 at SmallPersistentVector.kt:150
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                      ListImplementation.checkElementIndex$kotlinx_collections_immutable(0, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:150
+                        "".append("index: "): "index: " at ListImplementation.kt:15
+                        "index: ".append(0): "index: 0" at ListImplementation.kt:15
+                        "index: 0".append(", size: "): "index: 0, size: " at ListImplementation.kt:15
+                        "index: 0, size: ".append(0): "index: 0, size: 0" at ListImplementation.kt:15
+                        "index: 0, size: 0".toString(): "index: 0, size: 0" at ListImplementation.kt:15
                 Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                 ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
                 Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                 AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
                 exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:35
+                  invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
                 AssertionsKt.assertTrue(true, "expected fail") at ComparisonDSL.kt:35
                 exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:36
+                  invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
                 AssertionsKt.assertTrue(true, "actual fail") at ComparisonDSL.kt:36
           CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:23
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -566,7 +706,10 @@ ImmutableListTest.empty() at :0
               actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
               getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
                 CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:23
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 CollectionsKt.indexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:23
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:135
+                  ArraysKt.indexOf(Object;@1, null): -1 at SmallPersistentVector.kt:135
               AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
           CompareContext.propertyEquals$default(CompareContext@1, null, CollectionBehaviorsKt$$Lambda@1, 1, null) at CollectionBehaviors.kt:24
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:20
@@ -577,7 +720,10 @@ ImmutableListTest.empty() at :0
               actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
               getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
                 CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:24
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 CollectionsKt.lastIndexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:24
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:139
+                  ArraysKt.lastIndexOf(Object;@1, null): -1 at SmallPersistentVector.kt:139
               AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:26
             CompareContext.assertFailEquals$default(CompareContext@1, CompareContext$$Lambda@1, CompareContext$$Lambda@1, null, 4, null) at ComparisonDSL.kt:23
@@ -597,7 +743,19 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:23
                   getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                     propertyFails.size(): 0 at CollectionBehaviors.kt:26
+                      buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                     propertyFails.subList(0, 1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:26
+                      subList(0, 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
+                        PersistentList.DefaultImpls.subList(SmallPersistentVector@1, 0, 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
+                          ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, 0, 1): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
+                            buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                            "".append("fromIndex: "): "fromIndex: " at ListImplementation.kt:29
+                            "fromIndex: ".append(0): "fromIndex: 0" at ListImplementation.kt:29
+                            "fromIndex: 0".append(", toIndex: "): "fromIndex: 0, toIndex: " at ListImplementation.kt:29
+                            "fromIndex: 0, toIndex: ".append(1): "fromIndex: 0, toIndex: 1" at ListImplementation.kt:29
+                            "fromIndex: 0, toIndex: 1".append(", size: "): "fromIndex: 0, toIndex: 1, size: " at ListImplementation.kt:29
+                            "fromIndex: 0, toIndex: 1, size: ".append(0): "fromIndex: 0, toIndex: 1, size: 0" at ListImplementation.kt:29
+                            "fromIndex: 0, toIndex: 1, size: 0".toString(): "fromIndex: 0, toIndex: 1, size: 0" at ListImplementation.kt:29
                 Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                 ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
                 Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -623,6 +781,17 @@ ImmutableListTest.empty() at :0
                   actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:23
                   getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                     propertyFails.subList(-1, 0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:27
+                      subList(-1, 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
+                        PersistentList.DefaultImpls.subList(SmallPersistentVector@1, -1, 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
+                          ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, -1, 0): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
+                            buffer ➜ Object;@1 at SmallPersistentVector.kt:22
+                            "".append("fromIndex: "): "fromIndex: " at ListImplementation.kt:29
+                            "fromIndex: ".append(-1): "fromIndex: -1" at ListImplementation.kt:29
+                            "fromIndex: -1".append(", toIndex: "): "fromIndex: -1, toIndex: " at ListImplementation.kt:29
+                            "fromIndex: -1, toIndex: ".append(0): "fromIndex: -1, toIndex: 0" at ListImplementation.kt:29
+                            "fromIndex: -1, toIndex: 0".append(", size: "): "fromIndex: -1, toIndex: 0, size: " at ListImplementation.kt:29
+                            "fromIndex: -1, toIndex: 0, size: ".append(0): "fromIndex: -1, toIndex: 0, size: 0" at ListImplementation.kt:29
+                            "fromIndex: -1, toIndex: 0, size: 0".toString(): "fromIndex: -1, toIndex: 0, size: 0" at ListImplementation.kt:29
                 Result.Companion ➜ Result.Companion@1 at ComparisonDSL.kt:32
                 ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
                 Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
@@ -640,6 +809,12 @@ ImmutableListTest.empty() at :0
               actual ➜ SmallPersistentVector@1 at ComparisonDSL.kt:21
               getter.invoke(SmallPersistentVector@1): ImmutableList.SubList@1 at ComparisonDSL.kt:21
                 propertyEquals.size(): 0 at CollectionBehaviors.kt:28
+                  buffer ➜ Object;@1 at SmallPersistentVector.kt:22
                 propertyEquals.subList(0, 0): ImmutableList.SubList@1 at CollectionBehaviors.kt:28
+                  subList(0, 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:13
+                    PersistentList.DefaultImpls.subList(SmallPersistentVector@1, 0, 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:15
+                      ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, 0, 0): ImmutableList.SubList@1 at ImmutableList.kt:62
+                        buffer ➜ Object;@1 at SmallPersistentVector.kt:22
               AssertionsKt.assertEquals(EmptyList@1, ImmutableList.SubList@1, "") at ComparisonDSL.kt:21
+                _size ➜ 0 at ImmutableList.kt:46
         Unit.INSTANCE ➜ Unit at ImmutableListTest.kt:16

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -317,12 +317,13 @@ object LincheckJavaAgent {
         }
 
         // Traverse super classes, interfaces, and enclosing class
-        val classesToTransform =
-            listOfNotNull(clazz.superclass) +
-            listOfNotNull(clazz.enclosingClass) +
-            clazz.interfaces.asList()
-
-        classesToTransform.forEach {
+        clazz.superclass?.also {
+            ensureClassHierarchyIsTransformed(it)
+        }
+        clazz.enclosingClass?.also {
+            ensureClassHierarchyIsTransformed(it)
+        }
+        clazz.interfaces.forEach {
             ensureClassHierarchyIsTransformed(it)
         }
     }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -351,7 +351,7 @@ object LincheckJavaAgent {
         }
     }
 
-    fun ensureStaticFieldValueIsTransformed(className: String, fieldName: String) {
+    fun ensureFieldValueIsTransformed(className: String, fieldName: String) {
         if (INSTRUMENT_ALL_CLASSES) return
         if (!shouldTransform(className, instrumentationMode)) return
 
@@ -359,9 +359,6 @@ object LincheckJavaAgent {
         val field = clazz.allDeclaredFieldWithSuperclasses.find { it.name == fieldName }
         check(field != null) {
             "Field $fieldName not found in class $className"
-        }
-        check(Modifier.isStatic(field.modifiers)) {
-            "Field $fieldName is not static in class $className"
         }
         if (field.type.isPrimitive) return
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -283,15 +283,12 @@ object LincheckJavaAgent {
 
     private fun ensureClassHierarchyIsTransformed(className: String, transformStaticFields: Boolean) {
         if (className in instrumentedClasses) return // already instrumented
-        // this check is important for performance reasons,
-        // as it allows to avoid `Class.forName` in case when class is already instrumented
-        // TODO: replace with `Class.forName` caching, see `classCache` in `Utils.kt`
-        if (!shouldTransform(className, instrumentationMode)) return
 
         val clazz = Class.forName(className)
         ensureClassHierarchyIsTransformed(clazz)
 
-        if (transformStaticFields) {
+        // transform static fields only if it was requested and the class itself was transformed
+        if (transformStaticFields && className in instrumentedClasses) {
             ensureStaticFieldsAreTransformed(clazz)
         }
     }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -289,12 +289,12 @@ object LincheckJavaAgent {
      */
     fun ensureClassHierarchyIsTransformed(className: String) {
         if (INSTRUMENT_ALL_CLASSES) {
-            Class.forName(className)
+            ClassCache.forName(className)
             return
         }
         if (className in instrumentedClasses) return // already instrumented
 
-        val clazz = Class.forName(className)
+        val clazz = ClassCache.forName(className)
         ensureClassHierarchyIsTransformed(clazz)
     }
 
@@ -391,7 +391,7 @@ object LincheckJavaAgent {
         if (INSTRUMENT_ALL_CLASSES) return
         if (!shouldTransform(className, instrumentationMode)) return
 
-        val clazz = Class.forName(className)
+        val clazz = ClassCache.forName(className)
         val field = clazz.allDeclaredFieldWithSuperclasses.find { it.name == fieldName }
         check(field != null) {
             "Field $fieldName not found in class $className"

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -363,7 +363,7 @@ object LincheckJavaAgent {
         if (field.type.isPrimitive) return
 
         readFieldSafely(null, field).getOrNull()?.let { obj ->
-            ensureObjectIsTransformed(obj)
+            ensureClassHierarchyIsTransformed(obj.javaClass)
         }
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -325,7 +325,7 @@ object LincheckJavaAgent {
                 traverseStaticFields = true,
             )
         ) { obj ->
-            val shouldTransform = shouldTransform(obj.javaClass, instrumentationMode)
+            val shouldTransform = shouldTransform(obj.javaClass.name, instrumentationMode)
             val shouldTraverse =
                 // optimization and safety net: do not traverse low-level
                 // class instances from the standard Java library

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -351,13 +351,16 @@ object LincheckJavaAgent {
         }
     }
 
-    fun ensureStaticFieldsAreTransformed(clazz: Class<*>, fieldName: String? = null) {
-        val processedObjects: MutableSet<Any> = identityHashSetOf()
+    fun ensureStaticFieldValueIsTransformed(className: String, fieldName: String? = null) {
+        if (INSTRUMENT_ALL_CLASSES) return
+        if (!shouldTransform(className, instrumentationMode)) return
+
+        val clazz = Class.forName(className)
         for (field in clazz.allDeclaredFieldWithSuperclasses) {
             if (!Modifier.isStatic(field.modifiers) || field.type.isPrimitive) continue
             if (fieldName != null && field.name != fieldName) continue
             readFieldSafely(null, field).getOrNull()?.let { obj ->
-                ensureObjectIsTransformed(obj, processedObjects)
+                ensureObjectIsTransformed(obj)
             }
         }
     }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -359,10 +359,11 @@ object LincheckJavaAgent {
         }
     }
 
-    private fun ensureStaticFieldsAreTransformed(clazz: Class<*>) {
+    fun ensureStaticFieldsAreTransformed(clazz: Class<*>, fieldName: String? = null) {
         val processedObjects: MutableSet<Any> = identityHashSetOf()
         for (field in clazz.allDeclaredFieldWithSuperclasses) {
             if (!Modifier.isStatic(field.modifiers) || field.type.isPrimitive) continue
+            if (fieldName != null && field.name != fieldName) continue
             readFieldSafely(null, field).getOrNull()?.let { obj ->
                 ensureObjectIsTransformed(obj, processedObjects)
             }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -351,7 +351,7 @@ object LincheckJavaAgent {
         }
     }
 
-    fun ensureStaticFieldValueIsTransformed(className: String, fieldName: String? = null) {
+    fun ensureStaticFieldValueIsTransformed(className: String, fieldName: String) {
         if (INSTRUMENT_ALL_CLASSES) return
         if (!shouldTransform(className, instrumentationMode)) return
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -273,10 +273,7 @@ object LincheckJavaAgent {
      *
      * @param className The name of the class to be transformed.
      */
-    fun ensureClassHierarchyIsTransformed(
-        className: String,
-        transformStaticFields: Boolean = false,
-    ) {
+    fun ensureClassHierarchyIsTransformed(className: String) {
         if (INSTRUMENT_ALL_CLASSES) {
             Class.forName(className)
             return
@@ -285,11 +282,6 @@ object LincheckJavaAgent {
 
         val clazz = Class.forName(className)
         ensureClassHierarchyIsTransformed(clazz)
-
-        // transform static fields only if it was requested and the class itself was transformed
-        if (transformStaticFields && className in instrumentedClasses) {
-            ensureStaticFieldsAreTransformed(clazz)
-        }
     }
 
     /**

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -345,7 +345,8 @@ object LincheckJavaAgent {
      *
      * @param clazz The class to be transformed.
      */
-    private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
+    fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
+        if (INSTRUMENT_ALL_CLASSES) return
         if (clazz.name in instrumentedClasses) return // already instrumented
 
         if (shouldTransform(clazz, instrumentationMode)) {

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlinx.lincheck.transformation.transformers.coroutineCalli
 import org.jetbrains.lincheck.util.Logger
 import org.jetbrains.lincheck.util.*
 import java.lang.instrument.Instrumentation
-import java.lang.reflect.Modifier
 import java.io.File
 import java.util.jar.JarFile
 import java.util.*
@@ -311,16 +310,18 @@ object LincheckJavaAgent {
                 traverseStaticFields = true,
             )
         ) { obj ->
-            ensureClassHierarchyIsTransformed(obj.javaClass)
-
-            val shouldTraverseObject =
+            val shouldTransform = shouldTransform(obj.javaClass, instrumentationMode)
+            val shouldTraverse =
                 // optimization and safety net: do not traverse low-level
                 // class instances from the standard Java library
                 !isLowLevelJavaClass(obj.javaClass.name) ||
                 // unless the low-level class needs to be transformed
-                shouldTransform(obj.javaClass, instrumentationMode)
+                shouldTransform
 
-            return@traverseObjectGraph shouldTraverseObject
+            if (shouldTransform) {
+                ensureClassHierarchyIsTransformed(obj.javaClass)
+            }
+            return@traverseObjectGraph shouldTraverse
         }
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -307,17 +307,7 @@ object LincheckJavaAgent {
 
         // this function is used to transform the traversed object's class
         fun transformObject(obj: Any) {
-            val clazz = obj.javaClass
-            val className = clazz.name
-            when {
-                isJavaLambdaClass(className) -> {
-                    val enclosingClassName = getJavaLambdaEnclosingClass(className)
-                    ensureClassHierarchyIsTransformed(enclosingClassName, transformStaticFields = false)
-                }
-                else -> if (shouldTransform(clazz, instrumentationMode)) {
-                    ensureClassHierarchyIsTransformed(clazz)
-                }
-            }
+            ensureClassHierarchyIsTransformed(obj.javaClass)
         }
 
         // this function is used to decide what objects should be traversed further
@@ -364,7 +354,10 @@ object LincheckJavaAgent {
     private fun ensureClassHierarchyIsTransformed(clazz: Class<*>) {
         if (clazz.name in instrumentedClasses) return // already instrumented
 
-        if (shouldTransform(clazz, instrumentationMode)) {
+        if (isJavaLambdaClass(clazz.name)) {
+            val enclosingClassName = getJavaLambdaEnclosingClass(clazz.name)
+            ensureClassHierarchyIsTransformed(enclosingClassName, transformStaticFields = false)
+        } else if (shouldTransform(clazz, instrumentationMode)) {
             instrumentedClasses += clazz.name
             retransformClass(clazz)
         }

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -273,15 +273,14 @@ object LincheckJavaAgent {
      *
      * @param className The name of the class to be transformed.
      */
-    fun ensureClassHierarchyIsTransformed(className: String) {
+    fun ensureClassHierarchyIsTransformed(
+        className: String,
+        transformStaticFields: Boolean = true,
+    ) {
         if (INSTRUMENT_ALL_CLASSES) {
             Class.forName(className)
             return
         }
-        ensureClassHierarchyIsTransformed(className, transformStaticFields = true)
-    }
-
-    private fun ensureClassHierarchyIsTransformed(className: String, transformStaticFields: Boolean) {
         if (className in instrumentedClasses) return // already instrumented
 
         val clazz = Class.forName(className)
@@ -367,10 +366,8 @@ object LincheckJavaAgent {
     }
 
     private fun ensureStaticFieldsAreTransformed(clazz: Class<*>) {
-        // Traverse class static fields.
         val processedObjects: MutableSet<Any> = identityHashSetOf()
         for (field in clazz.allDeclaredFieldWithSuperclasses) {
-            // traverse only static non-primitive fields
             if (!Modifier.isStatic(field.modifiers) || field.type.isPrimitive) continue
             readFieldSafely(null, field).getOrNull()?.let { obj ->
                 ensureObjectIsTransformed(obj, processedObjects)

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -356,12 +356,17 @@ object LincheckJavaAgent {
         if (!shouldTransform(className, instrumentationMode)) return
 
         val clazz = Class.forName(className)
-        for (field in clazz.allDeclaredFieldWithSuperclasses) {
-            if (!Modifier.isStatic(field.modifiers) || field.type.isPrimitive) continue
-            if (fieldName != null && field.name != fieldName) continue
-            readFieldSafely(null, field).getOrNull()?.let { obj ->
-                ensureObjectIsTransformed(obj)
-            }
+        val field = clazz.allDeclaredFieldWithSuperclasses.find { it.name == fieldName }
+        check(field != null) {
+            "Field $fieldName not found in class $className"
+        }
+        check(Modifier.isStatic(field.modifiers)) {
+            "Field $fieldName is not static in class $className"
+        }
+        if (field.type.isPrimitive) return
+
+        readFieldSafely(null, field).getOrNull()?.let { obj ->
+            ensureObjectIsTransformed(obj)
         }
     }
 

--- a/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
+++ b/jvm-agent/src/main/org/jetbrains/kotlinx/lincheck/transformation/LincheckJavaAgent.kt
@@ -275,7 +275,7 @@ object LincheckJavaAgent {
      */
     fun ensureClassHierarchyIsTransformed(
         className: String,
-        transformStaticFields: Boolean = true,
+        transformStaticFields: Boolean = false,
     ) {
         if (INSTRUMENT_ALL_CLASSES) {
             Class.forName(className)
@@ -345,7 +345,7 @@ object LincheckJavaAgent {
             retransformClass(clazz)
         } else if (isJavaLambdaClass(clazz.name)) {
             val enclosingClassName = getJavaLambdaEnclosingClass(clazz.name)
-            ensureClassHierarchyIsTransformed(enclosingClassName, transformStaticFields = false)
+            ensureClassHierarchyIsTransformed(enclosingClassName)
         }
 
         // Traverse super classes, interfaces, and enclosing class

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -240,6 +240,3 @@ internal fun <T> Class<T>.newDefaultInstance(): T {
 
     throw IllegalStateException("No suitable constructor found for ${this.canonicalName}")
 }
-
-// We store the class references in a local map to avoid repeated Class.forName calls and reflection overhead
-val classCache = ConcurrentHashMap<String, Class<*>>()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1224,7 +1224,7 @@ internal abstract class ManagedStrategy(
         // We need to ensure all the classes related to the reading object are instrumented.
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className, transformStaticFields = true)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {
@@ -1425,7 +1425,7 @@ internal abstract class ManagedStrategy(
     }
 
     override fun beforeNewObjectCreation(className: String) = runInsideIgnoredSection {
-        LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
+        LincheckJavaAgent.ensureClassHierarchyIsTransformed(className, transformStaticFields = true)
     }
 
     override fun afterNewObjectCreation(obj: Any) {
@@ -1606,7 +1606,7 @@ internal abstract class ManagedStrategy(
         )
         // in case if a static method is called, ensure its class is instrumented
         if (receiver == null && methodSection < AnalysisSectionType.ATOMIC) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(methodDescriptor.className)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(methodDescriptor.className, transformStaticFields = true)
         }
         // in the case of atomics API setter method call, notify the object tracker about a new link between objects
         if (atomicMethodDescriptor != null && atomicMethodDescriptor.kind.isSetter) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1225,7 +1225,7 @@ internal abstract class ManagedStrategy(
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
-            LincheckJavaAgent.ensureStaticFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
+            LincheckJavaAgent.ensureFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1225,7 +1225,6 @@ internal abstract class ManagedStrategy(
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
-            // LincheckJavaAgent.ensureFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1225,7 +1225,7 @@ internal abstract class ManagedStrategy(
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
-            LincheckJavaAgent.ensureFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
+            // LincheckJavaAgent.ensureFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {
@@ -1249,11 +1249,14 @@ internal abstract class ManagedStrategy(
     }
 
     override fun afterReadField(obj: Any?, codeLocation: Int, fieldId: Int, value: Any?) = runInsideIgnoredSection {
+        val eventId = getNextEventId()
+        val threadId = threadScheduler.getCurrentThreadId()
+        val fieldDescriptor = TRACE_CONTEXT.getFieldDescriptor(fieldId)
+        if (fieldDescriptor.isStatic && value !== null) {
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(value.javaClass)
+        }
         if (collectTrace) {
-            val eventId = getNextEventId()
-            val threadId = threadScheduler.getCurrentThreadId()
-            val fieldDescriptor = TRACE_CONTEXT.getFieldDescriptor(fieldId)
-            if (value != null) {
+            if (value !== null) {
                 constants[value] = fieldDescriptor.fieldName
             }
             val valueRepresentation = objectTracker.getObjectRepresentation(value)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1224,7 +1224,8 @@ internal abstract class ManagedStrategy(
         // We need to ensure all the classes related to the reading object are instrumented.
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className, transformStaticFields = true)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
+            LincheckJavaAgent.ensureStaticFieldsAreTransformed(Class.forName(fieldDescriptor.className), fieldDescriptor.fieldName)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {
@@ -1425,7 +1426,7 @@ internal abstract class ManagedStrategy(
     }
 
     override fun beforeNewObjectCreation(className: String) = runInsideIgnoredSection {
-        LincheckJavaAgent.ensureClassHierarchyIsTransformed(className, transformStaticFields = true)
+        LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
     }
 
     override fun afterNewObjectCreation(obj: Any) {
@@ -1606,7 +1607,7 @@ internal abstract class ManagedStrategy(
         )
         // in case if a static method is called, ensure its class is instrumented
         if (receiver == null && methodSection < AnalysisSectionType.ATOMIC) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(methodDescriptor.className, transformStaticFields = true)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(methodDescriptor.className)
         }
         // in the case of atomics API setter method call, notify the object tracker about a new link between objects
         if (atomicMethodDescriptor != null && atomicMethodDescriptor.kind.isSetter) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1225,7 +1225,7 @@ internal abstract class ManagedStrategy(
         // The following call checks all the static fields.
         if (fieldDescriptor.isStatic) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(fieldDescriptor.className)
-            LincheckJavaAgent.ensureStaticFieldsAreTransformed(Class.forName(fieldDescriptor.className), fieldDescriptor.fieldName)
+            LincheckJavaAgent.ensureStaticFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
         }
         // Do not track accesses to untracked objects
         if (!shouldTrackFieldAccess(obj, fieldDescriptor)) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1251,7 +1251,7 @@ internal abstract class ManagedStrategy(
         val eventId = getNextEventId()
         val threadId = threadScheduler.getCurrentThreadId()
         val fieldDescriptor = TRACE_CONTEXT.getFieldDescriptor(fieldId)
-        if (fieldDescriptor.isStatic && value !== null) {
+        if (fieldDescriptor.isStatic && value !== null && !value.isImmutable) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(value.javaClass)
         }
         if (collectTrace) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/SnapshotTracker.kt
@@ -10,14 +10,12 @@
 
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
-import org.jetbrains.kotlinx.lincheck.classCache
 import org.jetbrains.kotlinx.lincheck.findField
 import org.jetbrains.kotlinx.lincheck.strategy.managed.SnapshotTracker.MemoryNode.*
 import org.jetbrains.lincheck.util.*
 import java.lang.Class
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
-import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.Stack
 import java.util.concurrent.atomic.AtomicIntegerArray
@@ -263,7 +261,7 @@ class SnapshotTracker {
     }
 
     private fun getDeclaringClass(obj: Any?, className: String, fieldName: String): Class<*> {
-        val clazz = classCache.getOrPut(className) { Class.forName(className) }
+        val clazz = ClassCache.forName(className)
         return getDeclaringClass(obj, clazz, fieldName)
     }
 

--- a/trace-debugger/src/main/org/jetbrains/lincheck/trace/debugger/TraceDebuggerInjections.kt
+++ b/trace-debugger/src/main/org/jetbrains/lincheck/trace/debugger/TraceDebuggerInjections.kt
@@ -91,7 +91,7 @@ object TraceDebuggerInjections {
 
     class TraceDebuggerStaticMethodWrapper {
         fun callStaticMethod(clazz: Class<*>, method: Method) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(clazz.name)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(clazz.name, transformStaticFields = true)
             method.invoke(null)
         }
     }

--- a/trace-debugger/src/main/org/jetbrains/lincheck/trace/debugger/TraceDebuggerInjections.kt
+++ b/trace-debugger/src/main/org/jetbrains/lincheck/trace/debugger/TraceDebuggerInjections.kt
@@ -91,7 +91,7 @@ object TraceDebuggerInjections {
 
     class TraceDebuggerStaticMethodWrapper {
         fun callStaticMethod(clazz: Class<*>, method: Method) {
-            LincheckJavaAgent.ensureClassHierarchyIsTransformed(clazz.name, transformStaticFields = true)
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(clazz.name)
             method.invoke(null)
         }
     }

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -306,6 +306,7 @@ class TraceCollectingEventTracker(
         val fieldDescriptor = TRACE_CONTEXT.getFieldDescriptor(fieldId)
         if (fieldDescriptor.isStatic) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(className)
+            LincheckJavaAgent.ensureFieldValueIsTransformed(fieldDescriptor.className, fieldDescriptor.fieldName)
         }
         return
     }

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -326,7 +326,7 @@ class TraceCollectingEventTracker(
     // and therefore all injected functions should run inside ignored section.
     override fun afterReadField(obj: Any?, codeLocation: Int, fieldId: Int, value: Any?) = runInsideIgnoredSection {
         val fieldDescriptor = TRACE_CONTEXT.getFieldDescriptor(fieldId)
-        if (fieldDescriptor.isStatic && value !== null) {
+        if (fieldDescriptor.isStatic && value !== null && !value.isImmutable) {
             LincheckJavaAgent.ensureClassHierarchyIsTransformed(value.javaClass)
         }
 


### PR DESCRIPTION
Traversing and transforming all static field (and reachable objects) in each call to `ensureClassHierarchyIsTransformed` is not necessary. 

We need to transform only the value read from a static field. 