### PR TITLE
Call `Thread.stop` with reflection.

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -204,11 +204,10 @@ internal class FixedActiveThreadsExecutor(private val testName: String, private 
     override fun close() {
         shutdown()
         // Thread.stop() throws UnsupportedOperationException
-        // starting from Java 20.
+        // starting from Java 20 and is removed in Java 26.
         if (hangDetected && majorJavaVersion < 20) {
-            @Suppress("DEPRECATION", "removal")
             threads.forEach {
-                it.stop()
+                it::class.java.getMethod("stop").invoke(it)
             }
         }
     }


### PR DESCRIPTION
This allows Lincheck to compile against Java 26+, when `Thread.stop`
will be removed entirely:

https://bugs.openjdk.org/browse/JDK-8368226

See also previous issues about `Thread.stop`, such as:

- https://github.com/JetBrains/lincheck/issues/210
- https://github.com/JetBrains/lincheck/pull/214
- https://github.com/JetBrains/lincheck/pull/271
