### PR TITLE
Allow of attaching trace recorder to unknown class.

### DIFF
--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
@@ -13,6 +13,7 @@ package org.jetbrains.lincheck.trace.recorder
 import org.jetbrains.lincheck.jvm.agent.TraceAgentParameters
 import org.jetbrains.lincheck.jvm.agent.InstrumentationMode
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
+import org.jetbrains.lincheck.util.Logger
 
 internal object TraceRecorderInjections {
     // Method `stopTraceRecorderAndDumpTrace` is called in the finally block of the wrapped test:
@@ -27,7 +28,12 @@ internal object TraceRecorderInjections {
         // Must be first or classes will not be found
         LincheckJavaAgent.install(InstrumentationMode.TRACE_RECORDING)
         // Retransform classes for event tracking
-        LincheckJavaAgent.ensureClassHierarchyIsTransformed(TraceAgentParameters.classUnderTraceDebugging)
+        // It is Ok to don't find class here, maybe agent was added too broadly
+        try {
+            LincheckJavaAgent.ensureClassHierarchyIsTransformed(TraceAgentParameters.classUnderTraceDebugging)
+        } catch (_: ClassNotFoundException) {
+            Logger.warn { "Cannot transform requested class ${TraceAgentParameters.classUnderTraceDebugging}: Class not found" }
+        }
     }
 
     @JvmStatic


### PR DESCRIPTION
Sometimes only convenient way to attach Trace Recorder agent is to pass arguments to several JVM instances (i.e. via gradle script).

Some of these instances can don't have target class, and it is Ok in such cases.

Don't fail if target class is not found.