### PR TITLE
Add option to enable "old" threading recording.

### DIFF
--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorder.kt
@@ -48,7 +48,7 @@ object TraceRecorder {
         format: String?,
         formatOption: String?,
         pack: Boolean,
-        traceAllThreads: Boolean
+        trackAllThreads: Boolean
     ) {
         // Set signal "void" object from Injections for better text output
         INJECTIONS_VOID_OBJECT = Injections.VOID_RESULT
@@ -69,7 +69,7 @@ object TraceRecorder {
 
         eventTracker!!.enableTrace()
         desc.enableAnalysis()
-        if (traceAllThreads) {
+        if (trackAllThreads) {
             Injections.enableGlobalThreadsTracking(eventTracker)
         }
     }

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderAgent.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderAgent.kt
@@ -32,7 +32,7 @@ internal object TraceRecorderAgent {
     const val ARGUMENT_FORMAT = "format"
     const val ARGUMENT_FOPTION = "formatOption"
     const val ARGUMENT_PACK = "pack"
-    const val ARGUMENT_TRACE_ALL_THREADS = "traceAllThreads"
+    const val ARGUMENT_TRACK_ALL_THREADS = "trackAllThreads"
 
     // Allowed additional arguments
     private val ADDITIONAL_ARGS = listOf(
@@ -42,7 +42,7 @@ internal object TraceRecorderAgent {
         ARGUMENT_EXCLUDE,
         ARGUMENT_LAZY,
         ARGUMENT_PACK,
-        ARGUMENT_TRACE_ALL_THREADS,
+        ARGUMENT_TRACK_ALL_THREADS,
     )
 
     @JvmStatic

--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
@@ -39,7 +39,7 @@ internal object TraceRecorderInjections {
             format = TraceAgentParameters.getArg(TraceRecorderAgent.ARGUMENT_FORMAT),
             formatOption = TraceAgentParameters.getArg(TraceRecorderAgent.ARGUMENT_FOPTION),
             pack = (TraceAgentParameters.getArg(TraceRecorderAgent.ARGUMENT_PACK) ?: "true").toBoolean(),
-            traceAllThreads = (TraceAgentParameters.getArg(TraceRecorderAgent.ARGUMENT_TRACE_ALL_THREADS) ?: "true").toBoolean(),
+            trackAllThreads = (TraceAgentParameters.getArg(TraceRecorderAgent.ARGUMENT_TRACK_ALL_THREADS) ?: "true").toBoolean(),
         )
     }
 


### PR DESCRIPTION
Add option not to trace all "old" threads (as was before), useful for parallel tests execution.