### PR TITLE
Manually pop method calls (not tracked from start) which completion was not tracked during execution

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TRTracePointPrinters.kt
@@ -201,6 +201,9 @@ abstract class AbstractTRMethodCallTracePointPrinter() {
         } else if (tracePoint.isMethodUnfinished()) {
             append(": ")
             appendSpecialSymbol(UNFINISHED_METHOD_RESULT_SYMBOL)
+        } else if (tracePoint.isMethodResultUntracked()) {
+            append(": ")
+            appendSpecialSymbol(UNTRACKED_METHOD_RESULT_SYMBOL)
         } else if (tracePoint.result != TR_OBJECT_VOID) {
             append(": ")
             appendObject(tracePoint.result)

--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -155,6 +155,12 @@ class TRMethodCallTracePoint(
         result == TR_OBJECT_UNFINISHED_METHOD_RESULT
 
     /**
+     * Returns `true` if method completion was not tracked and its return value is unknown, `false` otherwise.
+     */
+    fun isMethodResultUntracked(): Boolean =
+        result == TR_OBJECT_UNTRACKED_METHOD_RESULT
+
+    /**
      * @return `true` if tracing of the thread was started after this method call and there some missing tracepoints, `false` otherwise.
      */
     fun isMethodIncomplete(): Boolean =
@@ -542,7 +548,9 @@ const val TR_OBJECT_VOID_CLASSNAME = -2
 val TR_OBJECT_VOID = TRObject(TR_OBJECT_VOID_CLASSNAME, 0, null)
 
 const val UNFINISHED_METHOD_RESULT_SYMBOL = "<unfinished method>"
+const val UNTRACKED_METHOD_RESULT_SYMBOL = "<untracked result>"
 val TR_OBJECT_UNFINISHED_METHOD_RESULT = TRObject(TR_OBJECT_P_STRING, 0, UNFINISHED_METHOD_RESULT_SYMBOL)
+val TR_OBJECT_UNTRACKED_METHOD_RESULT = TRObject(TR_OBJECT_P_STRING, 0, UNTRACKED_METHOD_RESULT_SYMBOL)
 
 const val TR_OBJECT_P_BYTE = TR_OBJECT_VOID_CLASSNAME - 1
 const val TR_OBJECT_P_SHORT = TR_OBJECT_P_BYTE - 1


### PR DESCRIPTION
I have seen such problem on 3 tests from ktor
```
runKtorTest[207: io.ktor.client.engine.cio.CIORequestTest::longHeadersTest]
runKtorTest[208: io.ktor.client.engine.cio.CIORequestTest::testParameterWithoutPath]
runKtorTest[210: io.ktor.client.engine.cio.CIORequestTest::testInetAddressRetrievedOnce]
```
