### PR TITLE
Fix possible deadlock involving `Throwable`

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
@@ -266,9 +266,14 @@ class AnalysisProfile(val analyzeStdLib: Boolean) {
         // It is fine to inject the Lincheck analysis only into the
         // `java.util.*` ones, ignored the known atomic constructs.
         if (className.startsWith("java.")) {
+            // Instrument `Thread` to intercept thread events.
             if (className == "java.lang.Thread") return true
+            // Instrument `Throwable` as it has `synchronized` methods,
+            // and corresponding monitor events should be intercepted.
             if (className == "java.lang.Throwable") return true
+            // Instrument `java.util.concurrent` classes, except atomics.
             if (className.startsWith("java.util.concurrent.") && className.contains("Atomic")) return false
+            // Instrument `java.util` classes.
             if (className.startsWith("java.util.")) return true
             if (isInTraceDebuggerMode) {
                 if (className.startsWith("java.io.")) return true

--- a/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
@@ -267,6 +267,7 @@ class AnalysisProfile(val analyzeStdLib: Boolean) {
         // `java.util.*` ones, ignored the known atomic constructs.
         if (className.startsWith("java.")) {
             if (className == "java.lang.Thread") return true
+            if (className == "java.lang.Throwable") return true
             if (className.startsWith("java.util.concurrent.") && className.contains("Atomic")) return false
             if (className.startsWith("java.util.")) return true
             if (isInTraceDebuggerMode) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/trace/TraceFlattenPolicies.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/trace/TraceFlattenPolicies.kt
@@ -189,6 +189,7 @@ internal fun SingleThreadedTable<TraceNode>.extractPreExpandedNodes(flattenPolic
 private val TracePoint.isVirtual: Boolean get() =
     this.isThreadStart() || this.isThreadJoin()
 
+// trace points from `Throwable` methods are filter-out from the trace
 private val TracePoint.isThrowableTracePoint: Boolean get() {
     val codeLocation = (this as? CodeLocationTracePoint)?.codeLocation ?: return false
     val stackTraceElement = CodeLocations.stackTrace(codeLocation)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/trace/TraceFlattenPolicies.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/trace/TraceFlattenPolicies.kt
@@ -87,12 +87,12 @@ internal class VerboseTraceFlattenPolicy : TraceFlattenPolicy {
 internal class ShortTraceFlattenPolicy : TraceFlattenPolicy {
     override fun shouldIncludeThisNode(currentNode: TraceNode): Boolean = when (currentNode) {
         is EventNode -> with(currentNode) {
-            (!tracePoint.isVirtual && (
-                    isLast && tracePoint.isBlocking
-                            || tracePoint is SwitchEventTracePoint
-                            || tracePoint is ObstructionFreedomViolationExecutionAbortTracePoint
-                    )
-            ) || callDepth == 0
+            !tracePoint.isVirtual && (callDepth == 0 || (
+                    tracePoint.isBlocking && isLast ||
+                    tracePoint is SwitchEventTracePoint ||
+                    tracePoint is ObstructionFreedomViolationExecutionAbortTracePoint
+                )
+            )
         }
         is CallNode -> currentNode.tracePoint.wasSuspended || currentNode.isRootCall
         is ResultNode -> true
@@ -104,7 +104,9 @@ internal class ShortTraceFlattenPolicy : TraceFlattenPolicy {
         // if not verbose and atleast one child has no descendants and one other child has
         if (childDescendants.any { it.isNotEmpty() } && childDescendants.any { it.isEmpty() }) {
             // add all siblings
-            return childDescendants.mapIndexed { i, descendantList -> if (descendantList.isEmpty()) listOf(currentNode.children[i]) else descendantList }
+            return childDescendants.mapIndexed { i, descendantList ->
+                if (descendantList.isEmpty()) listOf(currentNode.children[i]) else descendantList
+            }
         }
         return childDescendants
     }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/ThrowableTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/gpmc/ThrowableTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2025 JetBrains s.r.o.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.jetbrains.kotlinx.lincheck_test.gpmc
+
+import org.jetbrains.lincheck.Lincheck
+import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent.ensureClassHierarchyIsTransformed
+import kotlin.concurrent.thread
+import org.junit.Test
+
+class ThrowableTest {
+
+    @Test(timeout = TIMEOUT)
+    fun throwableTest() = Lincheck.runConcurrentTest(invocations = 10_000) {
+        // `Throwable::addSuppressed` uses `ArrayList` internally to store suppressed exceptions.
+        // We need to ensure it is instrumented to trigger deadlock (see below).
+        ensureClassHierarchyIsTransformed(java.util.ArrayList::class.java)
+
+        val cause = Throwable("Cause")
+        val suppressed = Throwable("Suppressed")
+        val throwable = Throwable("Throwable", cause)
+
+        // `Throwable::addSuppressed` and `Throwable::cause` are both `synchronized` methods,
+        // meaning they acquire the monitor before executing the method body.
+        // We call them concurrently in an attempt to trigger deadlock.
+        //
+        // Without additional measures, the deadlock can happen in the following way:
+        // - thread 1 will acquire monitor on `addSuppressed`;
+        // - internally `addSuppressed` will call `ArrayList::add` method;
+        // - as this method is instrumented, it will call one of Lincheck injections;
+        // - this injection can decide to block the thread and switch to thread 2;
+        // - thread 2 will attempt to acquire monitor on `cause`;
+        // - this will deadlock with thread 1.
+        //
+        // To prevent this deadlock, Lincheck should ensure that the ` Throwable ` class is instrumented,
+        // and thus its monitor events are intercepted and could be handled by thread scheduler.
+        val t1 = thread {
+            throwable.addSuppressed(suppressed)
+        }
+        val t2 = thread {
+            throwable.cause?.also {
+                it.addSuppressed(suppressed) // do something
+            }
+        }
+
+        t1.join()
+        t2.join()
+    }
+
+    companion object {
+        @JvmField var throwable: Throwable? = null
+        @JvmField var counter: Int = 0
+    }
+
+}

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/MethodReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/representation/MethodReportingTest.kt
@@ -75,8 +75,8 @@ class MethodReportingTest {
         val log = StringBuilder().appendFailure(failure).toString()
         check("uselessIncrements(2) at" in log) { "increments in uselessIncrements method should be compressed" }
         check("inc(): " in log) { "treated as atomic methods should be reported" }
-        check("nonPrimitiveParameter(IllegalStateException#1)" in log)
-        check("nonPrimitiveResult(): IllegalStateException#2" in log)
+        check("nonPrimitiveParameter(IllegalStateException#2)" in log)
+        check("nonPrimitiveResult(): IllegalStateException#4" in log)
         checkTraceHasNoLincheckEvents(log)
     }
 }

--- a/src/jvm/test/resources/expected_logs/method_reporting.txt
+++ b/src/jvm/test/resources/expected_logs/method_reporting.txt
@@ -2,35 +2,34 @@
 | ------------------------------- |
 |    Thread 1    |    Thread 2    |
 | ------------------------------- |
-| operation(): 2 | operation(): 1 |
+| operation(): 2 | operation(): 3 |
 | ------------------------------- |
 
 The following interleaving leads to the error:
 | --------------------------------------------------------- |
 |    Thread 1    |                 Thread 2                 |
 | --------------------------------------------------------- |
-|                | operation(): 1                           |
+|                | operation(): 3                           |
 |                |   badMethod(): threw NotImplementedError |
 |                |   counter ➜ 0                            |
 |                |   counter = 1                            |
-|                |   counter ➜ 1                            |
 |                |   switch                                 |
 | operation(): 2 |                                          |
-|                |   counter = 2                            |
-|                |   result: 1                              |
+|                |   counter ➜ 3                            |
+|                |   counter = 4                            |
+|                |   result: 3                              |
 | --------------------------------------------------------- |
 
 Detailed trace:
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |                                                      Thread 1                                                       |                                                      Thread 2                                                       |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|                                                                                                                     | operation(): 1                                                                                                      |
+|                                                                                                                     | operation(): 3                                                                                                      |
 |                                                                                                                     |   badMethod(): threw NotImplementedError at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:95) |
 |                                                                                                                     |     useless ➜ 0 at CaughtExceptionMethodReportingTest.badMethod(MethodReportingTest.kt:103)                         |
 |                                                                                                                     |     useless = 1 at CaughtExceptionMethodReportingTest.badMethod(MethodReportingTest.kt:103)                         |
 |                                                                                                                     |   counter ➜ 0 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:97)                            |
 |                                                                                                                     |   counter = 1 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:97)                            |
-|                                                                                                                     |   counter ➜ 1 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
 |                                                                                                                     |   switch                                                                                                            |
 | operation(): 2                                                                                                      |                                                                                                                     |
 |   badMethod(): threw NotImplementedError at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:95) |                                                                                                                     |
@@ -41,6 +40,7 @@ Detailed trace:
 |   counter ➜ 2 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |                                                                                                                     |
 |   counter = 3 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |                                                                                                                     |
 |   result: 2                                                                                                         |                                                                                                                     |
-|                                                                                                                     |   counter = 2 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
-|                                                                                                                     |   result: 1                                                                                                         |
+|                                                                                                                     |   counter ➜ 3 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
+|                                                                                                                     |   counter = 4 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
+|                                                                                                                     |   result: 3                                                                                                         |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/jvm/test/resources/expected_logs/method_reporting_trace_debugger.txt
+++ b/src/jvm/test/resources/expected_logs/method_reporting_trace_debugger.txt
@@ -2,35 +2,34 @@
 | ------------------------------- |
 |    Thread 1    |    Thread 2    |
 | ------------------------------- |
-| operation(): 2 | operation(): 1 |
+| operation(): 2 | operation(): 3 |
 | ------------------------------- |
 
 The following interleaving leads to the error:
 | --------------------------------------------------------- |
 |    Thread 1    |                 Thread 2                 |
 | --------------------------------------------------------- |
-|                | operation(): 1                           |
+|                | operation(): 3                           |
 |                |   badMethod(): threw NotImplementedError |
 |                |   counter ➜ 0                            |
 |                |   counter = 1                            |
-|                |   counter ➜ 1                            |
 |                |   switch                                 |
 | operation(): 2 |                                          |
-|                |   counter = 2                            |
-|                |   result: 1                              |
+|                |   counter ➜ 3                            |
+|                |   counter = 4                            |
+|                |   result: 3                              |
 | --------------------------------------------------------- |
 
 Detailed trace:
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |                                                      Thread 1                                                       |                                                      Thread 2                                                       |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|                                                                                                                     | operation(): 1                                                                                                      |
+|                                                                                                                     | operation(): 3                                                                                                      |
 |                                                                                                                     |   badMethod(): threw NotImplementedError at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:95) |
 |                                                                                                                     |     useless ➜ 0 at CaughtExceptionMethodReportingTest.badMethod(MethodReportingTest.kt:103)                         |
 |                                                                                                                     |     useless = 1 at CaughtExceptionMethodReportingTest.badMethod(MethodReportingTest.kt:103)                         |
 |                                                                                                                     |   counter ➜ 0 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:97)                            |
 |                                                                                                                     |   counter = 1 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:97)                            |
-|                                                                                                                     |   counter ➜ 1 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
 |                                                                                                                     |   switch                                                                                                            |
 | operation(): 2                                                                                                      |                                                                                                                     |
 |   badMethod(): threw NotImplementedError at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:95) |                                                                                                                     |
@@ -41,6 +40,7 @@ Detailed trace:
 |   counter ➜ 2 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |                                                                                                                     |
 |   counter = 3 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |                                                                                                                     |
 |   result: 2                                                                                                         |                                                                                                                     |
-|                                                                                                                     |   counter = 2 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
-|                                                                                                                     |   result: 1                                                                                                         |
+|                                                                                                                     |   counter ➜ 3 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
+|                                                                                                                     |   counter = 4 at CaughtExceptionMethodReportingTest.operation(MethodReportingTest.kt:98)                            |
+|                                                                                                                     |   result: 3                                                                                                         |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
TLDR: `Throwable` has `suspend` methods and thus should be instrumented by Licnheck to intercept monitor events and guarantee correct thread scheduling.

Consider `synchronzied` methods `Throwable::addSuppressed` and `Throwable::cause`.
Consider a scenario when these two methods are called concurrently.

Without additional measures, the deadlock can happen in the following way:
- thread 1 will acquire monitor on `addSuppressed`;
- internally `addSuppressed` will call `ArrayList::add` method;
- this method could be instrumented, and if so it will call one of Lincheck injections;
- this injection can decide to block the thread and switch to thread 2;
- thread 2 will attempt to acquire monitor on `cause`;
- this will deadlock with thread 1.

To prevent this deadlock, Lincheck should ensure that the `Throwable` class is instrumented, and thus its monitor events are intercepted and could be handled by thread scheduler.

The original problem was reported by `compose-hot-reload` developers, as it was affecting their Lincheck tests.