### PR TITLE
Make sure that `Descriptor.Key` does not depend on any information from `TraceContext`

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/descriptors/Descriptors.kt
+++ b/common/src/main/org/jetbrains/lincheck/descriptors/Descriptors.kt
@@ -27,6 +27,11 @@ interface Descriptor {
     abstract class Key
 
     val id: Int
+
+    /**
+     * *Note*: [key] field cannot depend on any information from [TraceContext], because this field should be
+     * available for accessing during context building, so its value must be accessible with incomplete trace context as well.
+     */
     val key: Key
 
     companion object {


### PR DESCRIPTION
This PR fixes a bug:
`Descriptor.Key` field cannot depend on any information from TraceContext, because this field should be available for accessing during context building, so its value must be accessible with incomplete trace context as well.