### PR TITLE
Disable global threads descriptors creation on the trace end

### DIFF
--- a/bootstrap/src/sun/nio/ch/lincheck/Injections.java
+++ b/bootstrap/src/sun/nio/ch/lincheck/Injections.java
@@ -84,6 +84,13 @@ public class Injections {
     }
 
     /**
+     * Disables tracking of all threads.
+     */
+    public static void disableGlobalThreadsTracking() {
+        globalEventTracker = null;
+    }
+
+    /**
      * Enables analysis for the current thread.
     */
     public static void enableAnalysis() {

--- a/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/AnalysisSections.kt
@@ -168,7 +168,7 @@ inline fun <R> runInsideIgnoredSection(block: () -> R): R {
  * @return result of the [block] invocation or `null` if the analysis is disabled for the current thread.
  */
 inline fun <R> runInsideInjectedCode(block: () -> R): R? {
-    val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: return block()
+    val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: return null
 
     // General synchronization schema here is as follows:
     //   * This thread sets the flag, that it will now run some code from instrumentation (e.g. method from `EventTracker`)

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
@@ -68,8 +68,8 @@ object TraceRecorder {
         // this method does not need 'runInsideIgnoredSection' because we do not call instrumented code
         // and 'eventTracker.finishAndDumpTrace()' is called after analysis is disabled
         val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: return
-        desc.removeAsRootDescriptor()
         Injections.disableGlobalThreadsTracking()
+        desc.removeAsRootDescriptor()
         val currentTracker = desc.eventTracker
         if (currentTracker == eventTracker) {
             desc.disableAnalysis()

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
@@ -69,6 +69,7 @@ object TraceRecorder {
         // and 'eventTracker.finishAndDumpTrace()' is called after analysis is disabled
         val desc = ThreadDescriptor.getCurrentThreadDescriptor() ?: return
         desc.removeAsRootDescriptor()
+        Injections.disableGlobalThreadsTracking()
         val currentTracker = desc.eventTracker
         if (currentTracker == eventTracker) {
             desc.disableAnalysis()


### PR DESCRIPTION
When the main thread finishes and disables analysis in all other running threads, we need to ensure that we do not register any more threads in `EventTracker::registerRunningThread`