### PR TITLE
Revert removal of `alreadyStopped` flag

### DIFF
--- a/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
+++ b/trace-recorder/src/main/org/jetbrains/lincheck/trace/recorder/TraceRecorderInjections.kt
@@ -15,6 +15,12 @@ import org.jetbrains.lincheck.jvm.agent.InstrumentationMode
 import org.jetbrains.lincheck.jvm.agent.LincheckJavaAgent
 
 internal object TraceRecorderInjections {
+    // Method `stopTraceRecorderAndDumpTrace` is called in the finally block of the wrapped test:
+    // try { startTraceRecorder(); test() } finally { stopTraceRecorderAndDumpTrace() }
+    // and the way try-finally block is instrumented allows for double call of `stopTraceRecorderAndDumpTrace`
+    // in case if exception is thrown from it.
+    // We want to disallow that explicitly, and the simplest way to do that is to add a flag.
+    private var alreadyStopped: Boolean = false
 
     @JvmStatic
     fun prepareTraceRecorder() {
@@ -39,6 +45,7 @@ internal object TraceRecorderInjections {
 
     @JvmStatic
     fun stopTraceRecorderAndDumpTrace() {
+        if (alreadyStopped) return
         TraceRecorder.finishTraceAndDumpResults()
     }
 }


### PR DESCRIPTION
Insertion of `TraceDebuggerInjections::startTraceRecorder` method call still allows for its double invocation even though there was an attempt to fix the instrumentation in #855.

I revert that change, so that when exception is thrown from the `startTraceRecorder` we see it logged in the console instead of some unrelated error caused by second invocation of `startTraceRecorder` 