### PR TITLE
Add support for all-threads tracking

### DIFF
--- a/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
@@ -18,6 +18,7 @@ import java.lang.invoke.CallSite;
  */
 public interface EventTracker {
 
+    void beforeExistingThreadTracking(Thread thread, ThreadDescriptor descriptor);
     void beforeThreadFork(Thread thread, ThreadDescriptor descriptor);
     void beforeThreadStart();
     void afterThreadFinish();

--- a/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/EventTracker.java
@@ -18,7 +18,7 @@ import java.lang.invoke.CallSite;
  */
 public interface EventTracker {
 
-    void beforeExistingThreadTracking(Thread thread, ThreadDescriptor descriptor);
+    void registerRunningThread(Thread thread, ThreadDescriptor descriptor);
     void beforeThreadFork(Thread thread, ThreadDescriptor descriptor);
     void beforeThreadStart();
     void afterThreadFinish();

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -52,7 +52,6 @@ public class Injections {
             ThreadDescriptor.setThreadDescriptor(t, descriptor);
         }
         descriptor.setEventTracker(allThreadsEventTracker);
-        descriptor.setTrackedFromStart(false);
         ThreadDescriptor.setCurrentThreadDescriptor(descriptor);
         allThreadsEventTracker.beforeExistingThreadTracking(t, descriptor);
         return descriptor;

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -30,7 +30,7 @@ public class Injections {
     public static Object lastSuspendedCancellableContinuationDuringVerification = null;
 
     /**
-     * In case if {@code globalEventTracker != null} is {@code false}, returns the current thread descriptor or {@code null}.
+     * In case if {@code globalEventTracker == null}, returns the current thread descriptor or {@code null}.
      * </br></br>
      * Otherwise, creates a new thread descriptor for the current thread. This thread is considered
      * as the one not tracked from the start, so it is registered in the {@code globalEventTracker}

--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -22,8 +22,41 @@ public class Injections {
     // Special object to represent void method call result.
     public static final Object VOID_RESULT = new Object();
 
+    // Agent passes the event tracker if it decides to start recording trace points
+    // in already running threads.
+    public static EventTracker allThreadsEventTracker = null;
+
+    // Flag which enables tracking of events in all threads.
+    public static volatile boolean allThreadsTracked = false;
+
     // Used in the verification phase to store a suspended continuation.
     public static Object lastSuspendedCancellableContinuationDuringVerification = null;
+
+    /**
+     * In case if {@code allThreadsTracked} is {@code false}, returns the current thread descriptor or {@code null}.
+     * </br></br>
+     * Otherwise, creates a new thread descriptor for the current thread. This thread is considered
+     * as the one not tracked from the start, so it is registered in the {@code allThreadsEventTracker}
+     * by invoking {@code EventTracker.beforeExistingThreadTracking}.
+     * Eventually, the method returns the created thread descriptor.
+     */
+    private static ThreadDescriptor getOrCreateCurrentThreadDescriptor() {
+        ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
+        if (descriptor != null || !allThreadsTracked) {
+            return descriptor;
+        }
+        Thread t = Thread.currentThread();
+        descriptor = ThreadDescriptor.getThreadDescriptor(t);
+        if (descriptor == null) {
+            descriptor = new ThreadDescriptor(t);
+            ThreadDescriptor.setThreadDescriptor(t, descriptor);
+        }
+        descriptor.setEventTracker(allThreadsEventTracker);
+        descriptor.setTrackedFromStart(false);
+        ThreadDescriptor.setCurrentThreadDescriptor(descriptor);
+        allThreadsEventTracker.beforeExistingThreadTracking(t, descriptor);
+        return descriptor;
+    }
 
     public static EventTracker getEventTracker() {
         ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
@@ -41,6 +74,17 @@ public class Injections {
             // We are in the verification phase.
             lastSuspendedCancellableContinuationDuringVerification = cont;
         }
+    }
+
+    /**
+     * Enables tracking of all threads. Expects {@code eventTracker} to be the tracker
+     * which will be responsible for registering existing threads when they generate some trace point.
+     */
+    public static void enableAllThreadsTracking(EventTracker eventTracker) {
+        allThreadsEventTracker = eventTracker;
+        // Since `allThreadsTracked` is volatile, the order of assigning these variables is important:
+        // `allThreadsTracked` must be assigned afterward to allow for proper visibility of the `allThreadsEventTracker`.
+        allThreadsTracked = true;
     }
 
     /**
@@ -94,7 +138,11 @@ public class Injections {
      * @return true if the current thread is inside an ignored section, false otherwise.
      */
     public static boolean inAnalyzedCode() {
-        ThreadDescriptor descriptor = ThreadDescriptor.getCurrentThreadDescriptor();
+        // The tracking points for every existing thread are, basically, any of the events:
+        // field read/write, method call, etc. So to avoid inserting the call to each of the
+        // corresponding injection methods, `getOrCreateCurrentThreadDescriptor` is only called here:
+        // in the check which is invoked before each of the injection methods.
+        ThreadDescriptor descriptor = getOrCreateCurrentThreadDescriptor();
         if (descriptor == null) return false;
         return descriptor.inAnalyzedCode();
     }

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -83,11 +83,6 @@ public class ThreadDescriptor {
      */
     private int ignoredSectionDepth = 0;
 
-    /**
-     * This flag indicates whether the thread is tracked from the start by the attached agent.
-     */
-    private boolean isTrackedFromStart = true;
-
     public ThreadDescriptor(Thread thread) {
         if (thread == null) {
             throw new IllegalArgumentException("Thread must not be null");
@@ -113,14 +108,6 @@ public class ThreadDescriptor {
 
     public void setEventTrackerData(Object eventTrackerData) {
         this.eventTrackerData = new WeakReference<>(eventTrackerData);
-    }
-
-    public boolean isTrackedFromStart() {
-        return isTrackedFromStart;
-    }
-
-    public void setTrackedFromStart(boolean trackedFromStart) {
-        isTrackedFromStart = trackedFromStart;
     }
 
     public void setAsRootDescriptor() {

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -60,6 +60,9 @@ public class ThreadDescriptor {
 
     /**
      * This flag indicates whether the Lincheck analysis is currently enabled in this thread.
+     * <br><br>
+     * Note: the field is volatile because it could be modified from different threads:
+     * owner of this {@code ThreadDescriptor} and the Main thread of the test.
      */
     private volatile boolean isAnalysisEnabled = false;
 
@@ -67,12 +70,15 @@ public class ThreadDescriptor {
      * This flag indicates whether the thread is currently executing injected code (e.g., method from {@code EventTracker}).
      * <br><br>
      * This flag is used together with {@code isAnalysisEnabled}, they allow for proper synchronization in
-     * case if Trace Recorder is used with {@code allThreadsTracked} flag enabled.
+     * case if Trace Recorder is used with {@code globalEventTracker != null}.
      * <br>
      * When the Main thread wants to dump the trace, it needs to logically "finish" all currently running threads
      * so that they stop writing their trace points. For that Main marks some thread's {@code isAnalysisEnabled} flag as false,
      * and then waits until that thread's {@code isInsideInjectedCode} flag is also false,
      * afterward Main thread dumps the remaining tracepoints of thread that it waited for.
+     * <br><br>
+     * Note: the field is volatile because it could be modified from different threads:
+     * owner of this {@code ThreadDescriptor} and the Main thread of the test.
      */
     private volatile boolean isInsideInjectedCode = false;
 

--- a/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/ThreadDescriptor.java
@@ -70,6 +70,11 @@ public class ThreadDescriptor {
      */
     private int ignoredSectionDepth = 0;
 
+    /**
+     * This flag indicates whether the thread is tracked from the start by the attached agent.
+     */
+    private boolean isTrackedFromStart = true;
+
     public ThreadDescriptor(Thread thread) {
         if (thread == null) {
             throw new IllegalArgumentException("Thread must not be null");
@@ -95,6 +100,14 @@ public class ThreadDescriptor {
 
     public void setEventTrackerData(Object eventTrackerData) {
         this.eventTrackerData = new WeakReference<>(eventTrackerData);
+    }
+
+    public boolean isTrackedFromStart() {
+        return isTrackedFromStart;
+    }
+
+    public void setTrackedFromStart(boolean trackedFromStart) {
+        isTrackedFromStart = trackedFromStart;
     }
 
     public void setAsRootDescriptor() {
@@ -130,6 +143,13 @@ public class ThreadDescriptor {
      */
     public boolean inAnalyzedCode() {
         return isAnalysisEnabled && (ignoredSectionDepth == 0);
+    }
+
+    /**
+     * @return `true` if analysis is enabled for this thread, `false` otherwise.
+     */
+    public boolean isAnalysisEnabled() {
+        return isAnalysisEnabled;
     }
 
     /**

--- a/buildSrc/src/main/kotlin/TraceAgentIntegrationTestsTasks.kt
+++ b/buildSrc/src/main/kotlin/TraceAgentIntegrationTestsTasks.kt
@@ -39,6 +39,11 @@ private val projectsToTest = listOf(
         repositoryName = "ktor",
         commitHash = "40eb608b9b561c9e6d7d2d998f2a7c39bd63869d"
     ),
+    GithubProjectSnapshot(
+        organization = "Kotlin",
+        repositoryName = "kotlinx.coroutines",
+        commitHash = "8062e9f6c21bc2672528c5e63dcff7e9057a0989"
+    )
 )
 
 lateinit var traceAgentIntegrationTestsPrerequisites: TaskProvider<Task>

--- a/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
+++ b/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
@@ -23,6 +23,10 @@ import java.util.concurrent.ConcurrentHashMap
 val TRACE_CONTEXT: TraceContext = TraceContext()
 
 const val UNKNOWN_CODE_LOCATION_ID = -1
+// This method type corresponds to the following method descriptor '(V)V'
+// which is invalid jvm method descriptor, but it is only used to mark some method type as unknown
+// or impossible to properly track.
+val UNKNOWN_METHOD_TYPE = Types.MethodType(Types.VOID_TYPE, Types.VOID_TYPE)
 
 private val EMPTY_STACK_TRACE = StackTraceElement("", "", "", 0)
 

--- a/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
+++ b/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
@@ -53,21 +53,21 @@ class TraceContext {
 
     val methodDescriptors: List<MethodDescriptor?> get() = methods.content
 
-    fun getOrCreateMethodId(className: String, methodName: String, desc: String): Int {
+    fun getOrCreateMethodId(className: String, methodName: String, methodType: Types.MethodType): Int {
         return methods.getOrCreateId(
             MethodDescriptor(
                 context = this,
                 classId = getOrCreateClassId(className),
                 methodSignature = MethodSignature(
                     name = methodName,
-                    methodType = Types.convertAsmMethodType(desc)
+                    methodType = methodType
                 )
             )
         )
     }
 
-    fun getMethodDescriptor(className: String, methodName: String, desc: String): MethodDescriptor =
-        getMethodDescriptor(getOrCreateMethodId(className, methodName, desc))
+    fun getMethodDescriptor(className: String, methodName: String, methodType: Types.MethodType): MethodDescriptor =
+        getMethodDescriptor(getOrCreateMethodId(className, methodName, methodType))
 
     fun getMethodDescriptor(methodId: Int): MethodDescriptor = methods[methodId]
 

--- a/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
@@ -308,8 +308,8 @@ class AnalysisProfile(val analyzeStdLib: Boolean) {
         if (className.startsWith("org.junit.")) return false
         if (className.startsWith("junit.framework.")) return false
         // Finally, we should never instrument the Lincheck classes.
-        if (className.startsWith("org.jetbrains.lincheck.")) return false
-        if (className.startsWith("org.jetbrains.kotlinx.lincheck.")) return false
+        if (className.startsWith(LINCHECK_PACKAGE_NAME)) return false
+        if (className.startsWith(LINCHECK_KOTLINX_PACKAGE_NAME)) return false
         // All the classes that were not filtered out are eligible for transformation.
         return true
     }

--- a/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
@@ -1,14 +1,14 @@
 /*
  * Lincheck
  *
- * Copyright (C) 2019 - 2024 JetBrains s.r.o.
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
  *
  * This Source Code Form is subject to the terms of the
  * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package org.jetbrains.kotlinx.lincheck.util
+package org.jetbrains.lincheck.util
 
 /**
  * A spinner implements utility functions for spinning in a loop.
@@ -170,7 +170,7 @@ class Spinner private constructor(
  *
  * @see Spinner.spinWaitBoundedFor
  */
-internal inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
+inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
     spinWaitBoundedUntil {
         val result = getter()
         if (result != null)
@@ -187,7 +187,7 @@ internal inline fun <T> Spinner.spinWaitBoundedFor(getter: () -> T?): T? {
  * @param nThreads The number of threads in the group.
  */
 @Suppress("FunctionName")
-internal fun SpinnerGroup(nThreads: Int): List<Spinner> {
+fun SpinnerGroup(nThreads: Int): List<Spinner> {
     return Array(nThreads) { Spinner(nThreads) }.asList()
 }
 

--- a/integration-test/trace-recorder/src/main/org/jetbrains/trace/recorder/test/KotlinCoroutinesTraceRecorderIntegrationTest.kt
+++ b/integration-test/trace-recorder/src/main/org/jetbrains/trace/recorder/test/KotlinCoroutinesTraceRecorderIntegrationTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.trace.recorder.test
+
+import org.junit.Test
+import java.nio.file.Paths
+
+class KotlinCoroutinesTraceRecorderIntegrationTest : AbstractTraceRecorderIntegrationTest() {
+    override val projectPath: String = Paths.get("build", "integrationTestProjects", "kotlinx.coroutines").toString()
+
+    @Test
+    fun `kotlinx_coroutines_DelayJvmTest testDelayInArbitraryContext`() {
+        runGradleTest(
+            testClassName = "kotlinx.coroutines.DelayJvmTest",
+            testMethodName = "testDelayInArbitraryContext",
+            gradleCommands = listOf(
+                "kotlinx-coroutines-core:jvmTest",
+            )
+        )
+    }
+
+    @Test
+    fun `kotlinx_coroutines_EventLoopsTest testEventLoopInDefaultExecutor`() {
+        runGradleTest(
+            testClassName = "kotlinx.coroutines.EventLoopsTest",
+            testMethodName = "testEventLoopInDefaultExecutor",
+            gradleCommands = listOf(
+                "kotlinx-coroutines-core:jvmTest",
+            )
+        )
+    }
+
+    @Test
+    fun `kotlinx_coroutines_ExecutorsTest testExampleCancel02`() {
+        runGradleTest(
+            testClassName = "kotlinx.coroutines.ExecutorsTest",
+            testMethodName = "testDefaultDispatcherToExecutor",
+            gradleCommands = listOf(
+                "kotlinx-coroutines-core:jvmTest",
+            )
+        )
+    }
+}

--- a/integration-test/trace-recorder/src/main/org/jetbrains/trace/recorder/test/KotlinCoroutinesTraceRecorderIntegrationTest.kt
+++ b/integration-test/trace-recorder/src/main/org/jetbrains/trace/recorder/test/KotlinCoroutinesTraceRecorderIntegrationTest.kt
@@ -22,7 +22,7 @@ class KotlinCoroutinesTraceRecorderIntegrationTest : AbstractTraceRecorderIntegr
             testClassName = "kotlinx.coroutines.DelayJvmTest",
             testMethodName = "testDelayInArbitraryContext",
             gradleCommands = listOf(
-                "kotlinx-coroutines-core:jvmTest",
+                ":kotlinx-coroutines-core:jvmTest",
             )
         )
     }
@@ -33,7 +33,7 @@ class KotlinCoroutinesTraceRecorderIntegrationTest : AbstractTraceRecorderIntegr
             testClassName = "kotlinx.coroutines.EventLoopsTest",
             testMethodName = "testEventLoopInDefaultExecutor",
             gradleCommands = listOf(
-                "kotlinx-coroutines-core:jvmTest",
+                ":kotlinx-coroutines-core:jvmTest",
             )
         )
     }
@@ -44,7 +44,7 @@ class KotlinCoroutinesTraceRecorderIntegrationTest : AbstractTraceRecorderIntegr
             testClassName = "kotlinx.coroutines.ExecutorsTest",
             testMethodName = "testDefaultDispatcherToExecutor",
             gradleCommands = listOf(
-                "kotlinx-coroutines-core:jvmTest",
+                ":kotlinx-coroutines-core:jvmTest",
             )
         )
     }

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.DelayJvmTest_testDelayInArbitraryContext.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.DelayJvmTest_testDelayInArbitraryContext.txt
@@ -1,0 +1,470 @@
+# Thread 1 (Test worker)
+DelayJvmTest.testDelayInArbitraryContext() at :0
+  BuildersKt.runBlocking$default(null, DelayJvmTest$testDelayInArbitraryContext$1@1, 1, null): Unit at DelayJvmTest.kt:14
+    BuildersKt__BuildersKt.runBlocking$default(null, DelayJvmTest$testDelayInArbitraryContext$1@1, 1, null): Unit at :1
+      BuildersKt.runBlocking(EmptyCoroutineContext@1, DelayJvmTest$testDelayInArbitraryContext$1@1): Unit at Builders.kt:48
+        BuildersKt__BuildersKt.runBlocking(EmptyCoroutineContext@1, DelayJvmTest$testDelayInArbitraryContext$1@1): Unit at :1
+          Thread.currentThread(): Thread@1 at Builders.kt:53
+          context.get(ContinuationInterceptor.Key@1): null at Builders.kt:54
+          ThreadLocalEventLoop.INSTANCE.getEventLoop(): BlockingEventLoop@1 at Builders.kt:59
+          eventLoop = BlockingEventLoop@1 at Builders.kt:59
+          context.plus(BlockingEventLoop@1): BlockingEventLoop@1 at Builders.kt:60
+          CoroutineContextKt.newCoroutineContext(GlobalScope@1, BlockingEventLoop@1): CombinedContext@1 at Builders.kt:60
+            newCoroutineContext.getCoroutineContext(): EmptyCoroutineContext@1 at CoroutineContext.kt:15
+            CoroutineContextKt.foldCopies(EmptyCoroutineContext@1, BlockingEventLoop@1, true): BlockingEventLoop@1 at CoroutineContext.kt:15
+              CoroutineContextKt.hasCopyableElements(EmptyCoroutineContext@1): false at CoroutineContext.kt:50
+                hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+              CoroutineContextKt.hasCopyableElements(BlockingEventLoop@1): false at CoroutineContext.kt:51
+                hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+              originalContext.plus(BlockingEventLoop@1): BlockingEventLoop@1 at CoroutineContext.kt:55
+            DebugKt.getDEBUG(): true at CoroutineContext.kt:16
+            DebugKt.getCOROUTINE_ID(): AtomicLong@1 at CoroutineContext.kt:16
+            AtomicLong@1.incrementAndGet(): 1 at CoroutineContext.kt:16
+            combined.plus(CoroutineId@1): CombinedContext@1 at CoroutineContext.kt:16
+            Dispatchers.getDefault(): DefaultScheduler@1 at CoroutineContext.kt:17
+            combined.get(ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineContext.kt:17
+          newContext = CombinedContext@1 at Builders.kt:60
+          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:142
+          getParentHandle(): null at JobSupport.kt:142
+            JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): null at JobSupport.kt:129
+          setParentHandle(NonDisposableHandle@1) at JobSupport.kt:144
+            JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+          Job.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at JobSupport.kt:22
+            CoroutineContext.Element.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at Job.kt:118
+          coroutine.start(CoroutineStart.DEFAULT, BlockingCoroutine@1, DelayJvmTest$testDelayInArbitraryContext$1@1) at Builders.kt:69
+            start.invoke(DelayJvmTest$testDelayInArbitraryContext$1@1, BlockingCoroutine@1, BlockingCoroutine@1) at AbstractCoroutine.kt:134
+              DelayJvmTest$testDelayInArbitraryContext$1@1.L$0 = BlockingCoroutine@1 at DelayJvmTest.kt:0
+              continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+              DispatchedContinuation@1.resumeCancellableWith() at DispatchedContinuation.kt:278
+                CompletionStateKt.toState(Unit): Unit at DispatchedContinuation.kt:207
+                  Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                getContext(): CombinedContext@1 at DispatchedContinuation.kt:208
+                  continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                DispatchedContinuationKt.safeIsDispatchNeeded(BlockingEventLoop@1, CombinedContext@1): true at DispatchedContinuation.kt:208
+                  safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): true at DispatchedContinuation.kt:262
+                _state = Unit at DispatchedContinuation.kt:209
+                resumeMode = 1 at DispatchedContinuation.kt:210
+                getContext(): CombinedContext@1 at DispatchedContinuation.kt:211
+                  continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                DispatchedContinuationKt.safeDispatch(BlockingEventLoop@1, CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:211
+                  safeDispatch.dispatch(CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:254
+          coroutine.joinBlocking(): Unit at Builders.kt:70
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:89
+            BlockingEventLoop@1.incrementUseCount(false) at Builders.kt:91
+              delta(false): 1 at EventLoop.common.kt:100
+              useCount = 1 at EventLoop.common.kt:100
+              shared = true at EventLoop.common.kt:101
+            eventLoop.processNextEvent(): 0 at Builders.kt:94
+              updateThreadContext(CombinedContext@1): "Test worker" at CoroutineContext.kt:289
+                context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                  ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                  Job.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                    CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                currentThread.getName(): "Test worker" at CoroutineContext.kt:302
+                StringsKt.lastIndexOf$default("Test worker", " @", 0, false, 6, null): -1 at CoroutineContext.kt:303
+                lastIndex = -1 at CoroutineContext.kt:303
+                lastIndex = 11 at CoroutineContext.kt:304
+                updateThreadContext_u24lambda_u240.append("Test worker"): "Test worker" at CoroutineContext.kt:306
+                updateThreadContext_u24lambda_u240.append(" @"): "Test worker @" at CoroutineContext.kt:307
+                updateThreadContext_u24lambda_u240.append("coroutine"): "Test worker @coroutine" at CoroutineContext.kt:308
+                updateThreadContext_u24lambda_u240.append('#'): "Test worker @coroutine#" at CoroutineContext.kt:309
+                updateThreadContext_u24lambda_u240.append(1): "Test worker @coroutine#1" at CoroutineContext.kt:310
+                "Test worker @coroutine#1".toString(): "Test worker @coroutine#1" at CoroutineContext.kt:305
+                currentThread.setName("Test worker @coroutine#1") at CoroutineContext.kt:305
+              context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                Job.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                  CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+              DebugKt.getASSERTIONS_ENABLED(): true at DispatchedContinuation.kt:180
+              DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:180
+              DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:181
+              _state = Symbol@1 at DispatchedContinuation.kt:181
+              ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+              Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+              isActive(): true at AbstractCoroutine.kt:64
+                getState(): Empty@1 at JobSupport.kt:175
+                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                state.isActive(): true at JobSupport.kt:176
+              ResultKt.throwOnFailure(Unit) at DelayJvmTest.kt:14
+              Executors.newFixedThreadPool(1, DelayJvmTest$testDelayInArbitraryContext$1$$Lambda@1): ThreadPoolExecutor@1 at DelayJvmTest.kt:16
+              BuildersKt.async$default(BlockingCoroutine@1, DelayJvmTest.CustomInterceptor@1, null, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1, 2, null): DeferredCoroutine@1 at DelayJvmTest.kt:20
+                BuildersKt__Builders_commonKt.async$default(BlockingCoroutine@1, DelayJvmTest.CustomInterceptor@1, null, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1, 2, null): DeferredCoroutine@1 at :1
+                  BuildersKt.async(BlockingCoroutine@1, DelayJvmTest.CustomInterceptor@1, CoroutineStart.DEFAULT, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1): DeferredCoroutine@1 at Builders.common.kt:79
+                    BuildersKt__Builders_commonKt.async(BlockingCoroutine@1, DelayJvmTest.CustomInterceptor@1, CoroutineStart.DEFAULT, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1): DeferredCoroutine@1 at :1
+                      CoroutineContextKt.newCoroutineContext(BlockingCoroutine@1, DelayJvmTest.CustomInterceptor@1): CombinedContext@1 at Builders.common.kt:84
+                        newCoroutineContext.getCoroutineContext(): CombinedContext@1 at CoroutineContext.kt:15
+                        CoroutineContextKt.foldCopies(CombinedContext@1, DelayJvmTest.CustomInterceptor@1, true): CombinedContext@1 at CoroutineContext.kt:15
+                          CoroutineContextKt.hasCopyableElements(CombinedContext@1): false at CoroutineContext.kt:50
+                            hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+                          CoroutineContextKt.hasCopyableElements(DelayJvmTest.CustomInterceptor@1): false at CoroutineContext.kt:51
+                            hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+                          originalContext.plus(DelayJvmTest.CustomInterceptor@1): CombinedContext@1 at CoroutineContext.kt:55
+                            ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineDispatcher.kt:60
+                            Job.DefaultImpls.get(BlockingCoroutine@1, ContinuationInterceptor.Key@1): null at JobSupport.kt:22
+                              CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, ContinuationInterceptor.Key@1): null at Job.kt:118
+                        DebugKt.getDEBUG(): true at CoroutineContext.kt:16
+                        DebugKt.getCOROUTINE_ID(): AtomicLong@1 at CoroutineContext.kt:16
+                        AtomicLong@1.incrementAndGet(): 2 at CoroutineContext.kt:16
+                        combined.plus(CoroutineId@1): CombinedContext@1 at CoroutineContext.kt:16
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, CoroutineId.Key@1): null at DelayJvmTest.kt:55
+                          Job.DefaultImpls.get(BlockingCoroutine@1, CoroutineId.Key@1): null at JobSupport.kt:22
+                            CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, CoroutineId.Key@1): null at Job.kt:118
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                        Dispatchers.getDefault(): DefaultScheduler@1 at CoroutineContext.kt:17
+                        combined.get(ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at CoroutineContext.kt:17
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                      start.isLazy(): false at Builders.common.kt:85
+                      ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, Job.Key@1): null at DelayJvmTest.kt:55
+                      Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                        CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                      DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:142
+                      getParentHandle(): null at JobSupport.kt:142
+                        JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): null at JobSupport.kt:129
+                      parent.start(): false at JobSupport.kt:147
+                        getState(): Empty@1 at JobSupport.kt:170
+                          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                        startInternal(Empty@1): 0 at JobSupport.kt:378
+                          state.isActive(): true at JobSupport.kt:392
+                      parent.attachChild(DeferredCoroutine@1): ChildHandleNode@1 at JobSupport.kt:148
+                        it.setJob(BlockingCoroutine@1) at JobSupport.kt:1022
+                          job = BlockingCoroutine@1 at JobSupport.kt:1464
+                        getState(): Empty@1 at JobSupport.kt:170
+                          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                        state.isActive(): true at JobSupport.kt:539
+                        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:541
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, ChildHandleNode@1): true at JobSupport.kt:541
+                      setParentHandle(ChildHandleNode@1) at JobSupport.kt:149
+                        JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(DeferredCoroutine@1, ChildHandleNode@1) at JobSupport.kt:130
+                      isCompleted(): false at JobSupport.kt:151
+                        getState(): Empty@1 at JobSupport.kt:179
+                          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): Empty@1 at JobSupport.kt:163
+                      Job.DefaultImpls.fold(DeferredCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at JobSupport.kt:22
+                        CoroutineContext.Element.DefaultImpls.fold(DeferredCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at Job.kt:118
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, Job.Key@1): null at DelayJvmTest.kt:55
+                          Job.DefaultImpls.minusKey(BlockingCoroutine@1, Job.Key@1): EmptyCoroutineContext@1 at JobSupport.kt:22
+                            CoroutineContext.Element.DefaultImpls.minusKey(BlockingCoroutine@1, Job.Key@1): EmptyCoroutineContext@1 at Job.kt:118
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                      coroutine.start(CoroutineStart.DEFAULT, DeferredCoroutine@1, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1) at Builders.common.kt:88
+                        start.invoke(DelayJvmTest$testDelayInArbitraryContext$1$c$1@1, DeferredCoroutine@1, DeferredCoroutine@1) at AbstractCoroutine.kt:134
+                          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+                          resumeCancellableWith.resumeWith(Unit) at DispatchedContinuation.kt:279
+                            pool.execute(DelayJvmTest.Wrapper$$Lambda@1) at DelayJvmTest.kt:65
+                              thread. = Thread@1 at DelayJvmTest.kt:17
+              Boxing.boxInt(42): 42 at DelayJvmTest.kt:26
+              L$0 = ThreadPoolExecutor@1 at DelayJvmTest.kt:26
+              L$1 = 42 at DelayJvmTest.kt:26
+              label = 1 at DelayJvmTest.kt:26
+              c.await(DelayJvmTest$testDelayInArbitraryContext$1@1): 42 at DelayJvmTest.kt:26
+                DeferredCoroutine.await$suspendImpl(DeferredCoroutine@1, DelayJvmTest$testDelayInArbitraryContext$1@1): 42 at Builders.common.kt:0
+                  awaitInternal(DelayJvmTest$testDelayInArbitraryContext$1@1): 42 at Builders.common.kt:99
+                    getState(): Empty@1 at JobSupport.kt:1323
+                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): Empty@1 at JobSupport.kt:163
+                    startInternal(Empty@1): 0 at JobSupport.kt:1332
+                      state.isActive(): true at JobSupport.kt:392
+                    awaitSuspend(DelayJvmTest$testDelayInArbitraryContext$1@1): 42 at JobSupport.kt:1334
+                      continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                      cont.initCancellability() at JobSupport.kt:1345
+                        installParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:126
+                          getContext(): CombinedContext@1 at CancellableContinuationImpl.kt:340
+                          CombinedContext@1.get(Job.Key@1): BlockingCoroutine@1 at CancellableContinuationImpl.kt:340
+                            ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                            Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                              CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                          JobKt.invokeOnCompletion$default(BlockingCoroutine@1, false, ChildContinuation@1, 1, null): ChildContinuation@1 at CancellableContinuationImpl.kt:342
+                            JobKt__JobKt.invokeOnCompletion$default(BlockingCoroutine@1, false, ChildContinuation@1, 1, null): ChildContinuation@1 at :1
+                              JobKt.invokeOnCompletion(BlockingCoroutine@1, true, ChildContinuation@1): ChildContinuation@1 at Job.kt:366
+                                JobKt__JobKt.invokeOnCompletion(BlockingCoroutine@1, true, ChildContinuation@1): ChildContinuation@1 at :1
+                                  invokeOnCompletion.invokeOnCompletionInternal(true, ChildContinuation@1): ChildContinuation@1 at Job.kt:370
+                                    node.setJob(BlockingCoroutine@1) at JobSupport.kt:465
+                                      job = BlockingCoroutine@1 at JobSupport.kt:1464
+                                    getState(): Empty@1 at JobSupport.kt:170
+                                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                                    state.isActive(): true at JobSupport.kt:539
+                                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:541
+                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, ChildContinuation@1): true at JobSupport.kt:541
+                          CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:342
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(JobSupport.AwaitContinuation@1, null, ChildContinuation@1): true at CancellableContinuationImpl.kt:343
+                        isCompleted(): false at CancellableContinuationImpl.kt:131
+                          getState(): Active@1 at CancellableContinuationImpl.kt:109
+                            CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(JobSupport.AwaitContinuation@1): Active@1 at CancellableContinuationImpl.kt:105
+                      JobKt.invokeOnCompletion$default(DeferredCoroutine@1, false, ResumeAwaitOnCompletion@1, 1, null): NonDisposableHandle@1 at JobSupport.kt:1346
+                        JobKt__JobKt.invokeOnCompletion$default(DeferredCoroutine@1, false, ResumeAwaitOnCompletion@1, 1, null): NonDisposableHandle@1 at :1
+                          JobKt.invokeOnCompletion(DeferredCoroutine@1, true, ResumeAwaitOnCompletion@1): NonDisposableHandle@1 at Job.kt:366
+                            JobKt__JobKt.invokeOnCompletion(DeferredCoroutine@1, true, ResumeAwaitOnCompletion@1): NonDisposableHandle@1 at :1
+                              invokeOnCompletion.invokeOnCompletionInternal(true, ResumeAwaitOnCompletion@1): NonDisposableHandle@1 at Job.kt:370
+                                node.setJob(DeferredCoroutine@1) at JobSupport.kt:465
+                                  job = DeferredCoroutine@1 at JobSupport.kt:1464
+                                getState(): 42 at JobSupport.kt:170
+                                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): 42 at JobSupport.kt:163
+                                getState(): 42 at JobSupport.kt:516
+                                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): 42 at JobSupport.kt:163
+                                ResumeAwaitOnCompletion@1.invoke(null) at JobSupport.kt:516
+                                  getJob(): DeferredCoroutine@1 at JobSupport.kt:1549
+                                  DeferredCoroutine@1.getState(): 42 at JobSupport.kt:1549
+                                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): 42 at JobSupport.kt:163
+                                  DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:1550
+                                  JobSupportKt.unboxState(42): 42 at JobSupport.kt:1557
+                                  Result.constructor-impl(42): 42 at JobSupport.kt:1557
+                                  continuation.resumeWith(42) at JobSupport.kt:1557
+                                    CompletionStateKt.toState(42, JobSupport.AwaitContinuation@1): 42 at CancellableContinuationImpl.kt:359
+                                      Result.exceptionOrNull-impl(42): null at CompletionState.kt:11
+                                    JobSupport.AwaitContinuation@1.resumeImpl(42, 1, null) at CancellableContinuationImpl.kt:359
+                                      CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:493
+                                      handler$atomicfu.get(JobSupport.AwaitContinuation@1): Active@1 at CancellableContinuationImpl.kt:493
+                                      resumedState(Active@1, 42, 1, null, null): 42 at CancellableContinuationImpl.kt:501
+                                        DispatchedTaskKt.isCancellableMode(1): true at CancellableContinuationImpl.kt:485
+                                      CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:502
+                                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(JobSupport.AwaitContinuation@1, Active@1, 42): true at CancellableContinuationImpl.kt:502
+                                      detachChildIfNonReusable() at CancellableContinuationImpl.kt:503
+                                        isReusable(): false at CancellableContinuationImpl.kt:562
+                                          DispatchedTaskKt.isReusableMode(1): false at CancellableContinuationImpl.kt:138
+                                        detachChild() at CancellableContinuationImpl.kt:562
+                                          getParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:569
+                                            CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                                            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(JobSupport.AwaitContinuation@1): ChildContinuation@1 at CancellableContinuationImpl.kt:103
+                                          handle.dispose() at CancellableContinuationImpl.kt:570
+                                            getJob(): BlockingCoroutine@1 at JobSupport.kt:1475
+                                            BlockingCoroutine@1.removeNode(ChildContinuation@1) at JobSupport.kt:1475
+                                              getState(): ChildContinuation@1 at JobSupport.kt:170
+                                                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): ChildContinuation@1 at JobSupport.kt:163
+                                              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:626
+                                              JobSupportKt.access$getEMPTY_ACTIVE$p(): Empty@1 at JobSupport.kt:626
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, ChildContinuation@1, Empty@1): true at JobSupport.kt:626
+                                          CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:570
+                                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(JobSupport.AwaitContinuation@1, NonDisposableHandle@1) at CancellableContinuationImpl.kt:571
+                                      dispatchResume(1) at CancellableContinuationImpl.kt:504
+                                        tryResume(): true at CancellableContinuationImpl.kt:468
+                                          CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:279
+                                          handler$atomicfu.get(JobSupport.AwaitContinuation@1): 536870911 at CancellableContinuationImpl.kt:279
+                                          JobSupport.AwaitContinuation@1.getDecision() at CancellableContinuationImpl.kt:281
+                                          CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:282
+                                          JobSupport.AwaitContinuation@1.getIndex() at CancellableContinuationImpl.kt:282
+                                          JobSupport.AwaitContinuation@1.decisionAndIndex() at CancellableContinuationImpl.kt:282
+                                          AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1.compareAndSet(JobSupport.AwaitContinuation@1, 536870911, 1610612735): true at CancellableContinuationImpl.kt:282
+                      CancellableContinuationKt.disposeOnCancellation(JobSupport.AwaitContinuation@1, NonDisposableHandle@1) at JobSupport.kt:1346
+                        CancellableContinuationKt.invokeOnCancellation(JobSupport.AwaitContinuation@1, DisposeOnCancel@1) at CancellableContinuation.kt:492
+                          invokeOnCancellation.invokeOnCancellationInternal(DisposeOnCancel@1) at CancellableContinuation.kt:314
+                            invokeOnCancellationImpl(DisposeOnCancel@1) at CancellableContinuationImpl.kt:398
+                              DebugKt.getASSERTIONS_ENABLED(): true at CancellableContinuationImpl.kt:401
+                              CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:400
+                              handler$atomicfu.get(JobSupport.AwaitContinuation@1): 42 at CancellableContinuationImpl.kt:400
+                              CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:457
+                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(JobSupport.AwaitContinuation@1, 42, CompletedContinuation@1): true at CancellableContinuationImpl.kt:457
+                      cont.getResult(): 42 at JobSupport.kt:1347
+                        isReusable(): false at CancellableContinuationImpl.kt:291
+                          DispatchedTaskKt.isReusableMode(1): false at CancellableContinuationImpl.kt:138
+                        trySuspend(): false at CancellableContinuationImpl.kt:294
+                          CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:269
+                          handler$atomicfu.get(JobSupport.AwaitContinuation@1): 1610612735 at CancellableContinuationImpl.kt:269
+                          JobSupport.AwaitContinuation@1.getDecision() at CancellableContinuationImpl.kt:271
+                        getState(): CompletedContinuation@1 at CancellableContinuationImpl.kt:322
+                          CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(JobSupport.AwaitContinuation@1): CompletedContinuation@1 at CancellableContinuationImpl.kt:105
+                        DispatchedTaskKt.isCancellableMode(1): true at CancellableContinuationImpl.kt:328
+                        getContext(): CombinedContext@1 at CancellableContinuationImpl.kt:329
+                        CombinedContext@1.get(Job.Key@1): BlockingCoroutine@1 at CancellableContinuationImpl.kt:329
+                          ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                          Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                            CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                        job.isActive(): true at CancellableContinuationImpl.kt:330
+                          isActive(): true at AbstractCoroutine.kt:64
+                            getState(): Empty@1 at JobSupport.kt:175
+                              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                            state.isActive(): true at JobSupport.kt:176
+                        getSuccessfulResult(CompletedContinuation@1): 42 at CancellableContinuationImpl.kt:336
+              AssertionsKt.assertEquals$default(42, 42, null, 4, null) at DelayJvmTest.kt:26
+              pool.shutdown() at DelayJvmTest.kt:27
+              ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineDispatcher.kt:60
+              dispatched.release() at CoroutineDispatcher.kt:249
+                awaitReusability() at DispatchedContinuation.kt:83
+                  DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:71
+                  handler$atomicfu.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:71
+                getReusableCancellableContinuation(): null at DispatchedContinuation.kt:84
+                  DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:0
+                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:55
+              CompletionStateKt.toState(Unit): Unit at AbstractCoroutine.kt:99
+                Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+              makeCompletingOnce(Unit): Unit at AbstractCoroutine.kt:99
+                getState(): Empty@1 at JobSupport.kt:170
+                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                tryMakeCompleting(Empty@1, Unit): Unit at JobSupport.kt:859
+                  tryFinalizeSimpleState(Empty@1, Unit): true at JobSupport.kt:887
+                    DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:283
+                    DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:284
+                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:285
+                    JobSupportKt.boxIncomplete(Unit): Unit at JobSupport.kt:285
+                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, Unit): true at JobSupport.kt:285
+                    onCancelling(null) at JobSupport.kt:286
+                    onCompletionInternal(Unit) at JobSupport.kt:287
+                      onCompleted(Unit) at AbstractCoroutine.kt:92
+                    completeStateFinalization(Empty@1, Unit) at JobSupport.kt:288
+                      getParentHandle(): NonDisposableHandle@1 at JobSupport.kt:300
+                        JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): NonDisposableHandle@1 at JobSupport.kt:129
+                      it.dispose() at JobSupport.kt:301
+                      setParentHandle(NonDisposableHandle@1) at JobSupport.kt:302
+                        JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+                      state.getList(): null at JobSupport.kt:316
+                JobSupportKt.access$getCOMPLETING_ALREADY$p(): Symbol@1 at JobSupport.kt:861
+                JobSupportKt.access$getCOMPLETING_RETRY$p(): Symbol@1 at JobSupport.kt:866
+              afterResume(Unit) at AbstractCoroutine.kt:101
+                afterCompletion(Unit) at AbstractCoroutine.kt:113
+                  Thread.currentThread(): Thread@1 at Builders.kt:83
+              restoreThreadContext(CombinedContext@1, "Test worker") at CoroutineContext.kt:289
+                Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                Thread@1.setName("Test worker") at CoroutineContext.kt:316
+            isCompleted(): true at Builders.kt:96
+              getState(): Unit at JobSupport.kt:179
+                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+            BlockingEventLoop@1.decrementUseCount(false) at Builders.kt:101
+              delta(false): 1 at EventLoop.common.kt:105
+              useCount = 0 at EventLoop.common.kt:105
+              DebugKt.getASSERTIONS_ENABLED(): true at EventLoop.common.kt:107
+              shutdown() at EventLoop.common.kt:110
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:104
+            getState(): Unit at Builders.kt:107
+              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+            JobSupportKt.unboxState(Unit): Unit at Builders.kt:107
+# Thread 2 (Thread-3)
+Thread@1.run() at :0
+  cont.resumeWith(Unit) at DelayJvmTest.kt:65
+    ResultKt.throwOnFailure(Unit) at DelayJvmTest.kt:20
+    Thread.currentThread(): Thread@1 at DelayJvmTest.kt:21
+    AssertionsKt.assertEquals$default(Thread@1, Thread@1, null, 4, null) at DelayJvmTest.kt:21
+    label = 1 at DelayJvmTest.kt:22
+    DelayKt.delay(100, DelayJvmTest$testDelayInArbitraryContext$1$c$1@1): CoroutineSingletons.COROUTINE_SUSPENDED at DelayJvmTest.kt:22
+      cont.getContext(): CombinedContext@1 at DelayJvmTest.kt:62
+      cancellable.initCancellability() at CancellableContinuation.kt:433
+        ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, Job.Key@1): null at DelayJvmTest.kt:55
+        Job.DefaultImpls.get(DeferredCoroutine@1, Job.Key@1): DeferredCoroutine@1 at JobSupport.kt:22
+          CoroutineContext.Element.DefaultImpls.get(DeferredCoroutine@1, Job.Key@1): DeferredCoroutine@1 at Job.kt:118
+        node.setJob(DeferredCoroutine@1) at JobSupport.kt:465
+          job = DeferredCoroutine@1 at JobSupport.kt:1464
+        getState(): Empty@1 at JobSupport.kt:170
+          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): Empty@1 at JobSupport.kt:163
+        state.isActive(): true at JobSupport.kt:539
+        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:541
+        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DeferredCoroutine@1, Empty@1, ChildContinuation@1): true at JobSupport.kt:541
+      cont.getContext(): CombinedContext@1 at Delay.kt:126
+      DelayKt.getDelay(CombinedContext@1): DefaultExecutor@1 at Delay.kt:126
+        delay.get(ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at Delay.kt:149
+          ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+        DefaultExecutorKt.getDefaultDelay(): DefaultExecutor@1 at Delay.kt:149
+      DefaultExecutor@1.scheduleResumeAfterDelay(100, CancellableContinuationImpl@1) at Delay.kt:126
+      cancellable.getResult(): CoroutineSingletons.COROUTINE_SUSPENDED at CancellableContinuation.kt:435
+      DebugProbesKt.probeCoroutineSuspended(DelayJvmTest$testDelayInArbitraryContext$1$c$1@1) at CancellableContinuation.kt:426
+  cont.resumeWith(Unit) at DelayJvmTest.kt:65
+    ResultKt.throwOnFailure(Unit) at DelayJvmTest.kt:20
+    Thread.currentThread(): Thread@1 at DelayJvmTest.kt:23
+    AssertionsKt.assertEquals$default(Thread@1, Thread@1, null, 4, null) at DelayJvmTest.kt:23
+    Boxing.boxInt(42): 42 at DelayJvmTest.kt:24
+    ContinuationInterceptor.DefaultImpls.get(DelayJvmTest.CustomInterceptor@1, ContinuationInterceptor.Key@1): DelayJvmTest.CustomInterceptor@1 at DelayJvmTest.kt:55
+    ContinuationInterceptor.DefaultImpls.releaseInterceptedContinuation(DelayJvmTest.CustomInterceptor@1, DelayJvmTest.Wrapper@1) at DelayJvmTest.kt:55
+    CompletionStateKt.toState(42): 42 at AbstractCoroutine.kt:99
+      Result.exceptionOrNull-impl(42): null at CompletionState.kt:8
+    makeCompletingOnce(42): 42 at AbstractCoroutine.kt:99
+      getState(): Empty@1 at JobSupport.kt:170
+        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): Empty@1 at JobSupport.kt:163
+      tryMakeCompleting(Empty@1, 42): 42 at JobSupport.kt:859
+        tryFinalizeSimpleState(Empty@1, 42): true at JobSupport.kt:887
+          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:283
+          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:284
+          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:285
+          JobSupportKt.boxIncomplete(42): 42 at JobSupport.kt:285
+          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DeferredCoroutine@1, Empty@1, 42): true at JobSupport.kt:285
+          onCancelling(null) at JobSupport.kt:286
+          onCompletionInternal(42) at JobSupport.kt:287
+            onCompleted(42) at AbstractCoroutine.kt:92
+          completeStateFinalization(Empty@1, 42) at JobSupport.kt:288
+            getParentHandle(): ChildHandleNode@1 at JobSupport.kt:300
+              JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): ChildHandleNode@1 at JobSupport.kt:129
+            it.dispose() at JobSupport.kt:301
+              getJob(): BlockingCoroutine@1 at JobSupport.kt:1475
+              BlockingCoroutine@1.removeNode(ChildHandleNode@1) at JobSupport.kt:1475
+                getState(): ChildHandleNode@1 at JobSupport.kt:170
+                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): ChildHandleNode@1 at JobSupport.kt:163
+                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:626
+                JobSupportKt.access$getEMPTY_ACTIVE$p(): Empty@1 at JobSupport.kt:626
+                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, ChildHandleNode@1, Empty@1): true at JobSupport.kt:626
+            setParentHandle(NonDisposableHandle@1) at JobSupport.kt:302
+              JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(DeferredCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+            state.getList(): null at JobSupport.kt:316
+      JobSupportKt.access$getCOMPLETING_ALREADY$p(): Symbol@1 at JobSupport.kt:861
+      JobSupportKt.access$getCOMPLETING_RETRY$p(): Symbol@1 at JobSupport.kt:866
+    afterResume(42) at AbstractCoroutine.kt:101
+      afterCompletion(42) at AbstractCoroutine.kt:113
+# Thread 3 (kotlinx.coroutines.DefaultExecutor)
+Thread@1.run(): <unfinished method> at :0
+  CancellableContinuationImpl@1.resumeImpl(Unit, 1, null) at CancellableContinuationImpl.kt:596
+    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:493
+    handler$atomicfu.get(CancellableContinuationImpl@1): DisposeOnCancel@1 at CancellableContinuationImpl.kt:493
+    resumedState(DisposeOnCancel@1, Unit, 1, null, null): CompletedContinuation@1 at CancellableContinuationImpl.kt:501
+      DispatchedTaskKt.isCancellableMode(1): true at CancellableContinuationImpl.kt:485
+    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:502
+    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, DisposeOnCancel@1, CompletedContinuation@1): true at CancellableContinuationImpl.kt:502
+    detachChildIfNonReusable() at CancellableContinuationImpl.kt:503
+      isReusable(): false at CancellableContinuationImpl.kt:562
+        DispatchedTaskKt.isReusableMode(1): false at CancellableContinuationImpl.kt:138
+      detachChild() at CancellableContinuationImpl.kt:562
+        getParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:569
+          CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): ChildContinuation@1 at CancellableContinuationImpl.kt:103
+        handle.dispose() at CancellableContinuationImpl.kt:570
+          getJob(): DeferredCoroutine@1 at JobSupport.kt:1475
+          DeferredCoroutine@1.removeNode(ChildContinuation@1) at JobSupport.kt:1475
+            getState(): ChildContinuation@1 at JobSupport.kt:170
+              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DeferredCoroutine@1): ChildContinuation@1 at JobSupport.kt:163
+            JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:626
+            JobSupportKt.access$getEMPTY_ACTIVE$p(): Empty@1 at JobSupport.kt:626
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DeferredCoroutine@1, ChildContinuation@1, Empty@1): true at JobSupport.kt:626
+        CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:570
+        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(CancellableContinuationImpl@1, NonDisposableHandle@1) at CancellableContinuationImpl.kt:571
+    dispatchResume(1) at CancellableContinuationImpl.kt:504
+      tryResume(): false at CancellableContinuationImpl.kt:468
+        CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:279
+        handler$atomicfu.get(CancellableContinuationImpl@1): 1073741823 at CancellableContinuationImpl.kt:279
+        CancellableContinuationImpl@1.getDecision() at CancellableContinuationImpl.kt:281
+      DispatchedTaskKt.dispatch(CancellableContinuationImpl@1, 1) at CancellableContinuationImpl.kt:470
+        DebugKt.getASSERTIONS_ENABLED(): true at DispatchedTask.kt:137
+        dispatch.getDelegate(): DelayJvmTest.Wrapper@1 at DispatchedTask.kt:138
+        DispatchedTaskKt.resume(CancellableContinuationImpl@1, DelayJvmTest.Wrapper@1, false) at DispatchedTask.kt:152
+          resume.takeState(): CompletedContinuation@1 at DispatchedTask.kt:158
+            getState(): CompletedContinuation@1 at CancellableContinuationImpl.kt:165
+              CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): CompletedContinuation@1 at CancellableContinuationImpl.kt:105
+          resume.getExceptionalResult(CompletedContinuation@1): null at DispatchedTask.kt:159
+            getExceptionalResult(CompletedContinuation@1): null at CancellableContinuationImpl.kt:614
+          resume.getSuccessfulResult(CompletedContinuation@1): Unit at DispatchedTask.kt:160
+          Result.constructor-impl(Unit): Unit at DispatchedTask.kt:160
+          delegate.resumeWith(Unit) at DispatchedTask.kt:163
+            pool.execute(DelayJvmTest.Wrapper$$Lambda@1) at DelayJvmTest.kt:65

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.EventLoopsTest_testEventLoopInDefaultExecutor.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.EventLoopsTest_testEventLoopInDefaultExecutor.txt
@@ -1,0 +1,793 @@
+# Thread 1 (Test worker)
+EventLoopsTest.testEventLoopInDefaultExecutor() at :0
+  TestBase.runTest$default(EventLoopsTest@1, null, null, EventLoopsTest$testEventLoopInDefaultExecutor$1@1, 3, null) at EventLoopsTest.kt:53
+    CollectionsKt.emptyList(): EmptyList@1 at TestBase.kt:200
+    EventLoopsTest@1.runTest(null, EmptyList@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1) at TestBase.kt:117
+      .CoroutineExceptionHandler() at TestBase.kt:125
+      BuildersKt.runBlocking(TestBase$runTest$$inlined$CoroutineExceptionHandler$1@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1): Unit at TestBase.kt:125
+        BuildersKt__BuildersKt.runBlocking(TestBase$runTest$$inlined$CoroutineExceptionHandler$1@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1): Unit at :1
+          Thread.currentThread(): Thread@1 at Builders.kt:53
+          context.get(ContinuationInterceptor.Key@1): null at Builders.kt:54
+          ThreadLocalEventLoop.INSTANCE.getEventLoop(): BlockingEventLoop@1 at Builders.kt:59
+          eventLoop = BlockingEventLoop@1 at Builders.kt:59
+          context.plus(BlockingEventLoop@1): CombinedContext@1 at Builders.kt:60
+          CoroutineContextKt.newCoroutineContext(GlobalScope@1, CombinedContext@1): CombinedContext@1 at Builders.kt:60
+            newCoroutineContext.getCoroutineContext(): EmptyCoroutineContext@1 at CoroutineContext.kt:15
+            CoroutineContextKt.foldCopies(EmptyCoroutineContext@1, CombinedContext@1, true): CombinedContext@1 at CoroutineContext.kt:15
+              CoroutineContextKt.hasCopyableElements(EmptyCoroutineContext@1): false at CoroutineContext.kt:50
+                hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+              CoroutineContextKt.hasCopyableElements(CombinedContext@1): false at CoroutineContext.kt:51
+                hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+              originalContext.plus(CombinedContext@1): CombinedContext@1 at CoroutineContext.kt:55
+            DebugKt.getDEBUG(): true at CoroutineContext.kt:16
+            DebugKt.getCOROUTINE_ID(): AtomicLong@1 at CoroutineContext.kt:16
+            AtomicLong@1.incrementAndGet(): 1 at CoroutineContext.kt:16
+            combined.plus(CoroutineId@1): CombinedContext@1 at CoroutineContext.kt:16
+            Dispatchers.getDefault(): DefaultScheduler@1 at CoroutineContext.kt:17
+            combined.get(ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineContext.kt:17
+          newContext = CombinedContext@1 at Builders.kt:60
+          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:142
+          getParentHandle(): null at JobSupport.kt:142
+            JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): null at JobSupport.kt:129
+          setParentHandle(NonDisposableHandle@1) at JobSupport.kt:144
+            JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+          Job.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at JobSupport.kt:22
+            CoroutineContext.Element.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at Job.kt:118
+          coroutine.start(CoroutineStart.DEFAULT, BlockingCoroutine@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1) at Builders.kt:69
+            start.invoke(EventLoopsTest$testEventLoopInDefaultExecutor$1@1, BlockingCoroutine@1, BlockingCoroutine@1) at AbstractCoroutine.kt:134
+              continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+              DispatchedContinuation@1.resumeCancellableWith() at DispatchedContinuation.kt:278
+                CompletionStateKt.toState(Unit): Unit at DispatchedContinuation.kt:207
+                  Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                getContext(): CombinedContext@1 at DispatchedContinuation.kt:208
+                  continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                DispatchedContinuationKt.safeIsDispatchNeeded(BlockingEventLoop@1, CombinedContext@1): true at DispatchedContinuation.kt:208
+                  safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): true at DispatchedContinuation.kt:262
+                _state = Unit at DispatchedContinuation.kt:209
+                resumeMode = 1 at DispatchedContinuation.kt:210
+                getContext(): CombinedContext@1 at DispatchedContinuation.kt:211
+                  continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                DispatchedContinuationKt.safeDispatch(BlockingEventLoop@1, CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:211
+                  safeDispatch.dispatch(CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:254
+          coroutine.joinBlocking(): Unit at Builders.kt:70
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:89
+            BlockingEventLoop@1.incrementUseCount(false) at Builders.kt:91
+              delta(false): 1 at EventLoop.common.kt:100
+              useCount = 1 at EventLoop.common.kt:100
+              shared = true at EventLoop.common.kt:101
+            eventLoop.processNextEvent(): 0 at Builders.kt:94
+              updateThreadContext(CombinedContext@1): "Test worker" at CoroutineContext.kt:289
+                context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                  ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                  Job.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                    CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                currentThread.getName(): "Test worker" at CoroutineContext.kt:302
+                StringsKt.lastIndexOf$default("Test worker", " @", 0, false, 6, null): -1 at CoroutineContext.kt:303
+                lastIndex = -1 at CoroutineContext.kt:303
+                lastIndex = 11 at CoroutineContext.kt:304
+                updateThreadContext_u24lambda_u240.append("Test worker"): "Test worker" at CoroutineContext.kt:306
+                updateThreadContext_u24lambda_u240.append(" @"): "Test worker @" at CoroutineContext.kt:307
+                updateThreadContext_u24lambda_u240.append("coroutine"): "Test worker @coroutine" at CoroutineContext.kt:308
+                updateThreadContext_u24lambda_u240.append('#'): "Test worker @coroutine#" at CoroutineContext.kt:309
+                updateThreadContext_u24lambda_u240.append(1): "Test worker @coroutine#1" at CoroutineContext.kt:310
+                "Test worker @coroutine#1".toString(): "Test worker @coroutine#1" at CoroutineContext.kt:305
+                currentThread.setName("Test worker @coroutine#1") at CoroutineContext.kt:305
+              context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                Job.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                  CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+              DebugKt.getASSERTIONS_ENABLED(): true at DispatchedContinuation.kt:180
+              DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:180
+              DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:181
+              _state = Symbol@1 at DispatchedContinuation.kt:181
+              ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+              Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+              isActive(): true at AbstractCoroutine.kt:64
+                getState(): Empty@1 at JobSupport.kt:175
+                  JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                state.isActive(): true at JobSupport.kt:176
+              ResultKt.throwOnFailure(Unit) at EventLoopsTest.kt:53
+              expect(1) at EventLoopsTest.kt:54
+                orderedExecutionDelegate.expect(1) at TestBase.common.kt:193
+              Dispatchers.getUnconfined(): Unconfined@1 at EventLoopsTest.kt:55
+              label = 1 at EventLoopsTest.kt:55
+              BuildersKt.withContext(Unconfined@1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1): CoroutineSingletons.COROUTINE_SUSPENDED at EventLoopsTest.kt:55
+                BuildersKt__Builders_commonKt.withContext(Unconfined@1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1, EventLoopsTest$testEventLoopInDefaultExecutor$1@1): CoroutineSingletons.COROUTINE_SUSPENDED at :1
+                  uCont.getContext(): CombinedContext@1 at Builders.common.kt:149
+                  CoroutineContextKt.newCoroutineContext(CombinedContext@1, Unconfined@1): CombinedContext@1 at Builders.common.kt:151
+                    CoroutineContextKt.hasCopyableElements(Unconfined@1): false at CoroutineContext.kt:31
+                      hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+                    newCoroutineContext.plus(Unconfined@1): CombinedContext@1 at CoroutineContext.kt:31
+                      ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineDispatcher.kt:60
+                      Job.DefaultImpls.get(BlockingCoroutine@1, ContinuationInterceptor.Key@1): null at JobSupport.kt:22
+                        CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, ContinuationInterceptor.Key@1): null at Job.kt:118
+                  JobKt.ensureActive(CombinedContext@1) at Builders.common.kt:153
+                    JobKt__JobKt.ensureActive(CombinedContext@1) at :1
+                      ensureActive.get(Job.Key@1): BlockingCoroutine@1 at Job.kt:603
+                        ContinuationInterceptor.DefaultImpls.get(Unconfined@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                        Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                          CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                      JobKt.ensureActive(BlockingCoroutine@1) at Job.kt:603
+                        JobKt__JobKt.ensureActive(BlockingCoroutine@1) at :1
+                          ensureActive.isActive(): true at Job.kt:585
+                            isActive(): true at AbstractCoroutine.kt:64
+                              getState(): Empty@1 at JobSupport.kt:175
+                                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                              state.isActive(): true at JobSupport.kt:176
+                  newContext.get(ContinuationInterceptor.Key@1): Unconfined@1 at Builders.common.kt:161
+                    ContinuationInterceptor.DefaultImpls.get(Unconfined@1, ContinuationInterceptor.Key@1): Unconfined@1 at CoroutineDispatcher.kt:60
+                  oldContext.get(ContinuationInterceptor.Key@1): BlockingEventLoop@1 at Builders.common.kt:161
+                    ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineDispatcher.kt:60
+                  ContinuationInterceptor.DefaultImpls.get(Unconfined@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                  Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                    CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                  DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:142
+                  getParentHandle(): null at JobSupport.kt:142
+                    JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): null at JobSupport.kt:129
+                  parent.start(): false at JobSupport.kt:147
+                    getState(): Empty@1 at JobSupport.kt:170
+                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                    startInternal(Empty@1): 0 at JobSupport.kt:378
+                      state.isActive(): true at JobSupport.kt:392
+                  parent.attachChild(DispatchedCoroutine@1): ChildHandleNode@1 at JobSupport.kt:148
+                    it.setJob(BlockingCoroutine@1) at JobSupport.kt:1022
+                      job = BlockingCoroutine@1 at JobSupport.kt:1464
+                    getState(): Empty@1 at JobSupport.kt:170
+                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                    state.isActive(): true at JobSupport.kt:539
+                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:541
+                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, ChildHandleNode@1): true at JobSupport.kt:541
+                  setParentHandle(ChildHandleNode@1) at JobSupport.kt:149
+                    JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(DispatchedCoroutine@1, ChildHandleNode@1) at JobSupport.kt:130
+                  isCompleted(): false at JobSupport.kt:151
+                    getState(): Empty@1 at JobSupport.kt:179
+                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): Empty@1 at JobSupport.kt:163
+                  Job.DefaultImpls.fold(DispatchedCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at JobSupport.kt:22
+                    CoroutineContext.Element.DefaultImpls.fold(DispatchedCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at Job.kt:118
+                      ContinuationInterceptor.DefaultImpls.get(Unconfined@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                      Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                        CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                      ContinuationInterceptor.DefaultImpls.get(Unconfined@1, ContinuationInterceptor.Key@1): Unconfined@1 at CoroutineDispatcher.kt:60
+                      ContinuationInterceptor.DefaultImpls.get(Unconfined@1, ContinuationInterceptor.Key@1): Unconfined@1 at CoroutineDispatcher.kt:60
+                  CancellableKt.startCoroutineCancellable(EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1, DispatchedCoroutine@1, DispatchedCoroutine@1) at Builders.common.kt:170
+                    .runSafely() at Cancellable.kt:25
+                      .runSafely$Lambda() at Cancellable.kt:46
+                        Result.constructor-impl(Unit): Unit at Cancellable.kt:26
+                        DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation@1, Unit) at Cancellable.kt:26
+                          DispatchedContinuation@1.resumeCancellableWith() at DispatchedContinuation.kt:278
+                            CompletionStateKt.toState(Unit): Unit at DispatchedContinuation.kt:207
+                              Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                            getContext(): CombinedContext@1 at DispatchedContinuation.kt:208
+                              continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                            DispatchedContinuationKt.safeIsDispatchNeeded(Unconfined@1, CombinedContext@1): false at DispatchedContinuation.kt:208
+                              safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): false at DispatchedContinuation.kt:262
+                            .executeUnconfined() at DispatchedContinuation.kt:293
+                              DebugKt.getASSERTIONS_ENABLED(): true at DispatchedContinuation.kt:297
+                              ThreadLocalEventLoop.INSTANCE.getEventLoop(): BlockingEventLoop@1 at DispatchedContinuation.kt:298
+                              eventLoop$iv.isUnconfinedLoopActive(): false at DispatchedContinuation.kt:301
+                                delta(true): 4294967296 at EventLoop.common.kt:90
+                              DispatchedContinuation@1.runUnconfinedEventLoop() at DispatchedContinuation.kt:309
+                                eventLoop$iv.incrementUseCount(true) at DispatchedTask.kt:184
+                                  delta(true): 4294967296 at EventLoop.common.kt:100
+                                  useCount = 4294967297 at EventLoop.common.kt:100
+                                .resumeCancelled() at DispatchedContinuation.kt:214
+                                  getContext(): CombinedContext@1 at DispatchedContinuation.kt:224
+                                    continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                                  CombinedContext@1.get(Job.Key@1): DispatchedCoroutine@1 at DispatchedContinuation.kt:224
+                                    ContinuationInterceptor.DefaultImpls.get(Unconfined@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                                    Job.DefaultImpls.get(DispatchedCoroutine@1, Job.Key@1): DispatchedCoroutine@1 at JobSupport.kt:22
+                                      CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, Job.Key@1): DispatchedCoroutine@1 at Job.kt:118
+                                  job$iv.isActive(): true at DispatchedContinuation.kt:225
+                                    isActive(): true at AbstractCoroutine.kt:64
+                                      getState(): Empty@1 at JobSupport.kt:175
+                                        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): Empty@1 at JobSupport.kt:163
+                                      state.isActive(): true at JobSupport.kt:176
+                                .resumeUndispatchedWith() at DispatchedContinuation.kt:215
+                                  .withContinuationContext() at DispatchedContinuation.kt:236
+                                    continuation$iv$iv.getContext(): CombinedContext@1 at CoroutineContext.kt:103
+                                    ThreadContextKt.updateThreadContext(CombinedContext@1, CoroutineId@1): "Test worker @coroutine#1" at CoroutineContext.kt:104
+                                      element.updateThreadContext(CombinedContext@1): "Test worker @coroutine#1" at ThreadContext.kt:74
+                                        updateThreadContext(CombinedContext@1): "Test worker @coroutine#1" at CoroutineContext.kt:289
+                                          context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                                            ContinuationInterceptor.DefaultImpls.get(Unconfined@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                                            Job.DefaultImpls.get(DispatchedCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                                              CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                                          Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                                          currentThread.getName(): "Test worker @coroutine#1" at CoroutineContext.kt:302
+                                          StringsKt.lastIndexOf$default("Test worker @coroutine#1", " @", 0, false, 6, null): 11 at CoroutineContext.kt:303
+                                          lastIndex = 11 at CoroutineContext.kt:303
+                                          updateThreadContext_u24lambda_u240.append("Test worker"): "Test worker" at CoroutineContext.kt:306
+                                          updateThreadContext_u24lambda_u240.append(" @"): "Test worker @" at CoroutineContext.kt:307
+                                          updateThreadContext_u24lambda_u240.append("coroutine"): "Test worker @coroutine" at CoroutineContext.kt:308
+                                          updateThreadContext_u24lambda_u240.append('#'): "Test worker @coroutine#" at CoroutineContext.kt:309
+                                          updateThreadContext_u24lambda_u240.append(1): "Test worker @coroutine#1" at CoroutineContext.kt:310
+                                          "Test worker @coroutine#1".toString(): "Test worker @coroutine#1" at CoroutineContext.kt:305
+                                          currentThread.setName("Test worker @coroutine#1") at CoroutineContext.kt:305
+                                    CoroutineContextKt.updateUndispatchedCompletion(EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1, CombinedContext@1, "Test worker @coroutine#1"): null at CoroutineContext.kt:107
+                                      context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                                        ContinuationInterceptor.DefaultImpls.get(Unconfined@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                                        Job.DefaultImpls.get(DispatchedCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                                          CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+                                    .withContinuationContext$Lambda() at CoroutineContext.kt:112
+                                      continuation.resumeWith(Unit) at DispatchedContinuation.kt:237
+                                        ResultKt.throwOnFailure(Unit) at EventLoopsTest.kt:55
+                                        label = 1 at EventLoopsTest.kt:56
+                                        DelayKt.delay(1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1): CoroutineSingletons.COROUTINE_SUSPENDED at EventLoopsTest.kt:56
+                                          continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                                          cancellable.initCancellability() at CancellableContinuation.kt:433
+                                            installParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:126
+                                              getContext(): CombinedContext@1 at CancellableContinuationImpl.kt:340
+                                              CombinedContext@1.get(Job.Key@1): DispatchedCoroutine@1 at CancellableContinuationImpl.kt:340
+                                                ContinuationInterceptor.DefaultImpls.get(Unconfined@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                                                Job.DefaultImpls.get(DispatchedCoroutine@1, Job.Key@1): DispatchedCoroutine@1 at JobSupport.kt:22
+                                                  CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, Job.Key@1): DispatchedCoroutine@1 at Job.kt:118
+                                              JobKt.invokeOnCompletion$default(DispatchedCoroutine@1, false, ChildContinuation@1, 1, null): ChildContinuation@1 at CancellableContinuationImpl.kt:342
+                                                JobKt__JobKt.invokeOnCompletion$default(DispatchedCoroutine@1, false, ChildContinuation@1, 1, null): ChildContinuation@1 at :1
+                                                  JobKt.invokeOnCompletion(DispatchedCoroutine@1, true, ChildContinuation@1): ChildContinuation@1 at Job.kt:366
+                                                    JobKt__JobKt.invokeOnCompletion(DispatchedCoroutine@1, true, ChildContinuation@1): ChildContinuation@1 at :1
+                                                      invokeOnCompletion.invokeOnCompletionInternal(true, ChildContinuation@1): ChildContinuation@1 at Job.kt:370
+                                                        node.setJob(DispatchedCoroutine@1) at JobSupport.kt:465
+                                                          job = DispatchedCoroutine@1 at JobSupport.kt:1464
+                                                        getState(): Empty@1 at JobSupport.kt:170
+                                                          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): Empty@1 at JobSupport.kt:163
+                                                        state.isActive(): true at JobSupport.kt:539
+                                                        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:541
+                                                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DispatchedCoroutine@1, Empty@1, ChildContinuation@1): true at JobSupport.kt:541
+                                              CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:342
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, null, ChildContinuation@1): true at CancellableContinuationImpl.kt:343
+                                            isCompleted(): false at CancellableContinuationImpl.kt:131
+                                              getState(): Active@1 at CancellableContinuationImpl.kt:109
+                                                CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                                                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): Active@1 at CancellableContinuationImpl.kt:105
+                                          cont.getContext(): CombinedContext@1 at Delay.kt:126
+                                          DelayKt.getDelay(CombinedContext@1): DefaultExecutor@1 at Delay.kt:126
+                                            delay.get(ContinuationInterceptor.Key@1): Unconfined@1 at Delay.kt:149
+                                              ContinuationInterceptor.DefaultImpls.get(Unconfined@1, ContinuationInterceptor.Key@1): Unconfined@1 at CoroutineDispatcher.kt:60
+                                            DefaultExecutorKt.getDefaultDelay(): DefaultExecutor@1 at Delay.kt:149
+                                          DefaultExecutor@1.scheduleResumeAfterDelay(1, CancellableContinuationImpl@1) at Delay.kt:126
+                                            invokeOnCancellationImpl(DisposeOnCancel@1) at CancellableContinuationImpl.kt:398
+                                              DebugKt.getASSERTIONS_ENABLED(): true at CancellableContinuationImpl.kt:401
+                                              CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:400
+                                              handler$atomicfu.get(CancellableContinuationImpl@1): Active@1 at CancellableContinuationImpl.kt:400
+                                              CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:405
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, Active@1, DisposeOnCancel@1): true at CancellableContinuationImpl.kt:405
+                                          cancellable.getResult(): CoroutineSingletons.COROUTINE_SUSPENDED at CancellableContinuation.kt:435
+                                            isReusable(): false at CancellableContinuationImpl.kt:291
+                                              DispatchedTaskKt.isReusableMode(1): false at CancellableContinuationImpl.kt:138
+                                            trySuspend(): true at CancellableContinuationImpl.kt:294
+                                              CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:269
+                                              handler$atomicfu.get(CancellableContinuationImpl@1): 536870911 at CancellableContinuationImpl.kt:269
+                                              CancellableContinuationImpl@1.getDecision() at CancellableContinuationImpl.kt:271
+                                              CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:272
+                                              CancellableContinuationImpl@1.getIndex() at CancellableContinuationImpl.kt:272
+                                              CancellableContinuationImpl@1.decisionAndIndex() at CancellableContinuationImpl.kt:272
+                                              AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, 536870911, 1073741823): true at CancellableContinuationImpl.kt:272
+                                            getParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:304
+                                              CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): ChildContinuation@1 at CancellableContinuationImpl.kt:103
+                                          DebugProbesKt.probeCoroutineSuspended(EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1) at CancellableContinuation.kt:426
+                                    ThreadContextKt.restoreThreadContext(CombinedContext@1, "Test worker @coroutine#1") at CoroutineContext.kt:115
+                                      context.fold(null, ThreadContextKt$$Lambda@1): CoroutineId@1 at ThreadContext.kt:89
+                                      element.restoreThreadContext(CombinedContext@1, "Test worker @coroutine#1") at ThreadContext.kt:90
+                                        restoreThreadContext(CombinedContext@1, "Test worker @coroutine#1") at CoroutineContext.kt:289
+                                          Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                                          Thread@1.setName("Test worker @coroutine#1") at CoroutineContext.kt:316
+                                eventLoop$iv.processUnconfinedEvent(): false at DispatchedTask.kt:189
+                                eventLoop$iv.decrementUseCount(true) at DispatchedTask.kt:198
+                                  delta(true): 4294967296 at EventLoop.common.kt:105
+                                  useCount = 1 at EventLoop.common.kt:105
+                  coroutine.getResult(): CoroutineSingletons.COROUTINE_SUSPENDED at Builders.common.kt:171
+                    trySuspend(): true at Builders.common.kt:260
+                      DispatchedCoroutine.get_decision$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at Builders.common.kt:227
+                      handler$atomicfu.get(DispatchedCoroutine@1): 0 at Builders.common.kt:227
+                      DispatchedCoroutine.get_decision$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at Builders.common.kt:230
+                      AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1.compareAndSet(DispatchedCoroutine@1, 0, 1): true at Builders.common.kt:230
+                  DebugProbesKt.probeCoroutineSuspended(EventLoopsTest$testEventLoopInDefaultExecutor$1@1) at Builders.common.kt:147
+              context.fold(null, ThreadContextKt$$Lambda@1): CoroutineId@1 at ThreadContext.kt:89
+              element.restoreThreadContext(CombinedContext@1, "Test worker") at ThreadContext.kt:90
+                restoreThreadContext(CombinedContext@1, "Test worker") at CoroutineContext.kt:289
+                  Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                  Thread@1.setName("Test worker") at CoroutineContext.kt:316
+            isCompleted(): false at Builders.kt:96
+              getState(): ChildHandleNode@1 at JobSupport.kt:179
+                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): ChildHandleNode@1 at JobSupport.kt:163
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:97
+            LockSupport.parkNanos(BlockingCoroutine@1, 0) at Builders.kt:97
+            Thread.interrupted(): false at Builders.kt:98
+            eventLoop.processNextEvent(): 9223372036854775807 at Builders.kt:94
+            isCompleted(): false at Builders.kt:96
+              getState(): ChildHandleNode@1 at JobSupport.kt:179
+                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): ChildHandleNode@1 at JobSupport.kt:163
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:97
+            LockSupport.parkNanos(BlockingCoroutine@1, 9223372036854775807) at Builders.kt:97
+            Thread.interrupted(): false at Builders.kt:98
+            eventLoop.processNextEvent(): 0 at Builders.kt:94
+              DebugKt.getASSERTIONS_ENABLED(): true at DispatchedTask.kt:78
+              getDelegate(): DispatchedContinuation@1 at DispatchedTask.kt:80
+              .withContinuationContext() at DispatchedTask.kt:82
+                continuation.getContext(): CombinedContext@1 at CoroutineContext.kt:103
+                ThreadContextKt.updateThreadContext(CombinedContext@1, CoroutineId@1): "Test worker" at CoroutineContext.kt:104
+                  element.updateThreadContext(CombinedContext@1): "Test worker" at ThreadContext.kt:74
+                    updateThreadContext(CombinedContext@1): "Test worker" at CoroutineContext.kt:289
+                      context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                        ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                        Job.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                          CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                      Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                      currentThread.getName(): "Test worker" at CoroutineContext.kt:302
+                      StringsKt.lastIndexOf$default("Test worker", " @", 0, false, 6, null): -1 at CoroutineContext.kt:303
+                      lastIndex = -1 at CoroutineContext.kt:303
+                      lastIndex = 11 at CoroutineContext.kt:304
+                      updateThreadContext_u24lambda_u240.append("Test worker"): "Test worker" at CoroutineContext.kt:306
+                      updateThreadContext_u24lambda_u240.append(" @"): "Test worker @" at CoroutineContext.kt:307
+                      updateThreadContext_u24lambda_u240.append("coroutine"): "Test worker @coroutine" at CoroutineContext.kt:308
+                      updateThreadContext_u24lambda_u240.append('#'): "Test worker @coroutine#" at CoroutineContext.kt:309
+                      updateThreadContext_u24lambda_u240.append(1): "Test worker @coroutine#1" at CoroutineContext.kt:310
+                      "Test worker @coroutine#1".toString(): "Test worker @coroutine#1" at CoroutineContext.kt:305
+                      currentThread.setName("Test worker @coroutine#1") at CoroutineContext.kt:305
+                CoroutineContextKt.updateUndispatchedCompletion(EventLoopsTest$testEventLoopInDefaultExecutor$1@1, CombinedContext@1, "Test worker"): null at CoroutineContext.kt:107
+                  context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                    ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                    Job.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                      CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+                .withContinuationContext$Lambda() at CoroutineContext.kt:112
+                  continuation.getContext(): CombinedContext@1 at DispatchedTask.kt:83
+                  takeState(): Unit at DispatchedTask.kt:84
+                    DebugKt.getASSERTIONS_ENABLED(): true at DispatchedContinuation.kt:180
+                    DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:180
+                    DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:181
+                    _state = Symbol@1 at DispatchedContinuation.kt:181
+                  getExceptionalResult(Unit): null at DispatchedTask.kt:85
+                  DispatchedTaskKt.isCancellableMode(1): true at DispatchedTask.kt:91
+                  context.get(Job.Key@1): BlockingCoroutine@1 at DispatchedTask.kt:91
+                    ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                    Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                      CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                  job.isActive(): true at DispatchedTask.kt:92
+                    isActive(): true at AbstractCoroutine.kt:64
+                      getState(): Empty@1 at JobSupport.kt:175
+                        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                      state.isActive(): true at JobSupport.kt:176
+                  getSuccessfulResult(Unit): Unit at DispatchedTask.kt:100
+                  Result.constructor-impl(Unit): Unit at DispatchedTask.kt:100
+                  continuation.resumeWith(Unit) at DispatchedTask.kt:100
+                    ResultKt.throwOnFailure(Unit) at EventLoopsTest.kt:53
+                    finish(6) at EventLoopsTest.kt:68
+                      orderedExecutionDelegate.finish(6) at TestBase.common.kt:195
+                    ContinuationInterceptor.DefaultImpls.get(BlockingEventLoop@1, ContinuationInterceptor.Key@1): BlockingEventLoop@1 at CoroutineDispatcher.kt:60
+                    dispatched.release() at CoroutineDispatcher.kt:249
+                      awaitReusability() at DispatchedContinuation.kt:83
+                        DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:71
+                        handler$atomicfu.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:71
+                      getReusableCancellableContinuation(): null at DispatchedContinuation.kt:84
+                        DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:55
+                    CompletionStateKt.toState(Unit): Unit at AbstractCoroutine.kt:99
+                      Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                    makeCompletingOnce(Unit): Unit at AbstractCoroutine.kt:99
+                      getState(): Empty@1 at JobSupport.kt:170
+                        JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                      tryMakeCompleting(Empty@1, Unit): Unit at JobSupport.kt:859
+                        tryFinalizeSimpleState(Empty@1, Unit): true at JobSupport.kt:887
+                          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:283
+                          DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:284
+                          JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:285
+                          JobSupportKt.boxIncomplete(Unit): Unit at JobSupport.kt:285
+                          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, Unit): true at JobSupport.kt:285
+                          onCancelling(null) at JobSupport.kt:286
+                          onCompletionInternal(Unit) at JobSupport.kt:287
+                            onCompleted(Unit) at AbstractCoroutine.kt:92
+                          completeStateFinalization(Empty@1, Unit) at JobSupport.kt:288
+                            getParentHandle(): NonDisposableHandle@1 at JobSupport.kt:300
+                              JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): NonDisposableHandle@1 at JobSupport.kt:129
+                            it.dispose() at JobSupport.kt:301
+                            setParentHandle(NonDisposableHandle@1) at JobSupport.kt:302
+                              JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+                            state.getList(): null at JobSupport.kt:316
+                      JobSupportKt.access$getCOMPLETING_ALREADY$p(): Symbol@1 at JobSupport.kt:861
+                      JobSupportKt.access$getCOMPLETING_RETRY$p(): Symbol@1 at JobSupport.kt:866
+                    afterResume(Unit) at AbstractCoroutine.kt:101
+                      afterCompletion(Unit) at AbstractCoroutine.kt:113
+                        Thread.currentThread(): Thread@1 at Builders.kt:83
+                ThreadContextKt.restoreThreadContext(CombinedContext@1, "Test worker") at CoroutineContext.kt:115
+                  context.fold(null, ThreadContextKt$$Lambda@1): CoroutineId@1 at ThreadContext.kt:89
+                  element.restoreThreadContext(CombinedContext@1, "Test worker") at ThreadContext.kt:90
+                    restoreThreadContext(CombinedContext@1, "Test worker") at CoroutineContext.kt:289
+                      Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                      Thread@1.setName("Test worker") at CoroutineContext.kt:316
+            isCompleted(): true at Builders.kt:96
+              getState(): Unit at JobSupport.kt:179
+                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+            BlockingEventLoop@1.decrementUseCount(false) at Builders.kt:101
+              delta(false): 1 at EventLoop.common.kt:105
+              useCount = 0 at EventLoop.common.kt:105
+              DebugKt.getASSERTIONS_ENABLED(): true at EventLoop.common.kt:107
+              shutdown() at EventLoop.common.kt:110
+            AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:104
+            getState(): Unit at Builders.kt:107
+              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+            JobSupportKt.unboxState(Unit): Unit at Builders.kt:107
+      unhandled.size(): 0 at TestBase.kt:146
+# Thread 2 (kotlinx.coroutines.DefaultExecutor)
+Thread@1.run(): <unfinished method> at :0
+  CancellableContinuationImpl@1.resumeImpl(Unit, 1, null) at CancellableContinuationImpl.kt:596
+    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:493
+    handler$atomicfu.get(CancellableContinuationImpl@1): Active@1 at CancellableContinuationImpl.kt:493
+    resumedState(Active@1, Unit, 1, null, null): Unit at CancellableContinuationImpl.kt:501
+      DispatchedTaskKt.isCancellableMode(1): true at CancellableContinuationImpl.kt:485
+    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:502
+    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, Active@1, Unit): false at CancellableContinuationImpl.kt:502
+    handler$atomicfu.get(CancellableContinuationImpl@1): DisposeOnCancel@1 at CancellableContinuationImpl.kt:493
+    resumedState(DisposeOnCancel@1, Unit, 1, null, null): CompletedContinuation@1 at CancellableContinuationImpl.kt:501
+      DispatchedTaskKt.isCancellableMode(1): true at CancellableContinuationImpl.kt:485
+    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:502
+    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(CancellableContinuationImpl@1, DisposeOnCancel@1, CompletedContinuation@1): true at CancellableContinuationImpl.kt:502
+    detachChildIfNonReusable() at CancellableContinuationImpl.kt:503
+      isReusable(): false at CancellableContinuationImpl.kt:562
+        DispatchedTaskKt.isReusableMode(1): false at CancellableContinuationImpl.kt:138
+      detachChild() at CancellableContinuationImpl.kt:562
+        getParentHandle(): ChildContinuation@1 at CancellableContinuationImpl.kt:569
+          CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+          AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): ChildContinuation@1 at CancellableContinuationImpl.kt:103
+        handle.dispose() at CancellableContinuationImpl.kt:570
+          getJob(): DispatchedCoroutine@1 at JobSupport.kt:1475
+          DispatchedCoroutine@1.removeNode(ChildContinuation@1) at JobSupport.kt:1475
+            getState(): ChildContinuation@1 at JobSupport.kt:170
+              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): ChildContinuation@1 at JobSupport.kt:163
+            JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:626
+            JobSupportKt.access$getEMPTY_ACTIVE$p(): Empty@1 at JobSupport.kt:626
+            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DispatchedCoroutine@1, ChildContinuation@1, Empty@1): true at JobSupport.kt:626
+        CancellableContinuationImpl.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:570
+        AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(CancellableContinuationImpl@1, NonDisposableHandle@1) at CancellableContinuationImpl.kt:571
+    dispatchResume(1) at CancellableContinuationImpl.kt:504
+      tryResume(): false at CancellableContinuationImpl.kt:468
+        CancellableContinuationImpl.get_decisionAndIndex$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:279
+        handler$atomicfu.get(CancellableContinuationImpl@1): 1073741823 at CancellableContinuationImpl.kt:279
+        CancellableContinuationImpl@1.getDecision() at CancellableContinuationImpl.kt:281
+      DispatchedTaskKt.dispatch(CancellableContinuationImpl@1, 1) at CancellableContinuationImpl.kt:470
+        DebugKt.getASSERTIONS_ENABLED(): true at DispatchedTask.kt:137
+        dispatch.getDelegate(): DispatchedContinuation@1 at DispatchedTask.kt:138
+        DispatchedTaskKt.isCancellableMode(1): true at DispatchedTask.kt:140
+        DispatchedTaskKt.isCancellableMode(1): true at DispatchedTask.kt:140
+        delegate.getContext(): CombinedContext@1 at DispatchedTask.kt:143
+          continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+        DispatchedContinuationKt.safeIsDispatchNeeded(Unconfined@1, CombinedContext@1): false at DispatchedTask.kt:144
+          safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): false at DispatchedContinuation.kt:262
+        DispatchedTaskKt.resumeUnconfined(CancellableContinuationImpl@1) at DispatchedTask.kt:147
+          ThreadLocalEventLoop.INSTANCE.getEventLoop(): DefaultExecutor@1 at DispatchedTask.kt:168
+          eventLoop.isUnconfinedLoopActive(): false at DispatchedTask.kt:169
+            delta(true): 4294967296 at EventLoop.common.kt:90
+          CancellableContinuationImpl@1.runUnconfinedEventLoop() at DispatchedTask.kt:174
+            eventLoop.incrementUseCount(true) at DispatchedTask.kt:184
+              delta(true): 4294967296 at EventLoop.common.kt:100
+              useCount = 4294967297 at EventLoop.common.kt:100
+            .runUnconfinedEventLoop$Lambda() at DispatchedTask.kt:186
+              resumeUnconfined.getDelegate(): DispatchedContinuation@1 at DispatchedTask.kt:175
+              DispatchedTaskKt.resume(CancellableContinuationImpl@1, DispatchedContinuation@1, true) at DispatchedTask.kt:175
+                resume.takeState(): CompletedContinuation@1 at DispatchedTask.kt:158
+                  getState(): CompletedContinuation@1 at CancellableContinuationImpl.kt:165
+                    CancellableContinuationImpl.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at CancellableContinuationImpl.kt:0
+                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(CancellableContinuationImpl@1): CompletedContinuation@1 at CancellableContinuationImpl.kt:105
+                resume.getExceptionalResult(CompletedContinuation@1): null at DispatchedTask.kt:159
+                  getExceptionalResult(CompletedContinuation@1): null at CancellableContinuationImpl.kt:614
+                resume.getSuccessfulResult(CompletedContinuation@1): Unit at DispatchedTask.kt:160
+                Result.constructor-impl(Unit): Unit at DispatchedTask.kt:160
+                DispatchedContinuation@1.resumeUndispatchedWith() at DispatchedTask.kt:162
+                  .withContinuationContext() at DispatchedContinuation.kt:236
+                    continuation$iv.getContext(): CombinedContext@1 at CoroutineContext.kt:103
+                    ThreadContextKt.updateThreadContext(CombinedContext@1, CoroutineId@1): "kotlinx.coroutines.DefaultExecutor" at CoroutineContext.kt:104
+                      element.updateThreadContext(CombinedContext@1): "kotlinx.coroutines.DefaultExecutor" at ThreadContext.kt:74
+                        updateThreadContext(CombinedContext@1): "kotlinx.coroutines.DefaultExecutor" at CoroutineContext.kt:289
+                          context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                            ContinuationInterceptor.DefaultImpls.get(Unconfined@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                            Job.DefaultImpls.get(DispatchedCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                              CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                          Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                          currentThread.getName(): "kotlinx.coroutines.DefaultExecutor" at CoroutineContext.kt:302
+                          StringsKt.lastIndexOf$default("kotlinx.coroutines.DefaultExecutor", " @", 0, false, 6, null): -1 at CoroutineContext.kt:303
+                          lastIndex = -1 at CoroutineContext.kt:303
+                          lastIndex = 34 at CoroutineContext.kt:304
+                          updateThreadContext_u24lambda_u240.append("kotlinx.coroutines.DefaultExecutor"): "kotlinx.coroutines.DefaultExecutor" at CoroutineContext.kt:306
+                          updateThreadContext_u24lambda_u240.append(" @"): "kotlinx.coroutines.DefaultExecutor @" at CoroutineContext.kt:307
+                          updateThreadContext_u24lambda_u240.append("coroutine"): "kotlinx.coroutines.DefaultExecutor @coroutine" at CoroutineContext.kt:308
+                          updateThreadContext_u24lambda_u240.append('#'): "kotlinx.coroutines.DefaultExecutor @coroutine#" at CoroutineContext.kt:309
+                          updateThreadContext_u24lambda_u240.append(1): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at CoroutineContext.kt:310
+                          "kotlinx.coroutines.DefaultExecutor @coroutine#1".toString(): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at CoroutineContext.kt:305
+                          currentThread.setName("kotlinx.coroutines.DefaultExecutor @coroutine#1") at CoroutineContext.kt:305
+                    CoroutineContextKt.updateUndispatchedCompletion(EventLoopsTest$testEventLoopInDefaultExecutor$1$1@1, CombinedContext@1, "kotlinx.coroutines.DefaultExecutor"): null at CoroutineContext.kt:107
+                      context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                        ContinuationInterceptor.DefaultImpls.get(Unconfined@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                        Job.DefaultImpls.get(DispatchedCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                          CoroutineContext.Element.DefaultImpls.get(DispatchedCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+                    .withContinuationContext$Lambda() at CoroutineContext.kt:112
+                      continuation.resumeWith(Unit) at DispatchedContinuation.kt:237
+                        ResultKt.throwOnFailure(Unit) at EventLoopsTest.kt:55
+                        Thread.currentThread(): Thread@1 at EventLoopsTest.kt:57
+                        Thread@1.getName(): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at EventLoopsTest.kt:57
+                        StringsKt.startsWith$default("kotlinx.coroutines.DefaultExecutor @coroutine#1", "kotlinx.coroutines.DefaultExecutor", false, 2, null): true at EventLoopsTest.kt:57
+                        AssertionsKt.assertTrue$default(true, null, 2, null) at EventLoopsTest.kt:57
+                        expect(2) at EventLoopsTest.kt:58
+                          orderedExecutionDelegate.expect(2) at TestBase.common.kt:193
+                        DefaultExecutor.INSTANCE.enqueue(EventLoopsTest$testEventLoopInDefaultExecutor$1$1$$Lambda@1) at EventLoopsTest.kt:60
+                        expect(3) at EventLoopsTest.kt:63
+                          orderedExecutionDelegate.expect(3) at TestBase.common.kt:193
+                        BuildersKt.runBlocking$default(null, EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1, 1, null): Unit at EventLoopsTest.kt:64
+                          BuildersKt__BuildersKt.runBlocking$default(null, EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1, 1, null): Unit at :1
+                            BuildersKt.runBlocking(EmptyCoroutineContext@1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1): Unit at Builders.kt:48
+                              BuildersKt__BuildersKt.runBlocking(EmptyCoroutineContext@1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1): Unit at :1
+                                Thread.currentThread(): Thread@1 at Builders.kt:53
+                                context.get(ContinuationInterceptor.Key@1): null at Builders.kt:54
+                                ThreadLocalEventLoop.INSTANCE.getEventLoop(): DefaultExecutor@1 at Builders.kt:59
+                                eventLoop = DefaultExecutor@1 at Builders.kt:59
+                                context.plus(DefaultExecutor@1): DefaultExecutor@1 at Builders.kt:60
+                                CoroutineContextKt.newCoroutineContext(GlobalScope@1, DefaultExecutor@1): CombinedContext@1 at Builders.kt:60
+                                  newCoroutineContext.getCoroutineContext(): EmptyCoroutineContext@1 at CoroutineContext.kt:15
+                                  CoroutineContextKt.foldCopies(EmptyCoroutineContext@1, DefaultExecutor@1, true): DefaultExecutor@1 at CoroutineContext.kt:15
+                                    CoroutineContextKt.hasCopyableElements(EmptyCoroutineContext@1): false at CoroutineContext.kt:50
+                                      hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+                                    CoroutineContextKt.hasCopyableElements(DefaultExecutor@1): false at CoroutineContext.kt:51
+                                      hasCopyableElements.fold(false, CoroutineContextKt$$Lambda@1): false at CoroutineContext.kt:36
+                                    originalContext.plus(DefaultExecutor@1): DefaultExecutor@1 at CoroutineContext.kt:55
+                                  DebugKt.getDEBUG(): true at CoroutineContext.kt:16
+                                  DebugKt.getCOROUTINE_ID(): AtomicLong@1 at CoroutineContext.kt:16
+                                  AtomicLong@1.incrementAndGet(): 2 at CoroutineContext.kt:16
+                                  combined.plus(CoroutineId@1): CombinedContext@1 at CoroutineContext.kt:16
+                                    ContinuationInterceptor.DefaultImpls.minusKey(DefaultExecutor@1, CoroutineId.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                    ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                    ContinuationInterceptor.DefaultImpls.minusKey(DefaultExecutor@1, ContinuationInterceptor.Key@1): EmptyCoroutineContext@1 at CoroutineDispatcher.kt:60
+                                  Dispatchers.getDefault(): DefaultScheduler@1 at CoroutineContext.kt:17
+                                  combined.get(ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineContext.kt:17
+                                    ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                newContext = CombinedContext@1 at Builders.kt:60
+                                ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                                DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:142
+                                getParentHandle(): null at JobSupport.kt:142
+                                  JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): null at JobSupport.kt:129
+                                setParentHandle(NonDisposableHandle@1) at JobSupport.kt:144
+                                  JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+                                Job.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at JobSupport.kt:22
+                                  CoroutineContext.Element.DefaultImpls.fold(BlockingCoroutine@1, CombinedContext@1, CoroutineContext.DefaultImpls$$Lambda@1): CombinedContext@1 at Job.kt:118
+                                    ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                                    ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                    ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                coroutine.start(CoroutineStart.DEFAULT, BlockingCoroutine@1, EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1) at Builders.kt:69
+                                  start.invoke(EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1, BlockingCoroutine@1, BlockingCoroutine@1) at AbstractCoroutine.kt:134
+                                    .runSafely() at Cancellable.kt:25
+                                      .runSafely$Lambda() at Cancellable.kt:46
+                                        Result.constructor-impl(Unit): Unit at Cancellable.kt:26
+                                        DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation@1, Unit) at Cancellable.kt:26
+                                          DispatchedContinuation@1.resumeCancellableWith() at DispatchedContinuation.kt:278
+                                            CompletionStateKt.toState(Unit): Unit at DispatchedContinuation.kt:207
+                                              Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                                            getContext(): CombinedContext@1 at DispatchedContinuation.kt:208
+                                              continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                                            DispatchedContinuationKt.safeIsDispatchNeeded(DefaultExecutor@1, CombinedContext@1): true at DispatchedContinuation.kt:208
+                                              safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): true at DispatchedContinuation.kt:262
+                                            _state = Unit at DispatchedContinuation.kt:209
+                                            resumeMode = 1 at DispatchedContinuation.kt:210
+                                            getContext(): CombinedContext@1 at DispatchedContinuation.kt:211
+                                              continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                                            DispatchedContinuationKt.safeDispatch(DefaultExecutor@1, CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:211
+                                              safeDispatch.dispatch(CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:254
+                                coroutine.joinBlocking(): Unit at Builders.kt:70
+                                  AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:89
+                                  DefaultExecutor@1.incrementUseCount(false) at Builders.kt:91
+                                    delta(false): 1 at EventLoop.common.kt:100
+                                    useCount = 4294967298 at EventLoop.common.kt:100
+                                    shared = true at EventLoop.common.kt:101
+                                  eventLoop.processNextEvent(): 0 at Builders.kt:94
+                                    expect(4) at EventLoopsTest.kt:61
+                                      orderedExecutionDelegate.expect(4) at TestBase.common.kt:193
+                                  isCompleted(): false at Builders.kt:96
+                                    getState(): Empty@1 at JobSupport.kt:179
+                                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                                  AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:97
+                                  LockSupport.parkNanos(BlockingCoroutine@1, 0) at Builders.kt:97
+                                  Thread.interrupted(): false at Builders.kt:98
+                                  eventLoop.processNextEvent(): 0 at Builders.kt:94
+                                    DebugKt.getASSERTIONS_ENABLED(): true at DispatchedTask.kt:78
+                                    getDelegate(): DispatchedContinuation@1 at DispatchedTask.kt:80
+                                    .withContinuationContext() at DispatchedTask.kt:82
+                                      continuation.getContext(): CombinedContext@1 at CoroutineContext.kt:103
+                                      ThreadContextKt.updateThreadContext(CombinedContext@1, CoroutineId@1): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at CoroutineContext.kt:104
+                                        element.updateThreadContext(CombinedContext@1): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at ThreadContext.kt:74
+                                          updateThreadContext(CombinedContext@1): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at CoroutineContext.kt:289
+                                            context.get(CoroutineName.Key@1): null at CoroutineContext.kt:300
+                                              ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, CoroutineName.Key@1): null at CoroutineDispatcher.kt:60
+                                              Job.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at JobSupport.kt:22
+                                                CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, CoroutineName.Key@1): null at Job.kt:118
+                                            Thread.currentThread(): Thread@1 at CoroutineContext.kt:301
+                                            currentThread.getName(): "kotlinx.coroutines.DefaultExecutor @coroutine#1" at CoroutineContext.kt:302
+                                            StringsKt.lastIndexOf$default("kotlinx.coroutines.DefaultExecutor @coroutine#1", " @", 0, false, 6, null): 34 at CoroutineContext.kt:303
+                                            lastIndex = 34 at CoroutineContext.kt:303
+                                            updateThreadContext_u24lambda_u240.append("kotlinx.coroutines.DefaultExecutor"): "kotlinx.coroutines.DefaultExecutor" at CoroutineContext.kt:306
+                                            updateThreadContext_u24lambda_u240.append(" @"): "kotlinx.coroutines.DefaultExecutor @" at CoroutineContext.kt:307
+                                            updateThreadContext_u24lambda_u240.append("coroutine"): "kotlinx.coroutines.DefaultExecutor @coroutine" at CoroutineContext.kt:308
+                                            updateThreadContext_u24lambda_u240.append('#'): "kotlinx.coroutines.DefaultExecutor @coroutine#" at CoroutineContext.kt:309
+                                            updateThreadContext_u24lambda_u240.append(2): "kotlinx.coroutines.DefaultExecutor @coroutine#2" at CoroutineContext.kt:310
+                                            "kotlinx.coroutines.DefaultExecutor @coroutine#2".toString(): "kotlinx.coroutines.DefaultExecutor @coroutine#2" at CoroutineContext.kt:305
+                                            currentThread.setName("kotlinx.coroutines.DefaultExecutor @coroutine#2") at CoroutineContext.kt:305
+                                      CoroutineContextKt.updateUndispatchedCompletion(EventLoopsTest$testEventLoopInDefaultExecutor$1$1$2@1, CombinedContext@1, "kotlinx.coroutines.DefaultExecutor @coroutine#1"): null at CoroutineContext.kt:107
+                                        context.get(UndispatchedMarker@1): null at CoroutineContext.kt:134
+                                          ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, UndispatchedMarker@1): null at CoroutineDispatcher.kt:60
+                                          Job.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at JobSupport.kt:22
+                                            CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, UndispatchedMarker@1): null at Job.kt:118
+                                      .withContinuationContext$Lambda() at CoroutineContext.kt:112
+                                        continuation.getContext(): CombinedContext@1 at DispatchedTask.kt:83
+                                        takeState(): Unit at DispatchedTask.kt:84
+                                          DebugKt.getASSERTIONS_ENABLED(): true at DispatchedContinuation.kt:180
+                                          DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:180
+                                          DispatchedContinuationKt.access$getUNDEFINED$p(): Symbol@1 at DispatchedContinuation.kt:181
+                                          _state = Symbol@1 at DispatchedContinuation.kt:181
+                                        getExceptionalResult(Unit): null at DispatchedTask.kt:85
+                                        DispatchedTaskKt.isCancellableMode(1): true at DispatchedTask.kt:91
+                                        context.get(Job.Key@1): BlockingCoroutine@1 at DispatchedTask.kt:91
+                                          ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, Job.Key@1): null at CoroutineDispatcher.kt:60
+                                          Job.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at JobSupport.kt:22
+                                            CoroutineContext.Element.DefaultImpls.get(BlockingCoroutine@1, Job.Key@1): BlockingCoroutine@1 at Job.kt:118
+                                        job.isActive(): true at DispatchedTask.kt:92
+                                          isActive(): true at AbstractCoroutine.kt:64
+                                            getState(): Empty@1 at JobSupport.kt:175
+                                              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                                            state.isActive(): true at JobSupport.kt:176
+                                        getSuccessfulResult(Unit): Unit at DispatchedTask.kt:100
+                                        Result.constructor-impl(Unit): Unit at DispatchedTask.kt:100
+                                        continuation.resumeWith(Unit) at DispatchedTask.kt:100
+                                          ResultKt.throwOnFailure(Unit) at EventLoopsTest.kt:64
+                                          expect(5) at EventLoopsTest.kt:65
+                                            orderedExecutionDelegate.expect(5) at TestBase.common.kt:193
+                                          ContinuationInterceptor.DefaultImpls.get(DefaultExecutor@1, ContinuationInterceptor.Key@1): DefaultExecutor@1 at CoroutineDispatcher.kt:60
+                                          dispatched.release() at CoroutineDispatcher.kt:249
+                                            awaitReusability() at DispatchedContinuation.kt:83
+                                              DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:71
+                                              handler$atomicfu.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:71
+                                            getReusableCancellableContinuation(): null at DispatchedContinuation.kt:84
+                                              DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:0
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:55
+                                          CompletionStateKt.toState(Unit): Unit at AbstractCoroutine.kt:99
+                                            Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                                          makeCompletingOnce(Unit): Unit at AbstractCoroutine.kt:99
+                                            getState(): Empty@1 at JobSupport.kt:170
+                                              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Empty@1 at JobSupport.kt:163
+                                            tryMakeCompleting(Empty@1, Unit): Unit at JobSupport.kt:859
+                                              tryFinalizeSimpleState(Empty@1, Unit): true at JobSupport.kt:887
+                                                DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:283
+                                                DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:284
+                                                JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:285
+                                                JobSupportKt.boxIncomplete(Unit): Unit at JobSupport.kt:285
+                                                AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, Empty@1, Unit): true at JobSupport.kt:285
+                                                onCancelling(null) at JobSupport.kt:286
+                                                onCompletionInternal(Unit) at JobSupport.kt:287
+                                                  onCompleted(Unit) at AbstractCoroutine.kt:92
+                                                completeStateFinalization(Empty@1, Unit) at JobSupport.kt:288
+                                                  getParentHandle(): NonDisposableHandle@1 at JobSupport.kt:300
+                                                    JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): NonDisposableHandle@1 at JobSupport.kt:129
+                                                  it.dispose() at JobSupport.kt:301
+                                                  setParentHandle(NonDisposableHandle@1) at JobSupport.kt:302
+                                                    JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(BlockingCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+                                                  state.getList(): null at JobSupport.kt:316
+                                            JobSupportKt.access$getCOMPLETING_ALREADY$p(): Symbol@1 at JobSupport.kt:861
+                                            JobSupportKt.access$getCOMPLETING_RETRY$p(): Symbol@1 at JobSupport.kt:866
+                                          afterResume(Unit) at AbstractCoroutine.kt:101
+                                            afterCompletion(Unit) at AbstractCoroutine.kt:113
+                                              Thread.currentThread(): Thread@1 at Builders.kt:83
+                                      ThreadContextKt.restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor @coroutine#1") at CoroutineContext.kt:115
+                                        context.fold(null, ThreadContextKt$$Lambda@1): CoroutineId@1 at ThreadContext.kt:89
+                                        element.restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor @coroutine#1") at ThreadContext.kt:90
+                                          restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor @coroutine#1") at CoroutineContext.kt:289
+                                            Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                                            Thread@1.setName("kotlinx.coroutines.DefaultExecutor @coroutine#1") at CoroutineContext.kt:316
+                                  isCompleted(): true at Builders.kt:96
+                                    getState(): Unit at JobSupport.kt:179
+                                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+                                  DefaultExecutor@1.decrementUseCount(false) at Builders.kt:101
+                                    delta(false): 1 at EventLoop.common.kt:105
+                                    useCount = 4294967297 at EventLoop.common.kt:105
+                                  AbstractTimeSourceKt.access$getTimeSource$p(): null at Builders.kt:104
+                                  getState(): Unit at Builders.kt:107
+                                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): Unit at JobSupport.kt:163
+                                  JobSupportKt.unboxState(Unit): Unit at Builders.kt:107
+                        ContinuationInterceptor.DefaultImpls.get(Unconfined@1, ContinuationInterceptor.Key@1): Unconfined@1 at CoroutineDispatcher.kt:60
+                        dispatched.release() at CoroutineDispatcher.kt:249
+                          awaitReusability() at DispatchedContinuation.kt:83
+                            DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:71
+                            handler$atomicfu.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:71
+                          getReusableCancellableContinuation(): null at DispatchedContinuation.kt:84
+                            DispatchedContinuation.get_reusableCancellableContinuation$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at DispatchedContinuation.kt:0
+                            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedContinuation@1): null at DispatchedContinuation.kt:55
+                        CompletionStateKt.toState(Unit): Unit at AbstractCoroutine.kt:99
+                          Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                        makeCompletingOnce(Unit): Unit at AbstractCoroutine.kt:99
+                          getState(): Empty@1 at JobSupport.kt:170
+                            JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                            AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): Empty@1 at JobSupport.kt:163
+                          tryMakeCompleting(Empty@1, Unit): Unit at JobSupport.kt:859
+                            tryFinalizeSimpleState(Empty@1, Unit): true at JobSupport.kt:887
+                              DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:283
+                              DebugKt.getASSERTIONS_ENABLED(): true at JobSupport.kt:284
+                              JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:285
+                              JobSupportKt.boxIncomplete(Unit): Unit at JobSupport.kt:285
+                              AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(DispatchedCoroutine@1, Empty@1, Unit): true at JobSupport.kt:285
+                              onCancelling(null) at JobSupport.kt:286
+                              onCompletionInternal(Unit) at JobSupport.kt:287
+                                onCompleted(Unit) at AbstractCoroutine.kt:92
+                              completeStateFinalization(Empty@1, Unit) at JobSupport.kt:288
+                                getParentHandle(): ChildHandleNode@1 at JobSupport.kt:300
+                                  JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(DispatchedCoroutine@1): ChildHandleNode@1 at JobSupport.kt:129
+                                it.dispose() at JobSupport.kt:301
+                                  getJob(): BlockingCoroutine@1 at JobSupport.kt:1475
+                                  BlockingCoroutine@1.removeNode(ChildHandleNode@1) at JobSupport.kt:1475
+                                    getState(): ChildHandleNode@1 at JobSupport.kt:170
+                                      JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                      AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.get(BlockingCoroutine@1): ChildHandleNode@1 at JobSupport.kt:163
+                                    JobSupport.get_state$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:626
+                                    JobSupportKt.access$getEMPTY_ACTIVE$p(): Empty@1 at JobSupport.kt:626
+                                    AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.compareAndSet(BlockingCoroutine@1, ChildHandleNode@1, Empty@1): true at JobSupport.kt:626
+                                setParentHandle(NonDisposableHandle@1) at JobSupport.kt:302
+                                  JobSupport.get_parentHandle$volatile$FU(): AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1 at JobSupport.kt:0
+                                  AtomicReferenceFieldUpdater.AtomicReferenceFieldUpdaterImpl@1.set(DispatchedCoroutine@1, NonDisposableHandle@1) at JobSupport.kt:130
+                                state.getList(): null at JobSupport.kt:316
+                          JobSupportKt.access$getCOMPLETING_ALREADY$p(): Symbol@1 at JobSupport.kt:861
+                          JobSupportKt.access$getCOMPLETING_RETRY$p(): Symbol@1 at JobSupport.kt:866
+                        afterResume(Unit) at AbstractCoroutine.kt:101
+                          tryResume(): false at Builders.common.kt:254
+                            DispatchedCoroutine.get_decision$volatile$FU(): AtomicIntegerFieldUpdater.AtomicIntegerFieldUpdaterImpl@1 at Builders.common.kt:237
+                            handler$atomicfu.get(DispatchedCoroutine@1): 1 at Builders.common.kt:237
+                          CompletionStateKt.recoverResult(Unit, EventLoopsTest$testEventLoopInDefaultExecutor$1@1): Unit at Builders.common.kt:256
+                            Result.constructor-impl(Unit): Unit at CompletionState.kt:18
+                          DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation@1, Unit) at Builders.common.kt:256
+                            DispatchedContinuation@1.resumeCancellableWith() at DispatchedContinuation.kt:278
+                              CompletionStateKt.toState(Unit): Unit at DispatchedContinuation.kt:207
+                                Result.exceptionOrNull-impl(Unit): null at CompletionState.kt:8
+                              getContext(): CombinedContext@1 at DispatchedContinuation.kt:208
+                                continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                              DispatchedContinuationKt.safeIsDispatchNeeded(BlockingEventLoop@1, CombinedContext@1): true at DispatchedContinuation.kt:208
+                                safeIsDispatchNeeded.isDispatchNeeded(CombinedContext@1): true at DispatchedContinuation.kt:262
+                              _state = Unit at DispatchedContinuation.kt:209
+                              resumeMode = 1 at DispatchedContinuation.kt:210
+                              getContext(): CombinedContext@1 at DispatchedContinuation.kt:211
+                                continuation.getContext(): CombinedContext@1 at DispatchedContinuation.kt:0
+                              DispatchedContinuationKt.safeDispatch(BlockingEventLoop@1, CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:211
+                                safeDispatch.dispatch(CombinedContext@1, DispatchedContinuation@1) at DispatchedContinuation.kt:254
+                    ThreadContextKt.restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor") at CoroutineContext.kt:115
+                      context.fold(null, ThreadContextKt$$Lambda@1): CoroutineId@1 at ThreadContext.kt:89
+                      element.restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor") at ThreadContext.kt:90
+                        restoreThreadContext(CombinedContext@1, "kotlinx.coroutines.DefaultExecutor") at CoroutineContext.kt:289
+                          Thread.currentThread(): Thread@1 at CoroutineContext.kt:316
+                          Thread@1.setName("kotlinx.coroutines.DefaultExecutor") at CoroutineContext.kt:316
+            eventLoop.processUnconfinedEvent(): false at DispatchedTask.kt:189
+            eventLoop.decrementUseCount(true) at DispatchedTask.kt:198
+              delta(true): 4294967296 at EventLoop.common.kt:105
+              useCount = 1 at EventLoop.common.kt:105

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.ExecutorsTest_testDefaultDispatcherToExecutor.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.ExecutorsTest_testDefaultDispatcherToExecutor.txt
@@ -1,0 +1,20 @@
+# Thread 1 (Test worker)
+ExecutorsTest.testDefaultDispatcherToExecutor() at :0
+  Dispatchers.getDefault(): DefaultScheduler@1 at ExecutorsTest.kt:57
+  ExecutorsKt.asExecutor(DefaultScheduler@1): CoroutineScheduler@1 at ExecutorsTest.kt:57
+    DefaultScheduler@1.getExecutor(): CoroutineScheduler@1 at Executors.kt:104
+  CoroutineScheduler@1.execute(ExecutorsTest$$Lambda@1) at ExecutorsTest.kt:57
+  latch.await() at ExecutorsTest.kt:61
+# Thread 2 (DefaultDispatcher-worker-1)
+CoroutineScheduler.Worker.run(): <unfinished method> at :0
+  CoroutineScheduler.Worker.runWorker(): <unfinished method> at :0
+    CoroutineScheduler.Worker.executeTask(): <unfinished method> at :0
+      CoroutineScheduler.runSafely(): <unfinished method> at :0
+        TaskImpl.run(): <unfinished method> at :0
+          ExecutorsTest.testDefaultDispatcherToExecutor$lambda$3(): <unfinished method> at :0
+            checkThreadName("DefaultDispatcher") at ExecutorsTest.kt:58
+              Thread.currentThread(): CoroutineScheduler.Worker@1 at ExecutorsTest.kt:11
+              CoroutineScheduler.Worker@1.getName(): "DefaultDispatcher-worker-1" at ExecutorsTest.kt:11
+              StringsKt.startsWith$default("DefaultDispatcher-worker-1", "DefaultDispatcher", false, 2, null): true at ExecutorsTest.kt:12
+              ExecutorsTest@1.check() at ExecutorsTest.kt:12
+            latch.countDown() at ExecutorsTest.kt:59

--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/InlineMethodCallTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/InlineMethodCallTransformer.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.lincheck.jvm.agent.transformers
 
+import org.jetbrains.lincheck.descriptors.Types
 import org.jetbrains.lincheck.jvm.agent.*
 import org.jetbrains.lincheck.jvm.agent.invokeIfInAnalyzedCode
 import org.jetbrains.lincheck.jvm.agent.invokeStatic
@@ -328,7 +329,7 @@ internal class InlineMethodCallTransformer(
         TRACE_CONTEXT.getOrCreateMethodId(
             possibleClassName,
             inlineMethodName,
-            "()V"
+            Types.MethodType(Types.VOID_TYPE)
         )
 
     private fun topOfStackEndsBeforeLabel(label: Label): Boolean =

--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/IntrinsicCandidateMethodFilter.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/IntrinsicCandidateMethodFilter.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.lincheck.jvm.agent.transformers
 
+import org.jetbrains.lincheck.descriptors.Types
 import org.jetbrains.lincheck.trace.TRACE_CONTEXT
 import org.jetbrains.lincheck.util.isTrackedIntrinsic
 import org.jetbrains.lincheck.jvm.agent.ASM_API
@@ -32,7 +33,7 @@ internal class IntrinsicCandidateMethodFilter(
         // Also, some methods are intrinsified even though they do not have mentioned annotations
         // (such as Arrays.copyOf(...) methods).
         val methodDescriptor = TRACE_CONTEXT.getMethodDescriptor(
-            TRACE_CONTEXT.getOrCreateMethodId(className.toCanonicalClassName(), methodName, methodDesc)
+            TRACE_CONTEXT.getOrCreateMethodId(className.toCanonicalClassName(), methodName, Types.convertAsmMethodType(methodDesc))
         )
         if (methodDescriptor.isTrackedIntrinsic()) {
             methodDescriptor.isIntrinsic = true
@@ -43,7 +44,7 @@ internal class IntrinsicCandidateMethodFilter(
 
     override fun visitAnnotation(desc: String, visible: Boolean): AnnotationVisitor? {
         val methodDescriptor = TRACE_CONTEXT.getMethodDescriptor(
-            TRACE_CONTEXT.getOrCreateMethodId(className.toCanonicalClassName(), methodName, methodDesc)
+            TRACE_CONTEXT.getOrCreateMethodId(className.toCanonicalClassName(), methodName, Types.convertAsmMethodType(methodDesc))
         )
         if (isIntrinsicCandidateAnnotation(desc)) {
             methodDescriptor.isIntrinsic = true

--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/MethodCallMinimalTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/MethodCallMinimalTransformer.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.lincheck.jvm.agent.transformers
 
+import org.jetbrains.lincheck.descriptors.Types
 import org.jetbrains.lincheck.jvm.agent.*
 import org.jetbrains.lincheck.trace.TRACE_CONTEXT
 import org.objectweb.asm.MethodVisitor
@@ -55,7 +56,7 @@ internal class MethodCallMinimalTransformer(
             (opcode != INVOKESTATIC) -> newLocal(receiverType).also { storeLocal(it) }
             else -> null
         }
-        val methodId = TRACE_CONTEXT.getOrCreateMethodId(owner.toCanonicalClassName(), name, desc)
+        val methodId = TRACE_CONTEXT.getOrCreateMethodId(owner.toCanonicalClassName(), name, Types.convertAsmMethodType(desc))
         // STACK: <empty>
         processMethodCallEnter(methodId, receiverLocal, argumentsArrayLocal, ownerName, argumentNames)
         // STACK: deterministicCallDescriptor

--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/MethodCallTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/MethodCallTransformer.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.lincheck.jvm.agent.transformers
 
+import org.jetbrains.lincheck.descriptors.Types
 import org.jetbrains.lincheck.jvm.agent.*
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent.instrumentationMode
 import org.jetbrains.lincheck.jvm.agent.InstrumentationMode.TRACE_DEBUGGING
@@ -53,7 +54,7 @@ internal class MethodCallTransformer(
             (opcode != INVOKESTATIC) -> newLocal(receiverType).also { storeLocal(it) }
             else -> null
         }
-        val methodId = TRACE_CONTEXT.getOrCreateMethodId(owner.toCanonicalClassName(), name, desc)
+        val methodId = TRACE_CONTEXT.getOrCreateMethodId(owner.toCanonicalClassName(), name, Types.convertAsmMethodType(desc))
         // STACK: <empty>
         processMethodCallEnter(methodId, receiverLocal, argumentsArrayLocal, ownerName, argumentNames)
         // STACK: deterministicCallDescriptor

--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/ThreadTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/transformers/ThreadTransformer.kt
@@ -164,10 +164,8 @@ internal class ThreadTransformer(
     private fun isThreadJoinCall(className: String, methodName: String, desc: String) =
         // no need to check for thread subclasses here, since join methods are marked as final
         methodName == "join" && isThreadClass(className.toCanonicalClassName()) && (
-            desc == "()V" || desc == "(J)V" || desc == "(JI)V"
+            desc == VOID_METHOD_DESCRIPTOR || desc == "(J)V" || desc == "(JI)V"
         )
 }
 
-private val EMPTY_TYPE_ARRAY = emptyArray<Type>()
-
-private val VOID_METHOD_DESCRIPTOR: String = Type.getMethodDescriptor(Type.VOID_TYPE, *EMPTY_TYPE_ARRAY)
+private val VOID_METHOD_DESCRIPTOR: String = Type.getMethodDescriptor(Type.VOID_TYPE)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -10,8 +10,10 @@
 package org.jetbrains.kotlinx.lincheck.runner
 
 import org.jetbrains.kotlinx.lincheck.execution.*
-import org.jetbrains.kotlinx.lincheck.util.*
+import org.jetbrains.lincheck.util.Spinner
+import org.jetbrains.lincheck.util.SpinnerGroup
 import org.jetbrains.lincheck.util.runInsideIgnoredSection
+import org.jetbrains.lincheck.util.spinWaitBoundedFor
 import sun.nio.ch.lincheck.TestThread
 import java.io.*
 import java.lang.*

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedStrategy
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingStrategy
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
-import org.jetbrains.kotlinx.lincheck.util.*
+import org.jetbrains.lincheck.util.SpinnerGroup
 import org.jetbrains.lincheck.util.ensure
 import org.jetbrains.lincheck.util.runInsideIgnoredSection
 import org.jetbrains.lincheck.util.runOutsideIgnoredSection

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlinx.lincheck.strategy
 import sun.nio.ch.lincheck.TestThread
 import sun.nio.ch.lincheck.ThreadDescriptor
 import org.jetbrains.kotlinx.lincheck.util.*
+import org.jetbrains.lincheck.util.Spinner
 import org.jetbrains.lincheck.util.ensureNull
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -657,6 +657,10 @@ internal abstract class ManagedStrategy(
 
     // == LISTENING METHODS ==
 
+    override fun beforeExistingThreadTracking(thread: Thread, descriptor: ThreadDescriptor) {
+        error("Lincheck managed strategy does not support tracking of threads, started before agent attach.")
+    }
+
     override fun beforeThreadFork(thread: Thread, descriptor: ThreadDescriptor): Unit = runInsideIgnoredSection {
         val currentThreadId = threadScheduler.getCurrentThreadId()
         // do not track threads forked from unregistered threads

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -657,7 +657,7 @@ internal abstract class ManagedStrategy(
 
     // == LISTENING METHODS ==
 
-    override fun beforeExistingThreadTracking(thread: Thread, descriptor: ThreadDescriptor) {
+    override fun registerRunningThread(thread: Thread, descriptor: ThreadDescriptor) {
         error("Lincheck managed strategy does not support tracking of threads, started before agent attach.")
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -679,7 +679,6 @@ internal abstract class ManagedStrategy(
 
         onThreadStart(currentThreadId)
 
-        val methodDescriptor = getAsmMethod("void run()").descriptor
         val tracePoint = addBeforeMethodCallTracePoint(
             eventId = getNextEventId(),
             threadId = currentThreadId,
@@ -690,7 +689,7 @@ internal abstract class ManagedStrategy(
             methodId = TRACE_CONTEXT.getOrCreateMethodId(
                 className = "java.lang.Thread",
                 methodName = "run",
-                desc = methodDescriptor
+                methodType = Types.MethodType(Types.VOID_TYPE)
             ),
             methodParams = emptyArray(),
             atomicMethodDescriptor = null,
@@ -935,7 +934,7 @@ internal abstract class ManagedStrategy(
             methodId = TRACE_CONTEXT.getOrCreateMethodId(
                 className = actor.method.declaringClass.name.toCanonicalClassName(),
                 methodName = actor.method.name,
-                desc = methodDescriptor
+                methodType = Types.convertAsmMethodType(methodDescriptor)
             ),
             methodParams = actor.arguments.toTypedArray(),
             atomicMethodDescriptor = null,

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -154,7 +154,7 @@ class TraceCollectingEventTracker(
     private val threads = ConcurrentHashMap<Thread, ThreadData>()
 
     // For proper completion of threads which are not tracked from the start of the agent,
-    // of of those threads which are not joined by the Main thread,
+    // of those threads which are not joined by the Main thread,
     // we need to perform operations in them under locks.
     // Note: the only place where there is a contention on the locks is
     // when Main thread finishes and decides to "finish" all other running threads.

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -171,10 +171,10 @@ class TraceCollectingEventTracker(
             }
             TraceCollectorMode.BINARY_DUMP -> {
                 check(traceDumpPath != null) { "Binary output type needs non-empty output file name" }
-                strategy = MemoryTraceCollecting()
+                strategy = MemoryTraceCollecting(TRACE_CONTEXT)
             }
             else -> {
-                strategy = MemoryTraceCollecting()
+                strategy = MemoryTraceCollecting(TRACE_CONTEXT)
             }
         }
     }

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -11,6 +11,7 @@
 package org.jetbrains.lincheck.trace.recorder
 
 import org.jetbrains.lincheck.analysis.ShadowStackFrame
+import org.jetbrains.lincheck.descriptors.Types
 import org.jetbrains.lincheck.trace.TRACE_CONTEXT
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
 import org.jetbrains.lincheck.jvm.agent.TraceAgentParameters
@@ -188,11 +189,11 @@ class TraceCollectingEventTracker(
         // that method internally checks that the analysis is enabled before calling the provided lambda
         descriptor.enableAnalysis()
 
-        fun appendMethodCall(obj: TRObject?, className: String, methodName: String, methodDesc: String, codeLocationId: Int = -1, params: List<TRObject> = emptyList()) {
+        fun appendMethodCall(obj: TRObject?, className: String, methodName: String, methodType: Types.MethodType, codeLocationId: Int = -1, params: List<TRObject> = emptyList()) {
             val methodCall = TRIncompleteMethodCallTracePoint(
                 threadId = threadData.threadId,
                 codeLocationId = codeLocationId,
-                methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, methodDesc),
+                methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, methodType),
                 obj = obj,
                 parameters = params
             )
@@ -214,7 +215,7 @@ class TraceCollectingEventTracker(
                     !analysisProfile.shouldBeHidden(frame.className, frame.methodName)
                 ) {
                     // TODO: should code locations be computed from the frame?
-                    appendMethodCall(null, frame.className, frame.methodName, "()V")
+                    appendMethodCall(null, frame.className, frame.methodName,  Types.MethodType(Types.VOID_TYPE))
                 }
             }
         }
@@ -243,7 +244,7 @@ class TraceCollectingEventTracker(
             val tracePoint = TRMethodCallTracePoint(
                 threadId = threadData.threadId,
                 codeLocationId = -1,
-                methodId = TRACE_CONTEXT.getOrCreateMethodId("Thread", "run", "()V"),
+                methodId = TRACE_CONTEXT.getOrCreateMethodId("Thread", "run", Types.MethodType(Types.VOID_TYPE)),
                 obj = TRObject(thread),
                 parameters = emptyList()
             )
@@ -668,7 +669,7 @@ class TraceCollectingEventTracker(
         val tracePoint = TRMethodCallTracePoint(
             threadId = threadData.threadId,
             codeLocationId = UNKNOWN_CODE_LOCATION_ID,
-            methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, "()V"),
+            methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, Types.MethodType(Types.VOID_TYPE)),
             obj = null,
             parameters = emptyList()
         )

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -16,6 +16,7 @@ import org.jetbrains.lincheck.trace.TRACE_CONTEXT
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
 import org.jetbrains.lincheck.jvm.agent.TraceAgentParameters
 import org.jetbrains.lincheck.trace.*
+import org.jetbrains.lincheck.trace.TRMethodCallTracePoint.Companion.INCOMPLETE_METHOD_FLAG
 import org.jetbrains.lincheck.util.*
 import sun.nio.ch.lincheck.*
 import java.lang.invoke.CallSite
@@ -190,12 +191,13 @@ class TraceCollectingEventTracker(
         descriptor.enableAnalysis()
 
         fun appendMethodCall(obj: TRObject?, className: String, methodName: String, methodType: Types.MethodType, codeLocationId: Int, params: List<TRObject> = emptyList()) {
-            val methodCall = TRIncompleteMethodCallTracePoint(
+            val methodCall = TRMethodCallTracePoint(
                 threadId = threadData.threadId,
                 codeLocationId = codeLocationId,
                 methodId = TRACE_CONTEXT.getOrCreateMethodId(className, methodName, methodType),
                 obj = obj,
-                parameters = params
+                parameters = params,
+                flags = INCOMPLETE_METHOD_FLAG.toShort()
             )
             val parentTracePoint = if (threadData.getStack().isEmpty()) null
                                    else threadData.currentMethodCallTracePoint()

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceCollectingEventTracker.kt
@@ -189,7 +189,7 @@ class TraceCollectingEventTracker(
         // that method internally checks that the analysis is enabled before calling the provided lambda
         descriptor.enableAnalysis()
 
-        fun appendMethodCall(obj: TRObject?, className: String, methodName: String, methodType: Types.MethodType, codeLocationId: Int = -1, params: List<TRObject> = emptyList()) {
+        fun appendMethodCall(obj: TRObject?, className: String, methodName: String, methodType: Types.MethodType, codeLocationId: Int, params: List<TRObject> = emptyList()) {
             val methodCall = TRIncompleteMethodCallTracePoint(
                 threadId = threadData.threadId,
                 codeLocationId = codeLocationId,
@@ -214,8 +214,7 @@ class TraceCollectingEventTracker(
                     !frame.isNativeMethod &&
                     !analysisProfile.shouldBeHidden(frame.className, frame.methodName)
                 ) {
-                    // TODO: should code locations be computed from the frame?
-                    appendMethodCall(null, frame.className, frame.methodName,  Types.MethodType(Types.VOID_TYPE))
+                    appendMethodCall(null, frame.className, frame.methodName,  UNKNOWN_METHOD_TYPE, UNKNOWN_CODE_LOCATION_ID)
                 }
             }
         }

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
@@ -61,6 +61,7 @@ object TraceRecorder {
 
         eventTracker!!.enableTrace()
         desc.enableAnalysis()
+        Injections.enableAllThreadsTracking(eventTracker)
     }
 
     fun finishTraceAndDumpResults() {

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
@@ -61,7 +61,7 @@ object TraceRecorder {
 
         eventTracker!!.enableTrace()
         desc.enableAnalysis()
-        Injections.enableAllThreadsTracking(eventTracker)
+        Injections.enableGlobalThreadsTracking(eventTracker)
     }
 
     fun finishTraceAndDumpResults() {

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
@@ -15,6 +15,12 @@ import org.jetbrains.lincheck.jvm.agent.InstrumentationMode
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
 
 internal object TraceRecorderInjections {
+    // Method `stopTraceRecorderAndDumpTrace` is called in the finally block of the wrapped test:
+    // try { startTraceRecorder(); test() } finally { stopTraceRecorderAndDumpTrace() }
+    // and the way try-finally block is instrumented allows for double call of `stopTraceRecorderAndDumpTrace`
+    // in case if exception is thrown from it.
+    // We want to disallow that explicitly and the simplest way to do that is to add a flag.
+    private var alreadyStopped: Boolean = false
 
     @JvmStatic
     fun prepareTraceRecorder() {
@@ -38,6 +44,8 @@ internal object TraceRecorderInjections {
 
     @JvmStatic
     fun stopTraceRecorderAndDumpTrace() {
+        if (alreadyStopped) return
+        alreadyStopped = true
         TraceRecorder.finishTraceAndDumpResults()
     }
 }

--- a/trace/src/main/org/jetbrains/lincheck/trace/Printing.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Printing.kt
@@ -31,7 +31,7 @@ fun printPostProcessedTrace(outputFileName: String?, inputFileName: String, verb
 
     PrintStream(output.buffered(OUTPUT_BUFFER_SIZE)).use { output ->
         roots.forEachIndexed { i, root ->
-            output.println("# Thread ${i+1}")
+            output.println(getThreadName(i, roots.size, reader.context))
             lazyPrintTRPoint(output, reader, root, 0, verbose)
         }
     }
@@ -64,7 +64,7 @@ fun printRecorderTrace(output: OutputStream, context: TraceContext, rootCallsPer
     PrintStream(output.buffered(OUTPUT_BUFFER_SIZE)).use { output ->
         val appendable = DefaultTRTextAppendable(output, verbose)
         rootCallsPerThread.forEachIndexed { i, root ->
-            output.println("# Thread ${i+1}")
+            output.println(getThreadName(i, rootCallsPerThread.size, context))
             printTRPoint(appendable, root, 0)
         }
     }
@@ -97,4 +97,10 @@ private fun reportUnloaded(appendable: TRAppendable, unloaded: Int, depth: Int) 
         appendable.append(" ".repeat(depth * 2))
         appendable.append("... <${unloaded} unloaded children>\n")
     }
+}
+
+private fun getThreadName(idx: Int, totalThreads: Int, context: TraceContext): String {
+    val name = "# Thread ${idx + 1}"
+    if (totalThreads == 1) return name
+    return name + " (${context.getThreadName(idx)})"
 }

--- a/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
@@ -659,7 +659,7 @@ private class SimpleContextSavingState: ContextSavingState {
     }
 }
 
-private class DirectTraceWriter (
+private class DirectTraceWriter(
     dataStream: OutputStream,
     indexStream: OutputStream,
     context: TraceContext,
@@ -715,8 +715,11 @@ private class DirectTraceWriter (
     }
 }
 
-class MemoryTraceCollecting: TraceCollectingStrategy {
-    override fun registerCurrentThread(threadId: Int) {}
+class MemoryTraceCollecting(private val context: TraceContext): TraceCollectingStrategy {
+    override fun registerCurrentThread(threadId: Int) {
+        context.setThreadName(threadId, Thread.currentThread().name)
+    }
+
     override fun completeThread(thread: Thread) {}
 
     override fun tracePointCreated(

--- a/trace/src/main/org/jetbrains/lincheck/trace/SerializationCommon.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/SerializationCommon.kt
@@ -34,7 +34,7 @@ import kotlin.math.exp
 
 internal const val TRACE_MAGIC : Long = 0x706e547124ee5f70L
 internal const val INDEX_MAGIC : Long = TRACE_MAGIC.inv()
-internal const val TRACE_VERSION : Long = 10
+internal const val TRACE_VERSION : Long = 11
 
 internal const val INDEX_FILENAME_SUFFIX = ".idx"
 internal const val PACK_FILENAME_SUFFIX = ".packedtrace"

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -162,6 +162,9 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
             appendKeyword("threw")
             append(" ")
             append(tracePoint.exceptionClassName)
+        } else if (tracePoint.result == TR_OBJECT_UNFINISHED_METHOD_RESULT) {
+            append(": ")
+            appendSpecialSymbol(UNFINISHED_METHOD_RESULT_SYMBOL)
         } else if (tracePoint.result != TR_OBJECT_VOID) {
             append(": ")
             appendObject(tracePoint.result)

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -162,7 +162,7 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
             appendKeyword("threw")
             append(" ")
             append(tracePoint.exceptionClassName)
-        } else if (tracePoint.result == TR_OBJECT_UNFINISHED_METHOD_RESULT) {
+        } else if (tracePoint.isMethodUnfinished()) {
             append(": ")
             appendSpecialSymbol(UNFINISHED_METHOD_RESULT_SYMBOL)
         } else if (tracePoint.result != TR_OBJECT_VOID) {

--- a/trace/src/main/org/jetbrains/lincheck/trace/TracePostprocessor.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TracePostprocessor.kt
@@ -250,6 +250,7 @@ object CompressingPostprocessor : TracePostprocessor {
             child.methodId,
             child.obj,
             child.parameters,
+            child.flags,
             child.eventId
         )
         newNode.result = child.result

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -440,8 +440,8 @@ class TRWriteArrayTracePoint(
     }
 }
 
-private const val READ_ACCESS_SYMBOL  = "➜"
-private const val WRITE_ACCESS_SYMBOL = "="
+const val READ_ACCESS_SYMBOL  = "➜"
+const val WRITE_ACCESS_SYMBOL = "="
 
 fun loadTRTracePoint(inp: DataInput): TRTracePoint {
     val loader = getLoaderByClassId(inp.readByte())
@@ -496,7 +496,9 @@ val TR_OBJECT_NULL = TRObject(TR_OBJECT_NULL_CLASSNAME, 0, null)
 
 const val TR_OBJECT_VOID_CLASSNAME = -2
 val TR_OBJECT_VOID = TRObject(TR_OBJECT_VOID_CLASSNAME, 0, null)
-val TR_OBJECT_UNFINISHED_METHOD_RESULT = TRObject(TR_OBJECT_P_STRING, 0, "<unfinished method>")
+
+const val UNFINISHED_METHOD_RESULT_SYMBOL = "<unfinished method>"
+val TR_OBJECT_UNFINISHED_METHOD_RESULT = TRObject(TR_OBJECT_P_STRING, 0, UNFINISHED_METHOD_RESULT_SYMBOL)
 
 const val TR_OBJECT_P_BYTE = TR_OBJECT_VOID_CLASSNAME - 1
 const val TR_OBJECT_P_SHORT = TR_OBJECT_P_BYTE - 1

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -122,6 +122,9 @@ class TRMethodCallTracePoint(
         children.forgetAll()
     }
 
+    fun isMethodUnfinished(): Boolean =
+        result == TR_OBJECT_UNFINISHED_METHOD_RESULT
+
     override fun save(out: TraceWriter) {
         super.save(out)
         out.writeInt(methodId)

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -20,7 +20,6 @@ import org.jetbrains.lincheck.trace.DefaultTRArrayTracePointPrinter.append
 import org.jetbrains.lincheck.trace.DefaultTRFieldTracePointPrinter.append
 import org.jetbrains.lincheck.trace.DefaultTRLocalVariableTracePointPrinter.append
 import org.jetbrains.lincheck.trace.DefaultTRMethodCallTracePointPrinter.append
-import org.jetbrains.lincheck.trace.append
 import java.io.DataInput
 import java.io.DataOutput
 import java.math.BigDecimal
@@ -497,6 +496,7 @@ val TR_OBJECT_NULL = TRObject(TR_OBJECT_NULL_CLASSNAME, 0, null)
 
 const val TR_OBJECT_VOID_CLASSNAME = -2
 val TR_OBJECT_VOID = TRObject(TR_OBJECT_VOID_CLASSNAME, 0, null)
+val TR_OBJECT_UNFINISHED_METHOD_RESULT = TRObject(TR_OBJECT_P_STRING, 0, "<unfinished method>")
 
 const val TR_OBJECT_P_BYTE = TR_OBJECT_VOID_CLASSNAME - 1
 const val TR_OBJECT_P_SHORT = TR_OBJECT_P_BYTE - 1


### PR DESCRIPTION
TODO:
- [x] collect stack trace of the thread when it is first registered via `beforeExistingThreadTracking` call and append them to the stored call stack 
- [x] add markers that would allow to highlight missing prefix (thread not tracked from its start)
- [x] and suffix (thread keeps working after finish of Main) of thread trace points on the plugin side
- [x] implement plugin highlighting 
- [x] tests (3 integration tests from coroutines)

PR in the plugin: https://jetbrains.team/p/concurrency-tools/reviews/106/files