### PR TITLE
Bugfix loop iterations saving

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/TraceRecorderTracePoints.kt
@@ -165,7 +165,7 @@ sealed class TRContainerTracePoint(
         parentTracePoint = parent
     }
 
-    internal open fun addChildAddress(address: Long) {
+    internal fun addChildAddress(address: Long) {
         childrenAddresses.add(address)
         children.add(null)
     }
@@ -178,7 +178,7 @@ sealed class TRContainerTracePoint(
         }
     }
 
-    open fun addChild(child: TRTracePoint, address: Long = -1) {
+    fun addChild(child: TRTracePoint, address: Long = -1) {
         childrenAddresses.add(address)
         children.add(child)
 
@@ -436,16 +436,8 @@ class TRLoopTracePoint(
     var iterations: Int = 0
         private set
 
-    override fun addChild(child: TRTracePoint, address: Long) {
-        require(child is TRLoopIterationTracePoint) { "Only loop iterations can be children of loops" }
-        super.addChild(child, address)
-        iterations++
-    }
-
-    override fun addChildAddress(address: Long) {
-        super.addChildAddress(address)
-        // We believe that it is address of iteration
-        iterations++
+    fun incrementIterations(): Int {
+        return iterations++
     }
 
     override fun save(out: TraceWriter) {

--- a/trace/src/main/org/jetbrains/lincheck/trace/diff/TraceDiff.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/diff/TraceDiff.kt
@@ -463,7 +463,7 @@ private fun copyTracepointSubtree(
 ) {
     val outputPoint = cloner(point)
     outputPoint.diffStatus = diffStatus
-    outputParent?.addChild(outputPoint)
+    addCopiedChild(outputParent, outputPoint)
     outputPoint.save(output)
     // Save all children recursively, if needed
     if (outputPoint is TRContainerTracePoint && point is TRContainerTracePoint) {
@@ -477,6 +477,13 @@ private fun copyTracepointSubtree(
         // Free memory
         point.unloadAllChildren()
         outputPoint.unloadAllChildren()
+    }
+}
+
+private fun addCopiedChild(parent: TRContainerTracePoint?, child: TRTracePoint) {
+    parent?.addChild(child)
+    if (parent is TRLoopTracePoint) {
+        parent.incrementIterations()
     }
 }
 
@@ -504,7 +511,7 @@ private fun diffTracepointSubtree(
                     // "Remove" left and make it without children
                     val oldPoint = cloner.cloneLeftTracePoint(lp, rp.eventId)
                     oldPoint.diffStatus = DiffStatus.EDITED_OLD
-                    outputRoot?.addChild(oldPoint)
+                    addCopiedChild(outputRoot, oldPoint)
                     oldPoint.save(output)
                     if (oldPoint is TRContainerTracePoint) {
                         oldPoint.saveFooter(output)
@@ -513,7 +520,7 @@ private fun diffTracepointSubtree(
                 // Copy tracepoint itself from right subtree for now
                 val outputPoint = cloner.cloneRightTracePoint(rp, lp.eventId)
                 outputPoint.diffStatus = if (strict) DiffStatus.UNCHANGED else DiffStatus.EDITED_NEW
-                outputRoot?.addChild(outputPoint)
+                addCopiedChild(outputRoot, outputPoint)
                 outputPoint.save(output)
 
                 // Maybe, we need to go deeper?

--- a/tracer/src/main/org/jetbrains/lincheck/tracer/TraceCollectingEventTracker.kt
+++ b/tracer/src/main/org/jetbrains/lincheck/tracer/TraceCollectingEventTracker.kt
@@ -99,6 +99,7 @@ private class ThreadData(
         val frame = stack.last()
         val loop = frame.loopStack.last()
         loop.iterations.add(loopIterationTracePoint)
+        loop.header.incrementIterations()
     }
 
     fun exitLoop() {


### PR DESCRIPTION
- partly revert changes from #978

In #978 loop iteration management was moved to `addChild` function. But streaming trace collecting does not use this function, as it does not need to keep the tree in-memory. As a result of this, loop iteration was left `0`. In  combination with trace compression rule that removes 0-iteration loop nodes, it resulted in all loop nodes being removed from the trace in Trace Recorder plugin UI. 