### PR TITLE
Argument names for method calls (DR-311)

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
+++ b/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
@@ -167,7 +167,7 @@ class TraceContext {
         return loc.accessPath
     }
     
-    fun arguments(codeLocationId: Int): List<AccessPath?>? {
+    fun methodCallArgumentNames(codeLocationId: Int): List<AccessPath?>? {
         if (codeLocationId == UNKNOWN_CODE_LOCATION_ID) return null
         val loc = locations[codeLocationId]
         if (loc == null) {

--- a/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
+++ b/common/src/main/org/jetbrains/lincheck/trace/TraceContext.kt
@@ -166,6 +166,15 @@ class TraceContext {
         }
         return loc.accessPath
     }
+    
+    fun arguments(codeLocationId: Int): List<AccessPath?>? {
+        if (codeLocationId == UNKNOWN_CODE_LOCATION_ID) return null
+        val loc = locations[codeLocationId]
+        if (loc == null) {
+            error("Invalid code location id $codeLocationId")
+        }
+        return loc.argumentNames
+    }
 
     fun getAccessPath(id: Int): AccessPath = accessPaths[id] ?: error("Referenced access path $id not loaded")
 

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
@@ -5,8 +5,8 @@ SimpleProgramNonFailingTest.test() at :0
   Integer;@1[2] = 3 at SimpleProgramNonFailingTest.kt:9
   CollectionsKt.listOf(Integer;@1): Arrays.ArrayList@1 at SimpleProgramNonFailingTest.kt:9
   SimpleProgramNonFailingTestKt.sum(numbers): 3 at SimpleProgramNonFailingTest.kt:10
-    numbers.get(i -> 0): 1 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i ➜ 0): 1 at SimpleProgramNonFailingTest.kt:22
     sum = 1 at SimpleProgramNonFailingTest.kt:22
-    numbers.get(i -> 1): 2 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i ➜ 1): 2 at SimpleProgramNonFailingTest.kt:22
     sum = 3 at SimpleProgramNonFailingTest.kt:22
-  Assertions.assertEquals(6, sum -> 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12
+  Assertions.assertEquals(6, sum ➜ 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
@@ -5,8 +5,8 @@ SimpleProgramNonFailingTest.test() at :0
   Integer;@1[2] = 3 at SimpleProgramNonFailingTest.kt:9
   CollectionsKt.listOf(Integer;@1): Arrays.ArrayList@1 at SimpleProgramNonFailingTest.kt:9
   SimpleProgramNonFailingTestKt.sum(numbers): 3 at SimpleProgramNonFailingTest.kt:10
-    numbers.get(i ➜ 0): 1 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i➜0): 1 at SimpleProgramNonFailingTest.kt:22
     sum = 1 at SimpleProgramNonFailingTest.kt:22
-    numbers.get(i ➜ 1): 2 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i➜1): 2 at SimpleProgramNonFailingTest.kt:22
     sum = 3 at SimpleProgramNonFailingTest.kt:22
-  Assertions.assertEquals(6, sum ➜ 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12
+  Assertions.assertEquals(6, sum➜3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
@@ -5,8 +5,8 @@ SimpleProgramNonFailingTest.test() at :0
   Integer;@1[2] = 3 at SimpleProgramNonFailingTest.kt:9
   CollectionsKt.listOf(Integer;@1): Arrays.ArrayList@1 at SimpleProgramNonFailingTest.kt:9
   SimpleProgramNonFailingTestKt.sum(numbers): 3 at SimpleProgramNonFailingTest.kt:10
-    numbers.get(i➜0): 1 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i ➜ 0): 1 at SimpleProgramNonFailingTest.kt:22
     sum = 1 at SimpleProgramNonFailingTest.kt:22
-    numbers.get(i➜1): 2 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i ➜ 1): 2 at SimpleProgramNonFailingTest.kt:22
     sum = 3 at SimpleProgramNonFailingTest.kt:22
-  Assertions.assertEquals(6, sum➜3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12
+  Assertions.assertEquals(6, sum ➜ 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/TraceDebuggerExamples/org.examples.hackathon.SimpleProgramNonFailingTest_test.txt
@@ -4,9 +4,9 @@ SimpleProgramNonFailingTest.test() at :0
   Integer;@1[1] = 2 at SimpleProgramNonFailingTest.kt:9
   Integer;@1[2] = 3 at SimpleProgramNonFailingTest.kt:9
   CollectionsKt.listOf(Integer;@1): Arrays.ArrayList@1 at SimpleProgramNonFailingTest.kt:9
-  SimpleProgramNonFailingTestKt.sum(Arrays.ArrayList@1): 3 at SimpleProgramNonFailingTest.kt:10
-    numbers.get(0): 1 at SimpleProgramNonFailingTest.kt:22
+  SimpleProgramNonFailingTestKt.sum(numbers): 3 at SimpleProgramNonFailingTest.kt:10
+    numbers.get(i -> 0): 1 at SimpleProgramNonFailingTest.kt:22
     sum = 1 at SimpleProgramNonFailingTest.kt:22
-    numbers.get(1): 2 at SimpleProgramNonFailingTest.kt:22
+    numbers.get(i -> 1): 2 at SimpleProgramNonFailingTest.kt:22
     sum = 3 at SimpleProgramNonFailingTest.kt:22
-  Assertions.assertEquals(6, 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12
+  Assertions.assertEquals(6, sum -> 3): threw org.opentest4j.AssertionFailedError at SimpleProgramNonFailingTest.kt:12

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty.txt
@@ -8,191 +8,191 @@ ImmutableListTest.empty() at :0
     UtilsKt.persistentVectorOf(): SmallPersistentVector@1 at extensions.kt:452
       SmallPersistentVector.Companion.getEMPTY(): SmallPersistentVector@1 at Utils.kt:18
         SmallPersistentVector.access$getEMPTY$cp(): SmallPersistentVector@1 at SmallPersistentVector.kt:163
-  AssertionsKt.assertEquals$default(SmallPersistentVector@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:22
+  AssertionsKt.assertEquals$default(empty1, empty2, null, 4, null) at ImmutableListTest.kt:22
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:23
-  AssertionsKt.assertEquals$default(EmptyList@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:23
+  AssertionsKt.assertEquals$default(EmptyList@1, empty1, null, 4, null) at ImmutableListTest.kt:23
   AssertionsKt.assertTrue$default(true, null, 2, null) at ImmutableListTest.kt:24
   Reflection.getOrCreateKotlinClass(Class@1): KClassImpl@1 at ImmutableListTest.kt:26
   empty1.iterator(): BufferIterator@1 at ImmutableListTest.kt:26
     listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
       listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
-        ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
+        ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
   BufferIterator@1.next(): threw java.util.NoSuchElementException at ImmutableListTest.kt:26
     hasNext(): false at BufferIterator.kt:14
   ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ImmutableListTest.kt:26
   Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ImmutableListTest.kt:26
   AssertionsKt.checkResultIsFailure(KClassImpl@1, null, Result.Failure@1): NoSuchElementException@1 at ImmutableListTest.kt:26
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:28
-  compareLists(EmptyList@1, SmallPersistentVector@1) at ImmutableListTest.kt:28
-    ComparisonDSLKt.compare(EmptyList@1, SmallPersistentVector@1, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
+  compareLists(EmptyList@1, empty1) at ImmutableListTest.kt:28
+    ComparisonDSLKt.compare(expected, actual, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
       block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-        CollectionBehaviorsKt.listBehavior(CompareContext@1) at ImmutableListTest.kt:16
+        CollectionBehaviorsKt.listBehavior(compare) at ImmutableListTest.kt:16
           CollectionBehaviorsKt.equalityBehavior(CompareContext@1, "", true) at CollectionBehaviors.kt:9
-            "".append(""): "" at CollectionBehaviors.kt:96
+            "".append(objectName ➜ ""): "" at CollectionBehaviors.kt:96
             objectName.length(): 0 at CollectionBehaviors.kt:96
             "".append(""): "" at CollectionBehaviors.kt:96
             "".toString(): "" at CollectionBehaviors.kt:96
-            equalityBehavior.equals("") at CollectionBehaviors.kt:97
-              AssertionsKt.assertEquals(EmptyList@1, SmallPersistentVector@1, "") at ComparisonDSL.kt:18
-            "".append(""): "" at CollectionBehaviors.kt:98
+            equalityBehavior.equals(objectName ➜ "") at CollectionBehaviors.kt:97
+              AssertionsKt.assertEquals(this.expected, this.actual, message ➜ "") at ComparisonDSL.kt:18
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:98
             "".append("hashCode"): "hashCode" at CollectionBehaviors.kt:98
             "hashCode".toString(): "hashCode" at CollectionBehaviors.kt:98
             equalityBehavior.propertyEquals("hashCode", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:98
-              getter.invoke(EmptyList@1): 1 at ComparisonDSL.kt:21
+              getter.invoke(this.expected): 1 at ComparisonDSL.kt:21
                 propertyEquals.hashCode(): 1 at CollectionBehaviors.kt:98
-              getter.invoke(SmallPersistentVector@1): 1 at ComparisonDSL.kt:21
+              getter.invoke(this.actual): 1 at ComparisonDSL.kt:21
                 propertyEquals.hashCode(): 1 at CollectionBehaviors.kt:98
                   listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
                     listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
-                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-              AssertionsKt.assertEquals(1, 1, "hashCode") at ComparisonDSL.kt:21
-            "".append(""): "" at CollectionBehaviors.kt:100
+                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+              AssertionsKt.assertEquals(1, 1, message ➜ "hashCode") at ComparisonDSL.kt:21
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:100
             "".append("toString"): "toString" at CollectionBehaviors.kt:100
             "toString".toString(): "toString" at CollectionBehaviors.kt:100
             equalityBehavior.propertyEquals("toString", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:100
-              getter.invoke(EmptyList@1): "[]" at ComparisonDSL.kt:21
-              getter.invoke(SmallPersistentVector@1): "[]" at ComparisonDSL.kt:21
+              getter.invoke(this.expected): "[]" at ComparisonDSL.kt:21
+              getter.invoke(this.actual): "[]" at ComparisonDSL.kt:21
                 listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
                   listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
-                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-              AssertionsKt.assertEquals("[]", "[]", "toString") at ComparisonDSL.kt:21
+                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+              AssertionsKt.assertEquals("[]", "[]", message ➜ "toString") at ComparisonDSL.kt:21
           CollectionBehaviorsKt.collectionBehavior(CompareContext@1, "", true) at CollectionBehaviors.kt:10
-            "".append(""): "" at CollectionBehaviors.kt:105
+            "".append(objectName ➜ ""): "" at CollectionBehaviors.kt:105
             objectName.length(): 0 at CollectionBehaviors.kt:105
             "".append(""): "" at CollectionBehaviors.kt:105
             "".toString(): "" at CollectionBehaviors.kt:105
-            "".append(""): "" at CollectionBehaviors.kt:106
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:106
             "".append("size"): "size" at CollectionBehaviors.kt:106
             "size".toString(): "size" at CollectionBehaviors.kt:106
             collectionBehavior.propertyEquals("size", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:106
-              getter.invoke(EmptyList@1): 0 at ComparisonDSL.kt:21
-              getter.invoke(SmallPersistentVector@1): 0 at ComparisonDSL.kt:21
-              AssertionsKt.assertEquals(0, 0, "size") at ComparisonDSL.kt:21
-            "".append(""): "" at CollectionBehaviors.kt:107
+              getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
+              getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals(0, 0, message ➜ "size") at ComparisonDSL.kt:21
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:107
             "".append("isEmpty"): "isEmpty" at CollectionBehaviors.kt:107
             "isEmpty".toString(): "isEmpty" at CollectionBehaviors.kt:107
             collectionBehavior.propertyEquals("isEmpty", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:107
-              getter.invoke(EmptyList@1): true at ComparisonDSL.kt:21
+              getter.invoke(this.expected): true at ComparisonDSL.kt:21
                 propertyEquals.isEmpty(): true at CollectionBehaviors.kt:107
-              getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
+              getter.invoke(this.actual): true at ComparisonDSL.kt:21
                 propertyEquals.isEmpty(): true at CollectionBehaviors.kt:107
-              AssertionsKt.assertEquals(true, true, "isEmpty") at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals(true, true, message ➜ "isEmpty") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:109
-              getter.invoke(EmptyList@1): false at ComparisonDSL.kt:21
-                CollectionsKt.contains(EmptyList@1, CollectionBehaviorsKt$collectionBehavior$3@1): false at CollectionBehaviors.kt:109
-              getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
-                CollectionsKt.contains(SmallPersistentVector@1, CollectionBehaviorsKt$collectionBehavior$3@1): false at CollectionBehaviors.kt:109
-                  indexOf(CollectionBehaviorsKt$collectionBehavior$3@1): -1 at AbstractPersistentList.kt:52
-                    ArraysKt.indexOf(Object;@1, CollectionBehaviorsKt$collectionBehavior$3@1): -1 at SmallPersistentVector.kt:135
-              AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): false at ComparisonDSL.kt:21
+                CollectionsKt.contains(propertyEquals, it): false at CollectionBehaviors.kt:109
+              getter.invoke(this.actual): false at ComparisonDSL.kt:21
+                CollectionsKt.contains(propertyEquals, it): false at CollectionBehaviors.kt:109
+                  indexOf(element): -1 at AbstractPersistentList.kt:52
+                    ArraysKt.indexOf(this.buffer, element): -1 at SmallPersistentVector.kt:135
+              AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:110
-              getter.invoke(EmptyList@1): false at ComparisonDSL.kt:21
-                CollectionsKt.firstOrNull(EmptyList@1): null at CollectionBehaviors.kt:110
-                CollectionsKt.contains(EmptyList@1, null): false at CollectionBehaviors.kt:110
-              getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
-                CollectionsKt.firstOrNull(SmallPersistentVector@1): null at CollectionBehaviors.kt:110
-                CollectionsKt.contains(SmallPersistentVector@1, null): false at CollectionBehaviors.kt:110
-                  indexOf(null): -1 at AbstractPersistentList.kt:52
-                    ArraysKt.indexOf(Object;@1, null): -1 at SmallPersistentVector.kt:135
-              AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): false at ComparisonDSL.kt:21
+                CollectionsKt.firstOrNull(propertyEquals): null at CollectionBehaviors.kt:110
+                CollectionsKt.contains(propertyEquals, null): false at CollectionBehaviors.kt:110
+              getter.invoke(this.actual): false at ComparisonDSL.kt:21
+                CollectionsKt.firstOrNull(propertyEquals): null at CollectionBehaviors.kt:110
+                CollectionsKt.contains(propertyEquals, null): false at CollectionBehaviors.kt:110
+                  indexOf(element): -1 at AbstractPersistentList.kt:52
+                    ArraysKt.indexOf(this.buffer, element): -1 at SmallPersistentVector.kt:135
+              AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:111
-              getter.invoke(EmptyList@1): true at ComparisonDSL.kt:21
-                propertyEquals.containsAll(EmptyList@1): true at CollectionBehaviors.kt:111
-              getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
-                propertyEquals.containsAll(SmallPersistentVector@1): true at CollectionBehaviors.kt:111
+              getter.invoke(this.expected): true at ComparisonDSL.kt:21
+                propertyEquals.containsAll(propertyEquals): true at CollectionBehaviors.kt:111
+              getter.invoke(this.actual): true at ComparisonDSL.kt:21
+                propertyEquals.containsAll(propertyEquals): true at CollectionBehaviors.kt:111
                   isEmpty(): true at _Collections.kt:1734
-              AssertionsKt.assertEquals(true, true, "") at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals(true, true, message ➜ "") at ComparisonDSL.kt:21
             collectionBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:113
-              getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+              getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
                 compareProperty.iterator(): EmptyIterator@1 at CollectionBehaviors.kt:113
-              getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+              getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
                 compareProperty.iterator(): BufferIterator@1 at CollectionBehaviors.kt:113
                   listIterator(): BufferIterator@1 at AbstractPersistentList.kt:60
                     listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
-                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-              ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+                      ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+              ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
                 block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                  CollectionBehaviorsKt.iteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:113
+                  CollectionBehaviorsKt.iteratorBehavior(compareProperty) at CollectionBehaviors.kt:113
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:55
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:55
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:55
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     iteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:57
                     EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:57
                     iteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:61
                       CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                         expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                          getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                          getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:61
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                         AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                         actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                          getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                          getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:61
                               hasNext(): false at BufferIterator.kt:14
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                         AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                        TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                        TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                           expected.getClass(): Class@1 at testUtilsJvm.kt:11
                           actual.getClass(): Class@1 at testUtilsJvm.kt:11
                           AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:11
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(): EmptyIterator@1 at CollectionBehaviors.kt:11
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(): BufferIterator@1 at CollectionBehaviors.kt:11
                 listIterator(0): BufferIterator@1 at AbstractPersistentList.kt:64
-                  ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+                  ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:11
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:11
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                             hasNext(): false at BufferIterator.kt:14
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -201,74 +201,74 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                             hasPrevious(): false at BufferIterator.kt:21
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:12
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): EmptyIterator@1 at CollectionBehaviors.kt:12
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:12
-                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:12
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:12
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                             hasNext(): false at BufferIterator.kt:14
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -277,74 +277,74 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                             hasPrevious(): false at BufferIterator.kt:21
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:13
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): EmptyIterator@1 at CollectionBehaviors.kt:13
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:13
-                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(0, 0) at SmallPersistentVector.kt:143
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+                ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 0, 0) at SmallPersistentVector.kt:143
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:13
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:13
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                             hasNext(): false at BufferIterator.kt:14
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -353,177 +353,177 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                             hasPrevious(): false at BufferIterator.kt:21
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:15
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(-1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:15
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(-1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:15
-                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(-1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
+                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ -1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
                       "".append("index: "): "index: " at ListImplementation.kt:22
-                      "index: ".append(-1): "index: -1" at ListImplementation.kt:22
+                      "index: ".append(index ➜ -1): "index: -1" at ListImplementation.kt:22
                       "index: -1".append(", size: "): "index: -1, size: " at ListImplementation.kt:22
-                      "index: -1, size: ".append(0): "index: -1, size: 0" at ListImplementation.kt:22
+                      "index: -1, size: ".append(size ➜ 0): "index: -1, size: 0" at ListImplementation.kt:22
                       "index: -1, size: 0".toString(): "index: -1, size: 0" at ListImplementation.kt:22
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:16
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:16
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:16
-                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
+                    ListImplementation.checkPositionIndex$kotlinx_collections_immutable(index ➜ 1, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:143
                       "".append("index: "): "index: " at ListImplementation.kt:22
-                      "index: ".append(1): "index: 1" at ListImplementation.kt:22
+                      "index: ".append(index ➜ 1): "index: 1" at ListImplementation.kt:22
                       "index: 1".append(", size: "): "index: 1, size: " at ListImplementation.kt:22
-                      "index: 1, size: ".append(0): "index: 1, size: 0" at ListImplementation.kt:22
+                      "index: 1, size: ".append(size ➜ 0): "index: 1, size: 0" at ListImplementation.kt:22
                       "index: 1, size: 0".toString(): "index: 1, size: 0" at ListImplementation.kt:22
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.getExpected(): EmptyList@1 at CollectionBehaviors.kt:18
-          propertyFailsWith(CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:24
-            assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1@1) at ComparisonDSL.kt:25
+          propertyFailsWith(CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1.INSTANCE, getter) at ComparisonDSL.kt:24
+            assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, exceptionPredicate) at ComparisonDSL.kt:25
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
                   propertyFailsWith.get(0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:21
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
                   propertyFailsWith.get(0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:21
-                    ListImplementation.checkElementIndex$kotlinx_collections_immutable(0, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:150
+                    ListImplementation.checkElementIndex$kotlinx_collections_immutable(index ➜ 0, 0): threw java.lang.IndexOutOfBoundsException at SmallPersistentVector.kt:150
                       "".append("index: "): "index: " at ListImplementation.kt:15
-                      "index: ".append(0): "index: 0" at ListImplementation.kt:15
+                      "index: ".append(index ➜ 0): "index: 0" at ListImplementation.kt:15
                       "index: 0".append(", size: "): "index: 0, size: " at ListImplementation.kt:15
-                      "index: 0, size: ".append(0): "index: 0, size: 0" at ListImplementation.kt:15
+                      "index: 0, size: ".append(size ➜ 0): "index: 0, size: 0" at ListImplementation.kt:15
                       "index: 0, size: 0".toString(): "index: 0, size: 0" at ListImplementation.kt:15
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:35
-                invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
+              exceptionPredicate.invoke(expectedFail): true at ComparisonDSL.kt:35
+                invoke(p1): true at ComparisonDSL.kt:24
               AssertionsKt.assertTrue(true, "expected fail") at ComparisonDSL.kt:35
-              exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:36
-                invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
+              exceptionPredicate.invoke(actualFail): true at ComparisonDSL.kt:36
+                invoke(p1): true at ComparisonDSL.kt:24
               AssertionsKt.assertTrue(true, "actual fail") at ComparisonDSL.kt:36
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:23
-            getter.invoke(EmptyList@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(EmptyList@1, 0): null at CollectionBehaviors.kt:23
-              CollectionsKt.indexOf(EmptyList@1, null): -1 at CollectionBehaviors.kt:23
-            getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:23
-              CollectionsKt.indexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:23
-                ArraysKt.indexOf(Object;@1, null): -1 at SmallPersistentVector.kt:135
-            AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+            getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:23
+              CollectionsKt.indexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:23
+            getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:23
+              CollectionsKt.indexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:23
+                ArraysKt.indexOf(this.buffer, element): -1 at SmallPersistentVector.kt:135
+            AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:24
-            getter.invoke(EmptyList@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(EmptyList@1, 0): null at CollectionBehaviors.kt:24
-              CollectionsKt.lastIndexOf(EmptyList@1, null): -1 at CollectionBehaviors.kt:24
-            getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:24
-              CollectionsKt.lastIndexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:24
-                ArraysKt.lastIndexOf(Object;@1, null): -1 at SmallPersistentVector.kt:139
-            AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+            getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:24
+              CollectionsKt.lastIndexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:24
+            getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:24
+              CollectionsKt.lastIndexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:24
+                ArraysKt.lastIndexOf(this.buffer, element): -1 at SmallPersistentVector.kt:139
+            AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:26
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(0, 1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:26
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(0, 1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:26
-                    subList(0, 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
-                      PersistentList.DefaultImpls.subList(SmallPersistentVector@1, 0, 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
-                        ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, 0, 1): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
+                    subList(fromIndex ➜ 0, toIndex ➜ 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
+                      PersistentList.DefaultImpls.subList(this, fromIndex ➜ 0, toIndex ➜ 1): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
+                        ImmutableList.DefaultImpls.subList(this, fromIndex ➜ 0, toIndex ➜ 1): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
                           "".append("fromIndex: "): "fromIndex: " at ListImplementation.kt:29
-                          "fromIndex: ".append(0): "fromIndex: 0" at ListImplementation.kt:29
+                          "fromIndex: ".append(fromIndex ➜ 0): "fromIndex: 0" at ListImplementation.kt:29
                           "fromIndex: 0".append(", toIndex: "): "fromIndex: 0, toIndex: " at ListImplementation.kt:29
-                          "fromIndex: 0, toIndex: ".append(1): "fromIndex: 0, toIndex: 1" at ListImplementation.kt:29
+                          "fromIndex: 0, toIndex: ".append(toIndex ➜ 1): "fromIndex: 0, toIndex: 1" at ListImplementation.kt:29
                           "fromIndex: 0, toIndex: 1".append(", size: "): "fromIndex: 0, toIndex: 1, size: " at ListImplementation.kt:29
-                          "fromIndex: 0, toIndex: 1, size: ".append(0): "fromIndex: 0, toIndex: 1, size: 0" at ListImplementation.kt:29
+                          "fromIndex: 0, toIndex: 1, size: ".append(size ➜ 0): "fromIndex: 0, toIndex: 1, size: 0" at ListImplementation.kt:29
                           "fromIndex: 0, toIndex: 1, size: 0".toString(): "fromIndex: 0, toIndex: 1, size: 0" at ListImplementation.kt:29
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:27
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(-1, 0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:27
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(-1, 0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:27
-                    subList(-1, 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
-                      PersistentList.DefaultImpls.subList(SmallPersistentVector@1, -1, 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
-                        ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, -1, 0): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
+                    subList(fromIndex ➜ -1, toIndex ➜ 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:13
+                      PersistentList.DefaultImpls.subList(this, fromIndex ➜ -1, toIndex ➜ 0): threw java.lang.IndexOutOfBoundsException at AbstractPersistentList.kt:15
+                        ImmutableList.DefaultImpls.subList(this, fromIndex ➜ -1, toIndex ➜ 0): threw java.lang.IndexOutOfBoundsException at ImmutableList.kt:62
                           "".append("fromIndex: "): "fromIndex: " at ListImplementation.kt:29
-                          "fromIndex: ".append(-1): "fromIndex: -1" at ListImplementation.kt:29
+                          "fromIndex: ".append(fromIndex ➜ -1): "fromIndex: -1" at ListImplementation.kt:29
                           "fromIndex: -1".append(", toIndex: "): "fromIndex: -1, toIndex: " at ListImplementation.kt:29
-                          "fromIndex: -1, toIndex: ".append(0): "fromIndex: -1, toIndex: 0" at ListImplementation.kt:29
+                          "fromIndex: -1, toIndex: ".append(toIndex ➜ 0): "fromIndex: -1, toIndex: 0" at ListImplementation.kt:29
                           "fromIndex: -1, toIndex: 0".append(", size: "): "fromIndex: -1, toIndex: 0, size: " at ListImplementation.kt:29
-                          "fromIndex: -1, toIndex: 0, size: ".append(0): "fromIndex: -1, toIndex: 0, size: 0" at ListImplementation.kt:29
+                          "fromIndex: -1, toIndex: 0, size: ".append(size ➜ 0): "fromIndex: -1, toIndex: 0, size: 0" at ListImplementation.kt:29
                           "fromIndex: -1, toIndex: 0, size: 0".toString(): "fromIndex: -1, toIndex: 0, size: 0" at ListImplementation.kt:29
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:28
-            getter.invoke(EmptyList@1): EmptyList@1 at ComparisonDSL.kt:21
+            getter.invoke(this.expected): EmptyList@1 at ComparisonDSL.kt:21
               propertyEquals.subList(0, 0): EmptyList@1 at CollectionBehaviors.kt:28
-            getter.invoke(SmallPersistentVector@1): ImmutableList.SubList@1 at ComparisonDSL.kt:21
+            getter.invoke(this.actual): ImmutableList.SubList@1 at ComparisonDSL.kt:21
               propertyEquals.subList(0, 0): ImmutableList.SubList@1 at CollectionBehaviors.kt:28
-                subList(0, 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:13
-                  PersistentList.DefaultImpls.subList(SmallPersistentVector@1, 0, 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:15
-                    ImmutableList.DefaultImpls.subList(SmallPersistentVector@1, 0, 0): ImmutableList.SubList@1 at ImmutableList.kt:62
-            AssertionsKt.assertEquals(EmptyList@1, ImmutableList.SubList@1, "") at ComparisonDSL.kt:21
+                subList(fromIndex ➜ 0, toIndex ➜ 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:13
+                  PersistentList.DefaultImpls.subList(this, fromIndex ➜ 0, toIndex ➜ 0): ImmutableList.SubList@1 at AbstractPersistentList.kt:15
+                    ImmutableList.DefaultImpls.subList(this, fromIndex ➜ 0, toIndex ➜ 0): ImmutableList.SubList@1 at ImmutableList.kt:62
+            AssertionsKt.assertEquals(EmptyList@1, ImmutableList.SubList@1, message ➜ "") at ComparisonDSL.kt:21

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_exclude_filter.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_exclude_filter.txt
@@ -2,9 +2,9 @@
 ImmutableListTest.empty() at :0
   ExtensionsKt.persistentListOf(): SmallPersistentVector@1 at ImmutableListTest.kt:20
   ExtensionsKt.persistentListOf(): SmallPersistentVector@1 at ImmutableListTest.kt:21
-  AssertionsKt.assertEquals$default(SmallPersistentVector@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:22
+  AssertionsKt.assertEquals$default(empty1, empty2, null, 4, null) at ImmutableListTest.kt:22
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:23
-  AssertionsKt.assertEquals$default(EmptyList@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:23
+  AssertionsKt.assertEquals$default(EmptyList@1, empty1, null, 4, null) at ImmutableListTest.kt:23
   AssertionsKt.assertTrue$default(true, null, 2, null) at ImmutableListTest.kt:24
   Reflection.getOrCreateKotlinClass(Class@1): KClassImpl@1 at ImmutableListTest.kt:26
   empty1.iterator(): BufferIterator@1 at ImmutableListTest.kt:26
@@ -13,158 +13,158 @@ ImmutableListTest.empty() at :0
   Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ImmutableListTest.kt:26
   AssertionsKt.checkResultIsFailure(KClassImpl@1, null, Result.Failure@1): NoSuchElementException@1 at ImmutableListTest.kt:26
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:28
-  compareLists(EmptyList@1, SmallPersistentVector@1) at ImmutableListTest.kt:28
-    ComparisonDSLKt.compare(EmptyList@1, SmallPersistentVector@1, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
+  compareLists(EmptyList@1, empty1) at ImmutableListTest.kt:28
+    ComparisonDSLKt.compare(expected, actual, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
       block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-        CollectionBehaviorsKt.listBehavior(CompareContext@1) at ImmutableListTest.kt:16
+        CollectionBehaviorsKt.listBehavior(compare) at ImmutableListTest.kt:16
           CollectionBehaviorsKt.equalityBehavior(CompareContext@1, "", true) at CollectionBehaviors.kt:9
-            "".append(""): "" at CollectionBehaviors.kt:96
+            "".append(objectName ➜ ""): "" at CollectionBehaviors.kt:96
             objectName.length(): 0 at CollectionBehaviors.kt:96
             "".append(""): "" at CollectionBehaviors.kt:96
             "".toString(): "" at CollectionBehaviors.kt:96
-            equalityBehavior.equals("") at CollectionBehaviors.kt:97
-              AssertionsKt.assertEquals(EmptyList@1, SmallPersistentVector@1, "") at ComparisonDSL.kt:18
-            "".append(""): "" at CollectionBehaviors.kt:98
+            equalityBehavior.equals(objectName ➜ "") at CollectionBehaviors.kt:97
+              AssertionsKt.assertEquals(this.expected, this.actual, message ➜ "") at ComparisonDSL.kt:18
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:98
             "".append("hashCode"): "hashCode" at CollectionBehaviors.kt:98
             "hashCode".toString(): "hashCode" at CollectionBehaviors.kt:98
             equalityBehavior.propertyEquals("hashCode", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:98
-              getter.invoke(EmptyList@1): 1 at ComparisonDSL.kt:21
+              getter.invoke(this.expected): 1 at ComparisonDSL.kt:21
                 propertyEquals.hashCode(): 1 at CollectionBehaviors.kt:98
-              getter.invoke(SmallPersistentVector@1): 1 at ComparisonDSL.kt:21
+              getter.invoke(this.actual): 1 at ComparisonDSL.kt:21
                 propertyEquals.hashCode(): 1 at CollectionBehaviors.kt:98
-              AssertionsKt.assertEquals(1, 1, "hashCode") at ComparisonDSL.kt:21
-            "".append(""): "" at CollectionBehaviors.kt:100
+              AssertionsKt.assertEquals(1, 1, message ➜ "hashCode") at ComparisonDSL.kt:21
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:100
             "".append("toString"): "toString" at CollectionBehaviors.kt:100
             "toString".toString(): "toString" at CollectionBehaviors.kt:100
             equalityBehavior.propertyEquals("toString", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:100
-              getter.invoke(EmptyList@1): "[]" at ComparisonDSL.kt:21
-              getter.invoke(SmallPersistentVector@1): "[]" at ComparisonDSL.kt:21
-              AssertionsKt.assertEquals("[]", "[]", "toString") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): "[]" at ComparisonDSL.kt:21
+              getter.invoke(this.actual): "[]" at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals("[]", "[]", message ➜ "toString") at ComparisonDSL.kt:21
           CollectionBehaviorsKt.collectionBehavior(CompareContext@1, "", true) at CollectionBehaviors.kt:10
-            "".append(""): "" at CollectionBehaviors.kt:105
+            "".append(objectName ➜ ""): "" at CollectionBehaviors.kt:105
             objectName.length(): 0 at CollectionBehaviors.kt:105
             "".append(""): "" at CollectionBehaviors.kt:105
             "".toString(): "" at CollectionBehaviors.kt:105
-            "".append(""): "" at CollectionBehaviors.kt:106
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:106
             "".append("size"): "size" at CollectionBehaviors.kt:106
             "size".toString(): "size" at CollectionBehaviors.kt:106
             collectionBehavior.propertyEquals("size", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:106
-              getter.invoke(EmptyList@1): 0 at ComparisonDSL.kt:21
-              getter.invoke(SmallPersistentVector@1): 0 at ComparisonDSL.kt:21
-              AssertionsKt.assertEquals(0, 0, "size") at ComparisonDSL.kt:21
-            "".append(""): "" at CollectionBehaviors.kt:107
+              getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
+              getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals(0, 0, message ➜ "size") at ComparisonDSL.kt:21
+            "".append(prefix ➜ ""): "" at CollectionBehaviors.kt:107
             "".append("isEmpty"): "isEmpty" at CollectionBehaviors.kt:107
             "isEmpty".toString(): "isEmpty" at CollectionBehaviors.kt:107
             collectionBehavior.propertyEquals("isEmpty", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:107
-              getter.invoke(EmptyList@1): true at ComparisonDSL.kt:21
+              getter.invoke(this.expected): true at ComparisonDSL.kt:21
                 propertyEquals.isEmpty(): true at CollectionBehaviors.kt:107
-              getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
+              getter.invoke(this.actual): true at ComparisonDSL.kt:21
                 propertyEquals.isEmpty(): true at CollectionBehaviors.kt:107
-              AssertionsKt.assertEquals(true, true, "isEmpty") at ComparisonDSL.kt:21
+              AssertionsKt.assertEquals(true, true, message ➜ "isEmpty") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:109
-              getter.invoke(EmptyList@1): false at ComparisonDSL.kt:21
-                CollectionsKt.contains(EmptyList@1, CollectionBehaviorsKt$collectionBehavior$3@1): false at CollectionBehaviors.kt:109
-              getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
-                CollectionsKt.contains(SmallPersistentVector@1, CollectionBehaviorsKt$collectionBehavior$3@1): false at CollectionBehaviors.kt:109
-              AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): false at ComparisonDSL.kt:21
+                CollectionsKt.contains(propertyEquals, it): false at CollectionBehaviors.kt:109
+              getter.invoke(this.actual): false at ComparisonDSL.kt:21
+                CollectionsKt.contains(propertyEquals, it): false at CollectionBehaviors.kt:109
+              AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:110
-              getter.invoke(EmptyList@1): false at ComparisonDSL.kt:21
-                CollectionsKt.firstOrNull(EmptyList@1): null at CollectionBehaviors.kt:110
-                CollectionsKt.contains(EmptyList@1, null): false at CollectionBehaviors.kt:110
-              getter.invoke(SmallPersistentVector@1): false at ComparisonDSL.kt:21
-                CollectionsKt.firstOrNull(SmallPersistentVector@1): null at CollectionBehaviors.kt:110
-                CollectionsKt.contains(SmallPersistentVector@1, null): false at CollectionBehaviors.kt:110
-              AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): false at ComparisonDSL.kt:21
+                CollectionsKt.firstOrNull(propertyEquals): null at CollectionBehaviors.kt:110
+                CollectionsKt.contains(propertyEquals, null): false at CollectionBehaviors.kt:110
+              getter.invoke(this.actual): false at ComparisonDSL.kt:21
+                CollectionsKt.firstOrNull(propertyEquals): null at CollectionBehaviors.kt:110
+                CollectionsKt.contains(propertyEquals, null): false at CollectionBehaviors.kt:110
+              AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
             CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:111
-              getter.invoke(EmptyList@1): true at ComparisonDSL.kt:21
-                propertyEquals.containsAll(EmptyList@1): true at CollectionBehaviors.kt:111
-              getter.invoke(SmallPersistentVector@1): true at ComparisonDSL.kt:21
-                propertyEquals.containsAll(SmallPersistentVector@1): true at CollectionBehaviors.kt:111
-              AssertionsKt.assertEquals(true, true, "") at ComparisonDSL.kt:21
+              getter.invoke(this.expected): true at ComparisonDSL.kt:21
+                propertyEquals.containsAll(propertyEquals): true at CollectionBehaviors.kt:111
+              getter.invoke(this.actual): true at ComparisonDSL.kt:21
+                propertyEquals.containsAll(propertyEquals): true at CollectionBehaviors.kt:111
+              AssertionsKt.assertEquals(true, true, message ➜ "") at ComparisonDSL.kt:21
             collectionBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:113
-              getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+              getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
                 compareProperty.iterator(): EmptyIterator@1 at CollectionBehaviors.kt:113
-              getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+              getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
                 compareProperty.iterator(): BufferIterator@1 at CollectionBehaviors.kt:113
-              ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+              ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
                 block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                  CollectionBehaviorsKt.iteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:113
+                  CollectionBehaviorsKt.iteratorBehavior(compareProperty) at CollectionBehaviors.kt:113
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:55
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:55
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:55
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     iteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:57
                     EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:57
                     iteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:61
                       CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                         expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                          getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                          getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:61
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                         AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                         actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                          getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                          getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                             propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:61
                         ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                         Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                         AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                        TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                        TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                           expected.getClass(): Class@1 at testUtilsJvm.kt:11
                           actual.getClass(): Class@1 at testUtilsJvm.kt:11
                           AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:11
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(): EmptyIterator@1 at CollectionBehaviors.kt:11
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(): BufferIterator@1 at CollectionBehaviors.kt:11
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:11
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:11
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -173,71 +173,71 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:12
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): EmptyIterator@1 at CollectionBehaviors.kt:12
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:12
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:12
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:12
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -246,71 +246,71 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.compareProperty(CollectionBehaviorsKt$$Lambda@1, CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:13
-            getter.invoke(EmptyList@1): EmptyIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.expected): EmptyIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): EmptyIterator@1 at CollectionBehaviors.kt:13
-            getter.invoke(SmallPersistentVector@1): BufferIterator@1 at ComparisonDSL.kt:27
+            getter.invoke(this.actual): BufferIterator@1 at ComparisonDSL.kt:27
               compareProperty.listIterator(0): BufferIterator@1 at CollectionBehaviors.kt:13
-            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:27
+            ComparisonDSLKt.compare(EmptyIterator@1, BufferIterator@1, block) at ComparisonDSL.kt:27
               block.invoke(CompareContext@1): Unit at ComparisonDSL.kt:12
-                CollectionBehaviorsKt.listIteratorBehavior(CompareContext@1) at CollectionBehaviors.kt:13
-                  CollectionBehaviorsKt.listIteratorProperties(CompareContext@1) at CollectionBehaviors.kt:32
+                CollectionBehaviorsKt.listIteratorBehavior(compareProperty) at CollectionBehaviors.kt:13
+                  CollectionBehaviorsKt.listIteratorProperties(listIteratorBehavior) at CollectionBehaviors.kt:32
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:48
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasNext(): false at CollectionBehaviors.kt:48
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:49
-                      getter.invoke(EmptyIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      getter.invoke(BufferIterator@1): false at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): false at ComparisonDSL.kt:21
                         propertyEquals.hasPrevious(): false at CollectionBehaviors.kt:49
-                      AssertionsKt.assertEquals(false, false, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(false, false, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:50
-                      getter.invoke(EmptyIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      getter.invoke(BufferIterator@1): 0 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): 0 at ComparisonDSL.kt:21
                         propertyEquals.nextIndex(): 0 at CollectionBehaviors.kt:50
-                      AssertionsKt.assertEquals(0, 0, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(0, 0, message ➜ "") at ComparisonDSL.kt:21
                     CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:51
-                      getter.invoke(EmptyIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      getter.invoke(BufferIterator@1): -1 at ComparisonDSL.kt:21
+                      getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
                         propertyEquals.previousIndex(): -1 at CollectionBehaviors.kt:51
-                      AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+                      AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
                   listIteratorBehavior.getExpected(): EmptyIterator@1 at CollectionBehaviors.kt:34
                   EmptyIterator@1.hasNext(): false at CollectionBehaviors.kt:34
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:38
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.next(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:38
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
@@ -319,133 +319,133 @@ ImmutableListTest.empty() at :0
                   listIteratorBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:44
                     CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
                       expected.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:31
-                        getter.invoke(EmptyIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.expected): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:31
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:31
                       actual.invoke(): threw java.util.NoSuchElementException at ComparisonDSL.kt:32
-                        getter.invoke(BufferIterator@1): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
+                        getter.invoke(this$0.actual): threw java.util.NoSuchElementException at ComparisonDSL.kt:23
                           propertyFails.previous(): threw java.util.NoSuchElementException at CollectionBehaviors.kt:44
                       ResultKt.createFailure(NoSuchElementException@1): Result.Failure@1 at ComparisonDSL.kt:32
                       Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
                       AssertionsKt.checkResultIsFailure(null, Result.Failure@1): NoSuchElementException@1 at ComparisonDSL.kt:32
-                      TestUtilsJvmKt.assertTypeEquals(NoSuchElementException@1, NoSuchElementException@1) at ComparisonDSL.kt:39
+                      TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                         expected.getClass(): Class@1 at testUtilsJvm.kt:11
                         actual.getClass(): Class@1 at testUtilsJvm.kt:11
                         AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:15
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(-1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:15
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(-1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:15
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:16
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:16
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.listIterator(1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:16
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.getExpected(): EmptyList@1 at CollectionBehaviors.kt:18
-          propertyFailsWith(CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1@1, CollectionBehaviorsKt$$Lambda@1) at ComparisonDSL.kt:24
-            assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1@1) at ComparisonDSL.kt:25
+          propertyFailsWith(CollectionBehaviorsKt$listBehavior$$inlined$propertyFailsWith$1.INSTANCE, getter) at ComparisonDSL.kt:24
+            assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, exceptionPredicate) at ComparisonDSL.kt:25
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
                   propertyFailsWith.get(0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:21
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:25
                   propertyFailsWith.get(0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:21
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:35
-                invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
+              exceptionPredicate.invoke(expectedFail): true at ComparisonDSL.kt:35
+                invoke(p1): true at ComparisonDSL.kt:24
               AssertionsKt.assertTrue(true, "expected fail") at ComparisonDSL.kt:35
-              exceptionPredicate.invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:36
-                invoke(IndexOutOfBoundsException@1): true at ComparisonDSL.kt:24
+              exceptionPredicate.invoke(actualFail): true at ComparisonDSL.kt:36
+                invoke(p1): true at ComparisonDSL.kt:24
               AssertionsKt.assertTrue(true, "actual fail") at ComparisonDSL.kt:36
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:23
-            getter.invoke(EmptyList@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(EmptyList@1, 0): null at CollectionBehaviors.kt:23
-              CollectionsKt.indexOf(EmptyList@1, null): -1 at CollectionBehaviors.kt:23
-            getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:23
-              CollectionsKt.indexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:23
-            AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+            getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:23
+              CollectionsKt.indexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:23
+            getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:23
+              CollectionsKt.indexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:23
+            AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:24
-            getter.invoke(EmptyList@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(EmptyList@1, 0): null at CollectionBehaviors.kt:24
-              CollectionsKt.lastIndexOf(EmptyList@1, null): -1 at CollectionBehaviors.kt:24
-            getter.invoke(SmallPersistentVector@1): -1 at ComparisonDSL.kt:21
-              CollectionsKt.getOrNull(SmallPersistentVector@1, 0): null at CollectionBehaviors.kt:24
-              CollectionsKt.lastIndexOf(SmallPersistentVector@1, null): -1 at CollectionBehaviors.kt:24
-            AssertionsKt.assertEquals(-1, -1, "") at ComparisonDSL.kt:21
+            getter.invoke(this.expected): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:24
+              CollectionsKt.lastIndexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:24
+            getter.invoke(this.actual): -1 at ComparisonDSL.kt:21
+              CollectionsKt.getOrNull(propertyEquals, 0): null at CollectionBehaviors.kt:24
+              CollectionsKt.lastIndexOf(propertyEquals, null): -1 at CollectionBehaviors.kt:24
+            AssertionsKt.assertEquals(-1, -1, message ➜ "") at ComparisonDSL.kt:21
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:26
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(0, 1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:26
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(0, 1): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:26
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           listBehavior.propertyFails(CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:27
             CompareContext@1.assertFailEquals(CompareContext$$Lambda@1, CompareContext$$Lambda@1, null) at ComparisonDSL.kt:23
               expected.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:31
-                getter.invoke(EmptyList@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.expected): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(-1, 0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:27
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:31
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:31
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:31
               actual.invoke(): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:32
-                getter.invoke(SmallPersistentVector@1): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
+                getter.invoke(this$0.actual): threw java.lang.IndexOutOfBoundsException at ComparisonDSL.kt:23
                   propertyFails.subList(-1, 0): threw java.lang.IndexOutOfBoundsException at CollectionBehaviors.kt:27
               ResultKt.createFailure(IndexOutOfBoundsException@1): Result.Failure@1 at ComparisonDSL.kt:32
               Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ComparisonDSL.kt:32
               AssertionsKt.checkResultIsFailure(null, Result.Failure@1): IndexOutOfBoundsException@1 at ComparisonDSL.kt:32
-              TestUtilsJvmKt.assertTypeEquals(IndexOutOfBoundsException@1, IndexOutOfBoundsException@1) at ComparisonDSL.kt:39
+              TestUtilsJvmKt.assertTypeEquals(expectedFail, actualFail) at ComparisonDSL.kt:39
                 expected.getClass(): Class@1 at testUtilsJvm.kt:11
                 actual.getClass(): Class@1 at testUtilsJvm.kt:11
                 AssertionsKt.assertEquals$default(Class@1, Class@1, null, 4, null) at testUtilsJvm.kt:11
           CompareContext@1.propertyEquals("", CollectionBehaviorsKt$$Lambda@1) at CollectionBehaviors.kt:28
-            getter.invoke(EmptyList@1): EmptyList@1 at ComparisonDSL.kt:21
+            getter.invoke(this.expected): EmptyList@1 at ComparisonDSL.kt:21
               propertyEquals.subList(0, 0): EmptyList@1 at CollectionBehaviors.kt:28
-            getter.invoke(SmallPersistentVector@1): ImmutableList.SubList@1 at ComparisonDSL.kt:21
+            getter.invoke(this.actual): ImmutableList.SubList@1 at ComparisonDSL.kt:21
               propertyEquals.subList(0, 0): ImmutableList.SubList@1 at CollectionBehaviors.kt:28
-            AssertionsKt.assertEquals(EmptyList@1, ImmutableList.SubList@1, "") at ComparisonDSL.kt:21
+            AssertionsKt.assertEquals(EmptyList@1, ImmutableList.SubList@1, message ➜ "") at ComparisonDSL.kt:21

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_include_filter.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_include_filter.txt
@@ -15,4 +15,4 @@ ImmutableListTest.empty() at :0
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:28
   compareLists(EmptyList@1, empty1) at ImmutableListTest.kt:28
     ComparisonDSLKt.compare(expected, actual, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
-      CollectionBehaviorsKt.listBehavior($this$compare) at ImmutableListTest.kt:16
+      CollectionBehaviorsKt.listBehavior(compare) at ImmutableListTest.kt:16

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_include_filter.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.collections.immutable/tests.contract.list.ImmutableListTest_empty_with_include_filter.txt
@@ -2,9 +2,9 @@
 ImmutableListTest.empty() at :0
   ExtensionsKt.persistentListOf(): SmallPersistentVector@1 at ImmutableListTest.kt:20
   ExtensionsKt.persistentListOf(): SmallPersistentVector@1 at ImmutableListTest.kt:21
-  AssertionsKt.assertEquals$default(SmallPersistentVector@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:22
+  AssertionsKt.assertEquals$default(empty1, empty2, null, 4, null) at ImmutableListTest.kt:22
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:23
-  AssertionsKt.assertEquals$default(EmptyList@1, SmallPersistentVector@1, null, 4, null) at ImmutableListTest.kt:23
+  AssertionsKt.assertEquals$default(EmptyList@1, empty1, null, 4, null) at ImmutableListTest.kt:23
   AssertionsKt.assertTrue$default(true, null, 2, null) at ImmutableListTest.kt:24
   Reflection.getOrCreateKotlinClass(Class@1): KClassImpl@1 at ImmutableListTest.kt:26
   empty1.iterator(): BufferIterator@1 at ImmutableListTest.kt:26
@@ -13,6 +13,6 @@ ImmutableListTest.empty() at :0
   Result.constructor-impl(Result.Failure@1): Result.Failure@1 at ImmutableListTest.kt:26
   AssertionsKt.checkResultIsFailure(KClassImpl@1, null, Result.Failure@1): NoSuchElementException@1 at ImmutableListTest.kt:26
   CollectionsKt.emptyList(): EmptyList@1 at ImmutableListTest.kt:28
-  compareLists(EmptyList@1, SmallPersistentVector@1) at ImmutableListTest.kt:28
-    ComparisonDSLKt.compare(EmptyList@1, SmallPersistentVector@1, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
-      CollectionBehaviorsKt.listBehavior(CompareContext@1) at ImmutableListTest.kt:16
+  compareLists(EmptyList@1, empty1) at ImmutableListTest.kt:28
+    ComparisonDSLKt.compare(expected, actual, ImmutableListTest$$Lambda@1) at ImmutableListTest.kt:16
+      CollectionBehaviorsKt.listBehavior($this$compare) at ImmutableListTest.kt:16

--- a/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.ExecutorsTest_testDefaultDispatcherToExecutor.txt
+++ b/integration-test/trace-recorder/src/main/resources/integrationTestData/kotlinx.coroutines/kotlinx.coroutines.ExecutorsTest_testDefaultDispatcherToExecutor.txt
@@ -15,5 +15,5 @@ CoroutineScheduler.Worker.run(): <unfinished method> at :0
             checkThreadName("DefaultDispatcher") at ExecutorsTest.kt:58
               Thread.currentThread(): CoroutineScheduler.Worker@1 at ExecutorsTest.kt:11
               CoroutineScheduler.Worker@1.getName(): "DefaultDispatcher-worker-1" at ExecutorsTest.kt:11
-              StringsKt.startsWith$default("DefaultDispatcher-worker-1", "DefaultDispatcher", false, 2, null): true at ExecutorsTest.kt:12
+              StringsKt.startsWith$default(name ➜ "DefaultDispatcher-worker-1", prefix ➜ "DefaultDispatcher", false, 2, null): true at ExecutorsTest.kt:12
             latch.countDown() at ExecutorsTest.kt:59

--- a/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
@@ -341,12 +341,14 @@ private sealed class TraceWriterBase(
 
         val codeLocation = context.stackTrace(id)
         val accessPath = context.accessPath(id)
+        val argumentNames = context.arguments(id)
         // All strings only once. It will have duplications with class and method descriptors,
         // but size loss is negligible and this way is simpler
         val fileNameId = writeString(codeLocation.fileName)
         val classNameId = writeString(codeLocation.className)
         val methodNameId = writeString(codeLocation.methodName)
         val accessPathId = writeAccessPath(accessPath)
+        val argumentNamesIds = argumentNames?.map { writeAccessPath(it) }
 
         // Code location into data and position into index
         val position = currentDataPosition
@@ -357,6 +359,8 @@ private sealed class TraceWriterBase(
         data.writeInt(methodNameId)
         data.writeInt(codeLocation.lineNumber)
         data.writeInt(accessPathId)
+        data.writeInt(argumentNamesIds?.size ?: 0)
+        argumentNamesIds?.forEach { data.writeInt(it) }
         contextState.markCodeLocationSaved(id)
 
         writeIndexCell(ObjectKind.CODE_LOCATION, id, position, -1)

--- a/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/Serialization.kt
@@ -341,7 +341,7 @@ private sealed class TraceWriterBase(
 
         val codeLocation = context.stackTrace(id)
         val accessPath = context.accessPath(id)
-        val argumentNames = context.arguments(id)
+        val argumentNames = context.methodCallArgumentNames(id)
         // All strings only once. It will have duplications with class and method descriptors,
         // but size loss is negligible and this way is simpler
         val fileNameId = writeString(codeLocation.fileName)

--- a/trace/src/main/org/jetbrains/lincheck/trace/SerializationCommon.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/SerializationCommon.kt
@@ -34,7 +34,7 @@ import kotlin.math.exp
 
 internal const val TRACE_MAGIC : Long = 0x706e547124ee5f70L
 internal const val INDEX_MAGIC : Long = TRACE_MAGIC.inv()
-internal const val TRACE_VERSION : Long = 11
+internal const val TRACE_VERSION : Long = 12
 
 internal const val INDEX_FILENAME_SUFFIX = ".idx"
 internal const val PACK_FILENAME_SUFFIX = ".packedtrace"

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -165,7 +165,7 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
                 name.isNullOrEmpty() -> appendObject(parameter)
                 parameter?.isPrimitive == true -> {
                     append(name)
-                    append(" -> ")
+                    append(" ➜ ")
                     appendObject(parameter)
                 }
                 else -> append(name)

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -146,13 +146,21 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
     }
 
     protected fun TRAppendable.appendParameters(tracePoint: TRMethodCallTracePoint): TRAppendable {
-        check (tracePoint.parameters.size == tracePoint.argumentNames.size) { "Argument names size mismatch" }
+        // Due to trace compression codelocation can be shifted and therefore argument names do not match
+        // Without having paramter names it is impossible to match up
+        // In practise I have only seen `null` names for those kind of pais so probably doesn't really matter.
+        val argumentNames = if (tracePoint.parameters.size == tracePoint.argumentNames.size) {
+            tracePoint.argumentNames
+        } else {
+            List(tracePoint.parameters.size) { null }
+        }
+        
         tracePoint.parameters.forEachIndexed { i, parameter ->
             if (i != 0) {
                 appendSpecialSymbol(",")
                 append(" ")
             }
-            val name = tracePoint.argumentNames[i]
+            val name = argumentNames[i]
             when {
                 name == null -> appendObject(parameter)
                 parameter?.isPrimitive == true -> {

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -160,15 +160,15 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
                 appendSpecialSymbol(",")
                 append(" ")
             }
-            val name = argumentNames[i]?.toString()
+            val accessPath = argumentNames[i]
             when {
-                name.isNullOrEmpty() -> appendObject(parameter)
+                accessPath == null -> appendObject(parameter)
                 parameter?.isPrimitive == true -> {
-                    append(name)
-                    append(" ➜ ")
+                    appendAccessPath(accessPath)
+                    appendSpecialSymbol(READ_ACCESS_SYMBOL)
                     appendObject(parameter)
                 }
-                else -> append(name)
+                else -> appendAccessPath(accessPath)
             }
         }
         return this

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -160,15 +160,15 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
                 appendSpecialSymbol(",")
                 append(" ")
             }
-            val name = argumentNames[i]
+            val name = argumentNames[i]?.toString()
             when {
-                name == null -> appendObject(parameter)
+                name.isNullOrEmpty() -> appendObject(parameter)
                 parameter?.isPrimitive == true -> {
-                    append(name.toString())
+                    append(name)
                     append(" -> ")
                     appendObject(parameter)
                 }
-                else -> append(name.toString())
+                else -> append(name)
             }
         }
         return this

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -165,7 +165,9 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
                 accessPath == null -> appendObject(parameter)
                 parameter?.isPrimitive == true -> {
                     appendAccessPath(accessPath)
+                    append(" ")
                     appendSpecialSymbol(READ_ACCESS_SYMBOL)
+                    append(" ")
                     appendObject(parameter)
                 }
                 else -> appendAccessPath(accessPath)

--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -146,12 +146,22 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
     }
 
     protected fun TRAppendable.appendParameters(tracePoint: TRMethodCallTracePoint): TRAppendable {
+        check (tracePoint.parameters.size == tracePoint.argumentNames.size) { "Argument names size mismatch" }
         tracePoint.parameters.forEachIndexed { i, parameter ->
             if (i != 0) {
                 appendSpecialSymbol(",")
                 append(" ")
             }
-            appendObject(parameter)
+            val name = tracePoint.argumentNames[i]
+            when {
+                name == null -> appendObject(parameter)
+                parameter?.isPrimitive == true -> {
+                    append(name.toString())
+                    append(" -> ")
+                    appendObject(parameter)
+                }
+                else -> append(name.toString())
+            }
         }
         return this
     }

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.lincheck.trace
 
+import org.jetbrains.lincheck.descriptors.AccessPath
 import org.jetbrains.lincheck.descriptors.ClassDescriptor
 import org.jetbrains.lincheck.descriptors.CodeLocations
 import org.jetbrains.lincheck.descriptors.FieldDescriptor
@@ -83,6 +84,7 @@ class TRMethodCallTracePoint(
     // Shortcuts
     val className: String get() = methodDescriptor.className
     val methodName: String get() = methodDescriptor.methodName
+    val argumentNames: List<AccessPath?> get() = TRACE_CONTEXT.arguments(codeLocationId) ?: emptyList()
     val argumentTypes: List<Types.Type> get() = methodDescriptor.argumentTypes
     val returnType: Types.Type get() = methodDescriptor.returnType
 

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -84,7 +84,7 @@ class TRMethodCallTracePoint(
     // Shortcuts
     val className: String get() = methodDescriptor.className
     val methodName: String get() = methodDescriptor.methodName
-    val argumentNames: List<AccessPath?> get() = TRACE_CONTEXT.arguments(codeLocationId) ?: emptyList()
+    val argumentNames: List<AccessPath?> get() = TRACE_CONTEXT.methodCallArgumentNames(codeLocationId) ?: emptyList()
     val argumentTypes: List<Types.Type> get() = methodDescriptor.argumentTypes
     val returnType: Types.Type get() = methodDescriptor.returnType
 


### PR DESCRIPTION
see [DR-311](https://youtrack.jetbrains.com/issue/DR-311) Apply owner name trace prettifying to method arguments

- Serialize and deserialize codelocation arguments
- Show method call arguments in trace
  - For primitives `name -> value`
  - For objects `name`
  - When name is not available we default to original behaviour