### PR TITLE
Fix problem with targeting methods where source files are not available

### DIFF
--- a/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/TraceAgentTransformer.kt
+++ b/jvm-agent/src/main/org/jetbrains/lincheck/jvm/agent/TraceAgentTransformer.kt
@@ -115,7 +115,7 @@ private class TraceAgentClassVisitor(
 
     override fun visitSource(source: String?, debug: String?) {
         super.visitSource(source, debug)
-        fileName = source ?: ""
+        fileName = source ?: "<unknown>"
     }
 
     override fun visitMethod(


### PR DESCRIPTION
We would like to target a method from `com.intellij.rt.junit.JUnitStarter` to allow tested logic in spring project to appear in trace. This class however, does not have source files available. This fixes that problem.