### PR TITLE
Fix EventStructure object tracker

### DIFF
--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1371,9 +1371,7 @@ internal abstract class ManagedStrategy(
         if (fieldDescriptor.isStatic && value !== null && !value.isImmutable) {
             LincheckInstrumentation.ensureClassHierarchyIsTransformed(value.javaClass)
         }
-        if (value !== null && objectTracker.shouldTrackObject(value)) {
-            objectTracker.registerObjectIfAbsent(value)
-        }
+        // TODO: add assertion that the value is registered in the object tracker if it needs toj
         if (collectTrace) {
             val valueRepresentation = objectTracker.getObjectRepresentation(value)
             val typeRepresentation = objectFqTypeName(value)
@@ -1402,9 +1400,7 @@ internal abstract class ManagedStrategy(
         index: Int,
         value: Any?
     ) = threadDescriptor.runInsideIgnoredSection {
-        if (value != null && objectTracker.shouldTrackObject(value)) {
-            objectTracker.registerObjectIfAbsent(value)
-        }
+        // TODO: add assertion that the value is registered in the object tracker if it needs to (but I guess that it could break some other object tracker stuff)
         if (collectTrace) {
             val eventId = getNextEventId()
             val threadId = threadScheduler.getCurrentThreadId()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -1371,7 +1371,10 @@ internal abstract class ManagedStrategy(
         if (fieldDescriptor.isStatic && value !== null && !value.isImmutable) {
             LincheckInstrumentation.ensureClassHierarchyIsTransformed(value.javaClass)
         }
-        // TODO: add assertion that the value is registered in the object tracker if it needs toj
+        if (value !== null && objectTracker.shouldTrackObject(value)) {
+            objectTracker.registerObjectIfAbsent(value)
+        }
+
         if (collectTrace) {
             val valueRepresentation = objectTracker.getObjectRepresentation(value)
             val typeRepresentation = objectFqTypeName(value)
@@ -1400,7 +1403,9 @@ internal abstract class ManagedStrategy(
         index: Int,
         value: Any?
     ) = threadDescriptor.runInsideIgnoredSection {
-        // TODO: add assertion that the value is registered in the object tracker if it needs to (but I guess that it could break some other object tracker stuff)
+        if (value !== null && objectTracker.shouldTrackObject(value)) {
+            objectTracker.registerObjectIfAbsent(value)
+        }
         if (collectTrace) {
             val eventId = getNextEventId()
             val threadId = threadScheduler.getCurrentThreadId()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -174,13 +174,16 @@ typealias ObjectNumber = Int
  * @property objectNumber A unique serial number for the object.
  * @property objectHashCode The identity hash code of the object.
  * @property objectDisplayNumber The number used in string representation of the object.
- * @property objectReference A weak reference to the associated object.
+ * @property objectWeakReference A weak reference to the associated object.
+ * @property objectStrongReference An optional strong reference to the associated object.
+ *      It exists solely to prevent garbage collection of the tracked object
  */
 open class ObjectEntry(
     val objectNumber: Int,
     val objectHashCode: Int,
     val objectDisplayNumber: Int,
-    val objectReference: WeakReference<Any>,
+    val objectWeakReference: WeakReference<Any>,
+    val objectStrongReference: Any? = null,
 )
 
 /**
@@ -239,7 +242,7 @@ fun ObjectTracker.getObjectDisplayNumber(obj: Any): Int =
 internal fun ObjectTracker.enumerateAllObjects(): Map<Any, Int> {
     val objectNumberMap = hashMapOf<Any, Int>()
     for (objectEntry in enumerateObjectEntries()) {
-        val obj = objectEntry.objectReference.get() ?: continue
+        val obj = objectEntry.objectWeakReference.get() ?: continue
         objectNumberMap[obj] = objectEntry.objectDisplayNumber
     }
     return objectNumberMap
@@ -447,11 +450,13 @@ open class BaseObjectTracker(
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
+        obj: Any,
         kind: ObjectKind = ObjectKind.NEW,
     ): ObjectEntry {
-        return ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
+        return ObjectEntry(objNumber, objHashCode, objDisplayNumber, createWeakReference(obj))
     }
+
+    protected fun createWeakReference(obj: Any): WeakReference<Any> = WeakReference(obj, referenceQueue)
 
     protected fun computeObjectDisplayNumber(obj: Any): Int {
         val classRepr = obj.getSpecialClassNameRepresentation()
@@ -482,7 +487,7 @@ open class BaseObjectTracker(
             objNumber = ++objectCounter,
             objHashCode = System.identityHashCode(obj),
             objDisplayNumber = computeObjectDisplayNumber(obj),
-            objReference = WeakIdentityReference(obj, referenceQueue),
+            obj = obj,
             kind = kind,
         )
         objectIndex.updateInplace(entry.objectHashCode, default = mutableListOf()) {
@@ -525,7 +530,7 @@ open class BaseObjectTracker(
     override operator fun get(obj: Any?): ObjectEntry? {
         val objHashCode = System.identityHashCode(obj)
         val entries = getEntries(objHashCode) ?: return null
-        return entries.find { it.objectReference.get() === obj }
+        return entries.find { it.objectWeakReference.get() === obj }
     }
 
     override fun enumerateObjectEntries(): Sequence<ObjectEntry> =
@@ -568,7 +573,7 @@ open class BaseObjectTracker(
      */
     private fun MutableList<ObjectEntry>.cleanup() {
         retainAll {
-            val isAlive = (it.objectReference.get() != null)
+            val isAlive = (it.objectWeakReference.get() != null)
             if (!isAlive) {
                 objectNumberIndex.remove(it.objectNumber)
             }
@@ -579,7 +584,7 @@ open class BaseObjectTracker(
     // For debugging
     override fun toString(): String {
         return "${objectIndex.entries.map { idToEntries -> 
-            "#${idToEntries.key} -> [${idToEntries.value.map { objectEntry -> objectEntry.objectReference.get() }.joinToString()}]" 
+            "#${idToEntries.key} -> [${idToEntries.value.map { objectEntry -> objectEntry.objectWeakReference.get() }.joinToString()}]" 
         }.joinToString("\n")}"
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -44,6 +44,15 @@ import kotlin.reflect.KClass
 interface ObjectTracker {
 
     /**
+     * Represents the kind of object being tracked.
+     *
+     * Can be either:
+     *   - [NEW] - Newly created object registered in the tracker.
+     *   - [EXTERNAL] - External object registered in the tracker.
+     */
+    enum class ObjectKind { NEW, EXTERNAL }
+
+    /**
      * Registers a thread with the given id in the object tracker.
      *
      * @param threadId the id of the thread to register.
@@ -175,6 +184,7 @@ typealias ObjectNumber = Int
  * @property objectHashCode The identity hash code of the object.
  * @property objectDisplayNumber The number used in string representation of the object.
  * @property objectWeakReference A weak reference to the associated object.
+ * @property objectKind Whether the object is an external or a new object
  * @property objectStrongReference An optional strong reference to the associated object.
  *      It exists solely to prevent garbage collection of the tracked object
  */
@@ -182,6 +192,7 @@ open class ObjectEntry(
     val objectNumber: Int,
     val objectHashCode: Int,
     val objectDisplayNumber: Int,
+    val objectKind: ObjectTracker.ObjectKind,
     val objectWeakReference: WeakReference<Any>,
     val objectStrongReference: Any? = null,
 )
@@ -433,30 +444,6 @@ open class BaseObjectTracker(
     private val perClassObjectNumeration = WeakHashMap<Class<*>, Int>()
 
     /**
-     * Represents the kind of object being tracked.
-     *
-     * Can be either:
-     *   - [NEW] - Newly created object registered in the tracker.
-     *   - [EXTERNAL] - External object registered in the tracker.
-     */
-    protected enum class ObjectKind { NEW, EXTERNAL }
-
-    protected open class BaseObjectEntry(
-        objNumber: Int,
-        objHashCode: Int,
-        objDisplayNumber: Int,
-        objWeakReference: WeakReference<Any>,
-        objStrongReference: Any?,
-        val objKind: ObjectKind
-    ) : ObjectEntry(
-        objNumber,
-        objHashCode,
-        objDisplayNumber,
-        objWeakReference,
-        objStrongReference
-    ) {}
-
-    /**
      * Method responsible for creating an instance of [ObjectEntry] for tracking an object in the system.
      * Derived classes may override this method to create their own customized instances of [ObjectEntry]
      * with additional meta-data.
@@ -466,15 +453,15 @@ open class BaseObjectTracker(
         objHashCode: Int,
         objDisplayNumber: Int,
         obj: Any,
-        kind: ObjectKind = ObjectKind.NEW,
+        kind: ObjectTracker.ObjectKind = ObjectTracker.ObjectKind.NEW,
     ): ObjectEntry {
-        return BaseObjectEntry(
+        return ObjectEntry(
             objNumber,
             objHashCode,
             objDisplayNumber,
-            objWeakReference = createWeakReference(obj),
-            objStrongReference = null,
-            objKind = kind,
+            objectKind = kind,
+            objectWeakReference = createWeakReference(obj),
+            objectStrongReference = null,
         )
     }
 
@@ -495,13 +482,13 @@ open class BaseObjectTracker(
         if (shouldOverwriteNewObjectsIdentityHashCode) {
             overwriteIdentityHashCode(obj)
         }
-        return registerObject(ObjectKind.NEW, obj)
+        return registerObject(ObjectTracker.ObjectKind.NEW, obj)
     }
 
     override fun registerExternalObject(obj: Any): ObjectEntry =
-        registerObject(ObjectKind.EXTERNAL, obj)
+        registerObject(ObjectTracker.ObjectKind.EXTERNAL, obj)
 
-    private fun registerObject(kind: ObjectKind, obj: Any): ObjectEntry {
+    private fun registerObject(kind: ObjectTracker.ObjectKind, obj: Any): ObjectEntry {
         check(!obj.isPrimitive)
         check(obj.isImmutable implies shouldTrackImmutableValues)
         cleanup()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -575,6 +575,10 @@ open class BaseObjectTracker(
             return@retainAll isAlive
         }
     }
+    // For debugging
+    override fun toString(): String {
+        return "${objectIndex.entries.map { entry -> "#${entry.key} -> [${entry.value.map { foo -> foo.objectReference.get() }.joinToString()}]" }.joinToString("\n")}"
+    }
 
     private fun overwriteIdentityHashCode(obj: Any) {
         // Zero out the identity hash code in the object header to ensure deterministic behavior.

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -575,9 +575,12 @@ open class BaseObjectTracker(
             return@retainAll isAlive
         }
     }
+
     // For debugging
     override fun toString(): String {
-        return "${objectIndex.entries.map { entry -> "#${entry.key} -> [${entry.value.map { foo -> foo.objectReference.get() }.joinToString()}]" }.joinToString("\n")}"
+        return "${objectIndex.entries.map { idToEntries -> 
+            "#${idToEntries.key} -> [${idToEntries.value.map { objectEntry -> objectEntry.objectReference.get() }.joinToString()}]" 
+        }.joinToString("\n")}"
     }
 
     private fun overwriteIdentityHashCode(obj: Any) {

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -478,7 +478,7 @@ open class BaseObjectTracker(
         )
     }
 
-    protected fun createWeakReference(obj: Any): WeakReference<Any> = WeakReference(obj, referenceQueue)
+    protected fun createWeakReference(obj: Any): WeakReference<Any> = WeakIdentityReference(obj, referenceQueue)
 
     protected fun computeObjectDisplayNumber(obj: Any): Int {
         val classRepr = obj.getSpecialClassNameRepresentation()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -441,6 +441,21 @@ open class BaseObjectTracker(
      */
     protected enum class ObjectKind { NEW, EXTERNAL }
 
+    protected open class BaseObjectEntry(
+        objNumber: Int,
+        objHashCode: Int,
+        objDisplayNumber: Int,
+        objWeakReference: WeakReference<Any>,
+        objStrongReference: Any?,
+        val objKind: ObjectKind
+    ) : ObjectEntry(
+        objNumber,
+        objHashCode,
+        objDisplayNumber,
+        objWeakReference,
+        objStrongReference
+    ) {}
+
     /**
      * Method responsible for creating an instance of [ObjectEntry] for tracking an object in the system.
      * Derived classes may override this method to create their own customized instances of [ObjectEntry]
@@ -453,7 +468,14 @@ open class BaseObjectTracker(
         obj: Any,
         kind: ObjectKind = ObjectKind.NEW,
     ): ObjectEntry {
-        return ObjectEntry(objNumber, objHashCode, objDisplayNumber, createWeakReference(obj))
+        return BaseObjectEntry(
+            objNumber,
+            objHashCode,
+            objDisplayNumber,
+            objWeakReference = createWeakReference(obj),
+            objStrongReference = null,
+            objKind = kind,
+        )
     }
 
     protected fun createWeakReference(obj: Any): WeakReference<Any> = WeakReference(obj, referenceQueue)

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
@@ -788,10 +788,10 @@ internal class EventStructure(
     private fun addResponseEvents(requestEvent: AtomicThreadEvent): Pair<AtomicThreadEvent?, List<AtomicThreadEvent>> {
         require(requestEvent.label.isRequest)
         tryReplayEvent(requestEvent.threadId)?.let { event ->
-            val resync = event.resynchronize(syncAlgebra)
+            val resyncLabel = event.resynchronize(syncAlgebra)
             check(event.label.isResponse)
             check(event.parent == requestEvent)
-            check(event.label == resync)
+            check(event.label == resyncLabel)
             addEventToCurrentExecution(event)
             return event to listOf(event)
         }
@@ -949,6 +949,11 @@ internal class EventStructure(
     fun addObjectAllocationEvent(iThread: Int, value: OpaqueValue, objectID: ObjectNumber): AtomicThreadEvent {
         tryReplayEvent(iThread)?.let { event ->
             check(event.label is ObjectAllocationLabel)
+            //NOTE: Currently the objectID value represents the "suggested" objectID from the object tracker.
+            //      The objectID is incremented each time a new object is added to the object tracker and this value is not
+            //      reset between invocations.
+            //      When replaying events, we need to keep the old objectID, which needs to be at least smaller or equal
+            //      to the new objectID suggested by the object tracker.
             check(event.label.objectID <= objectID)
             addEventToCurrentExecution(event)
             return event

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
@@ -788,9 +788,10 @@ internal class EventStructure(
     private fun addResponseEvents(requestEvent: AtomicThreadEvent): Pair<AtomicThreadEvent?, List<AtomicThreadEvent>> {
         require(requestEvent.label.isRequest)
         tryReplayEvent(requestEvent.threadId)?.let { event ->
+            val resync = event.resynchronize(syncAlgebra)
             check(event.label.isResponse)
             check(event.parent == requestEvent)
-            check(event.label == event.resynchronize(syncAlgebra))
+            check(event.label == resync)
             addEventToCurrentExecution(event)
             return event to listOf(event)
         }
@@ -948,11 +949,7 @@ internal class EventStructure(
     fun addObjectAllocationEvent(iThread: Int, value: OpaqueValue, objectID: ObjectNumber): AtomicThreadEvent {
         tryReplayEvent(iThread)?.let { event ->
             check(event.label is ObjectAllocationLabel)
-            // TODO: Is this a reasonable check?
-            check(event.label.objectID == objectID)
-            val id = event.label.objectID
-//            val entry = RegistryObjectEntry(id, value, event)
-//            objectRegistry.register(entry)
+            check(event.label.objectID <= objectID)
             addEventToCurrentExecution(event)
             return event
         }

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
@@ -950,10 +950,10 @@ internal class EventStructure(
         tryReplayEvent(iThread)?.let { event ->
             check(event.label is ObjectAllocationLabel)
             //NOTE: Currently the objectID value represents the "suggested" objectID from the object tracker.
-            //      The objectID is incremented each time a new object is added to the object tracker and this value is not
-            //      reset between invocations.
-            //      When replaying events, we need to keep the old objectID, which needs to be at least smaller or equal
-            //      to the new objectID suggested by the object tracker.
+            //  The objectID is incremented each time a new object is added to the object tracker and this value is not
+            //  reset between invocations.
+            //  When replaying events, we need to keep the old objectID, which needs to be at least smaller or equal
+            //  to the new objectID suggested by the object tracker.
             check(event.label.objectID <= objectID)
             addEventToCurrentExecution(event)
             return event

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -32,15 +32,16 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
 
     override val shouldTrackImmutableValues: Boolean = true
 
-    // We have two types of object entires:
-    // * Internal which belong to object that are allocated during an invocation, and the test instance itself.
+    // We have two types of object entries.
+    // * Internal entries which correspond to objects that are allocated during a test invocation, as well as the test instance itself. and the test instance itself.
     //   These are purged from the ObjectTracker after each invocation.
     //   Also when replaying an invocation, the ObjectID of an internal object is set to be equal to the ObjectID of the previous
     //   allocation event.
-    // * External which belong to object that were already allocated before we started the tests
+    //
+    // * External which belong to objects that were already allocated before we started the tests
     //   Most often these are the initial threads, and the initial values of the fields of the test instance class
     //   Since these values are persistent across invocations, we keep them in the object tracker after invocations
-    //   We also hold a refernce to them to prevent the GC from removing them, while we still use them
+    //   We also hold a reference to them to prevent the GC from removing them, while they are still in use
     private abstract class EventStructureObjectEntry(
         objNumber: Int,
         objHashCode: Int,
@@ -118,6 +119,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     fun getObject(id: ObjectNumber): OpaqueValue? {
         return lookupByNumber(id)?.objectReference?.get()?.opaque()
     }
+
     override fun reset() {
         retain { (it is ExternalEventStructureObjectEntry)  }
     }

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -42,32 +42,21 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     //   Most often these are the initial threads, and the initial values of the fields of the test instance class
     //   Since these values are persistent across invocations, we keep them in the object tracker after invocations
     //   We also hold a reference to them to prevent the GC from removing them, while they are still in use
-    private abstract class EventStructureObjectEntry(
+    private class EventStructureObjectEntry(
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
+        objWeakReference: WeakReference<Any>,
+        objStrongReference: Any?,
         val allocation: AtomicThreadEvent,
-    ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
-
-    private class InternalEventStructureObjectEntry(
-        objNumber: Int,
-        objHashCode: Int,
-        objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
-        allocation: AtomicThreadEvent,
-    ) : EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, allocation)
-
-    private class ExternalEventStructureObjectEntry(
-        objNumber: Int,
-        objHashCode: Int,
-        objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
-        @Suppress("unused")
-        val hardRef: Any, // Prevent the gc from gc
-        allocation: AtomicThreadEvent,
-    ) : EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, allocation)
-
+        val isExternal: Boolean,
+    ) : ObjectEntry(
+        objNumber,
+        objHashCode,
+        objDisplayNumber,
+        objWeakReference,
+        objStrongReference
+    ) {}
 
 
     private var initEvent: AtomicThreadEvent? = null
@@ -88,13 +77,22 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
+        obj: Any,
         kind: ObjectKind
     ): ObjectEntry {
-        val obj = objReference.get()!!
+        // We create a base entry just for the weak reference inside it
+        val objWeakReference = createWeakReference(obj)
         if (kind == ObjectKind.EXTERNAL) {
             (initEvent!!.label as InitializationLabel).trackExternalObject(obj.javaClass.simpleName, objNumber)
-            return ExternalEventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, obj, initEvent!!)
+            return EventStructureObjectEntry(
+                objNumber,
+                objHashCode,
+                objDisplayNumber,
+                objWeakReference,
+                obj,
+                initEvent!!,
+                true,
+            )
         } else {
             val iThread = (Thread.currentThread() as? TestThread)?.threadId ?: eventStructure.mainThreadId
             // We create a new object allocation event and we "suggest" an objNumber
@@ -103,7 +101,15 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
             val allocationEvent = eventStructure.addObjectAllocationEvent(iThread!!,obj.opaque(), objNumber)
             val actualObjectNumber = (allocationEvent.label as ObjectAllocationLabel).objectID
             check(actualObjectNumber <= objNumber)
-            return InternalEventStructureObjectEntry(actualObjectNumber, objHashCode, objDisplayNumber, objReference, allocationEvent)
+            return EventStructureObjectEntry(
+                actualObjectNumber,
+                objHashCode,
+                objDisplayNumber,
+                objWeakReference,
+                null,
+                allocationEvent,
+                false,
+            )
         }
     }
 
@@ -117,11 +123,11 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     }
 
     fun getObject(id: ObjectNumber): OpaqueValue? {
-        return lookupByNumber(id)?.objectReference?.get()?.opaque()
+        return lookupByNumber(id)?.objectWeakReference?.get()?.opaque()
     }
 
     override fun reset() {
-        retain { (it is ExternalEventStructureObjectEntry)  }
+        retain { (it as? EventStructureObjectEntry)?.isExternal ?: false }
     }
 }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -32,14 +32,41 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
 
     override val shouldTrackImmutableValues: Boolean = true
 
-    private class EventStructureObjectEntry(
+    // We have two types of object entires:
+    // * Internal which belong to object that are allocated during an invocation, and the test instance itself.
+    //   These are purged from the ObjectTracker after each invocation.
+    //   Also when replaying an invocation, the ObjectID of an internal object is set to be equal to the ObjectID of the previous
+    //   allocation event.
+    // * External which belong to object that were already allocated before we started the tests
+    //   Most often these are the initial threads, and the initial values of the fields of the test instance class
+    //   Since these values are persistent across invocations, we keep them in the object tracker after invocations
+    //   We also hold a refernce to them to prevent the GC from removing them, while we still use them
+    private abstract class EventStructureObjectEntry(
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
         val allocation: AtomicThreadEvent,
-        val external: Boolean,
     ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
+
+    private class InternalEventStructureObjectEntry(
+        objNumber: Int,
+        objHashCode: Int,
+        objDisplayNumber: Int,
+        objReference: WeakReference<Any>,
+        allocation: AtomicThreadEvent,
+    ) : EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, allocation)
+
+    private class ExternalEventStructureObjectEntry(
+        objNumber: Int,
+        objHashCode: Int,
+        objDisplayNumber: Int,
+        objReference: WeakReference<Any>,
+        @Suppress("unused")
+        val hardRef: Any, // Prevent the gc from gc
+        allocation: AtomicThreadEvent,
+    ) : EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, allocation)
+
 
 
     private var initEvent: AtomicThreadEvent? = null
@@ -66,7 +93,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         val obj = objReference.get()!!
         if (kind == ObjectKind.EXTERNAL) {
             (initEvent!!.label as InitializationLabel).trackExternalObject(obj.javaClass.simpleName, objNumber)
-            return EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, initEvent!!, true)
+            return ExternalEventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, obj, initEvent!!)
         } else {
             val iThread = (Thread.currentThread() as? TestThread)?.threadId ?: eventStructure.mainThreadId
             // We create a new object allocation event and we "suggest" an objNumber
@@ -75,7 +102,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
             val allocationEvent = eventStructure.addObjectAllocationEvent(iThread!!,obj.opaque(), objNumber)
             val actualObjectNumber = (allocationEvent.label as ObjectAllocationLabel).objectID
             check(actualObjectNumber <= objNumber)
-            return EventStructureObjectEntry(actualObjectNumber, objHashCode, objDisplayNumber, objReference, allocationEvent, false)
+            return InternalEventStructureObjectEntry(actualObjectNumber, objHashCode, objDisplayNumber, objReference, allocationEvent)
         }
     }
 
@@ -92,7 +119,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         return lookupByNumber(id)?.objectReference?.get()?.opaque()
     }
     override fun reset() {
-        retain { (it as EventStructureObjectEntry).external }
+        retain { (it is ExternalEventStructureObjectEntry)  }
     }
 }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -33,11 +33,11 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     override val shouldTrackImmutableValues: Boolean = true
 
     // We have two types of object entries.
-    // * Internal entries which correspond to objects that are allocated during a test invocation, as well as the test instance itself. and the test instance itself.
+    // * Internal entries which correspond to objects that are allocated during a test invocation,
+    //   as well as the test  instance itself.
     //   These are purged from the ObjectTracker after each invocation.
-    //   Also when replaying an invocation, the ObjectID of an internal object is set to be equal to the ObjectID of the previous
-    //   allocation event.
-    //
+    //   Also when replaying an invocation, the ObjectID of an internal object is set to be equal to the ObjectID
+    //   of the previous allocation event.
     // * External which belong to objects that were already allocated before we started the tests
     //   Most often these are the initial threads, and the initial values of the fields of the test instance class
     //   Since these values are persistent across invocations, we keep them in the object tracker after invocations

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -37,7 +37,8 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
-        val allocation: AtomicThreadEvent
+        val allocation: AtomicThreadEvent,
+        val external: Boolean,
     ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
 
 
@@ -47,6 +48,13 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         require(initEvent.label is InitializationLabel)
         this.initEvent = initEvent
     }
+
+    //NOTE: as in the oringinal ObjectRegistry, if an external object is already registered
+    // we do not register it again.
+    // This is because the external object may already exist, which messes up the objectIDs
+    override fun registerExternalObject(obj: Any): ObjectEntry =
+       get(obj) ?: super.registerExternalObject(obj)
+
 
     override fun createObjectEntry(
         objNumber: Int,
@@ -58,11 +66,16 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         val obj = objReference.get()!!
         if (kind == ObjectKind.EXTERNAL) {
             (initEvent!!.label as InitializationLabel).trackExternalObject(obj.javaClass.simpleName, objNumber)
-            return EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, initEvent!!)
+            return EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, initEvent!!, true)
         } else {
-            val iThread = (Thread.currentThread() as? TestThread)?.threadId
+            val iThread = (Thread.currentThread() as? TestThread)?.threadId ?: eventStructure.mainThreadId
+            // We create a new object allocation event and we "suggest" an objNumber
+            // If we are in the replay phase however, the object allocation may have a different id
+            // In that case we just take the id from the object allocation
             val allocationEvent = eventStructure.addObjectAllocationEvent(iThread!!,obj.opaque(), objNumber)
-            return EventStructureObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference, allocationEvent)
+            val actualObjectNumber = (allocationEvent.label as ObjectAllocationLabel).objectID
+            check(actualObjectNumber <= objNumber)
+            return EventStructureObjectEntry(actualObjectNumber, objHashCode, objDisplayNumber, objReference, allocationEvent, false)
         }
     }
 
@@ -77,6 +90,9 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
 
     fun getObject(id: ObjectNumber): OpaqueValue? {
         return lookupByNumber(id)?.objectReference?.get()?.opaque()
+    }
+    override fun reset() {
+        retain { (it as EventStructureObjectEntry).external }
     }
 }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -48,14 +48,15 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         objDisplayNumber: Int,
         objWeakReference: WeakReference<Any>,
         objStrongReference: Any?,
+        objKind: ObjectKind,
         val allocation: AtomicThreadEvent,
-        val isExternal: Boolean,
-    ) : ObjectEntry(
+    ) : BaseObjectEntry(
         objNumber,
         objHashCode,
         objDisplayNumber,
         objWeakReference,
-        objStrongReference
+        objStrongReference,
+        objKind,
     ) {}
 
 
@@ -89,9 +90,9 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
                 objHashCode,
                 objDisplayNumber,
                 objWeakReference,
-                obj,
+                objStrongReference = obj,
+                objKind = kind,
                 initEvent!!,
-                true,
             )
         } else {
             val iThread = (Thread.currentThread() as? TestThread)?.threadId ?: eventStructure.mainThreadId
@@ -106,9 +107,9 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
                 objHashCode,
                 objDisplayNumber,
                 objWeakReference,
-                null,
+                objStrongReference = obj,
+                objKind = kind,
                 allocationEvent,
-                false,
             )
         }
     }
@@ -127,7 +128,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     }
 
     override fun reset() {
-        retain { (it as? EventStructureObjectEntry)?.isExternal ?: false }
+        retain { (it as? EventStructureObjectEntry)?.objKind == ObjectKind.EXTERNAL }
     }
 }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -46,17 +46,16 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
+        objKind: ObjectTracker.ObjectKind,
         objWeakReference: WeakReference<Any>,
         objStrongReference: Any?,
-        objKind: ObjectKind,
         val allocation: AtomicThreadEvent,
-    ) : BaseObjectEntry(
-        objNumber,
+    ) : ObjectEntry(objNumber,
         objHashCode,
         objDisplayNumber,
+        objKind,
         objWeakReference,
         objStrongReference,
-        objKind,
     ) {}
 
 
@@ -79,20 +78,20 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         objHashCode: Int,
         objDisplayNumber: Int,
         obj: Any,
-        kind: ObjectKind
+        kind: ObjectTracker.ObjectKind
     ): ObjectEntry {
         // We create a base entry just for the weak reference inside it
         val objWeakReference = createWeakReference(obj)
-        if (kind == ObjectKind.EXTERNAL) {
+        if (kind == ObjectTracker.ObjectKind.EXTERNAL) {
             (initEvent!!.label as InitializationLabel).trackExternalObject(obj.javaClass.simpleName, objNumber)
             return EventStructureObjectEntry(
                 objNumber,
                 objHashCode,
                 objDisplayNumber,
-                objWeakReference,
-                objStrongReference = obj,
                 objKind = kind,
-                initEvent!!,
+                objWeakReference = objWeakReference,
+                objStrongReference = obj,
+                allocation = initEvent!!
             )
         } else {
             val iThread = (Thread.currentThread() as? TestThread)?.threadId ?: eventStructure.mainThreadId
@@ -106,10 +105,10 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
                 actualObjectNumber,
                 objHashCode,
                 objDisplayNumber,
-                objWeakReference,
-                objStrongReference = obj,
                 objKind = kind,
-                allocationEvent,
+                objWeakReference = objWeakReference,
+                objStrongReference = null,
+                allocation = allocationEvent,
             )
         }
     }
@@ -128,7 +127,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     }
 
     override fun reset() {
-        retain { (it as? EventStructureObjectEntry)?.objKind == ObjectKind.EXTERNAL }
+        retain { (it as? EventStructureObjectEntry)?.objectKind == ObjectTracker.ObjectKind.EXTERNAL }
     }
 }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
@@ -356,7 +356,9 @@ internal class EventStructureStrategy(
     private fun registerTestInstance() {
         check(!isTestInstanceRegistered)
         val testInstance = (runner as ExecutionScenarioRunner).testInstance
-        //NOTE: The threadID may be messed up. See how this can be fixed.
+        //NOTE: Since the IdentityHashCode of the test instance changes between invocations
+        // we cannot keep it as an external object. Instead, we register it as an "internal"
+        // object on each invocation
         (objectTracker as EventStructureObjectTracker).registerNewObject(testInstance)
         isTestInstanceRegistered = true
     }

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
@@ -357,7 +357,7 @@ internal class EventStructureStrategy(
         check(!isTestInstanceRegistered)
         val testInstance = (runner as ExecutionScenarioRunner).testInstance
         //NOTE: The threadID may be messed up. See how this can be fixed.
-        (objectTracker as EventStructureObjectTracker).registerExternalObject(testInstance)
+        (objectTracker as EventStructureObjectTracker).registerNewObject(testInstance)
         isTestInstanceRegistered = true
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureStrategy.kt
@@ -403,6 +403,38 @@ internal class EventStructureStrategy(
         super.onActorFinish(iThread)
     }
 
+    override fun afterReadField(
+        threadDescriptor: ThreadDescriptor,
+        codeLocation: Int,
+        obj: Any?,
+        fieldId: Int,
+        value: Any?
+    ) {
+        threadDescriptor.runInsideIgnoredSection {
+            // In the case of eventstrcutre this object should already be registered
+            if (value !== null && objectTracker.shouldTrackObject(value)) {
+                check(objectTracker.get(value) != null)
+            }
+        }
+        super.afterReadField(threadDescriptor, codeLocation, obj, fieldId, value)
+    }
+
+    override fun afterReadArrayElement(
+        threadDescriptor: ThreadDescriptor,
+        codeLocation: Int,
+        array: Any?,
+        index: Int,
+        value: Any?
+    ) {
+        threadDescriptor.runInsideIgnoredSection {
+            // In the case of eventstrcutre this object should already be registered
+            if (value !== null && objectTracker.shouldTrackObject(value)) {
+                check(objectTracker.get(value) != null)
+            }
+        }
+        super.afterReadArrayElement(threadDescriptor, codeLocation, array, index, value)
+    }
+
     private fun onInconsistency(inconsistency: Inconsistency) {
         abortWithSuddenInvocationResult(InconsistentInvocationResult(inconsistency))
     }

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -507,13 +507,13 @@ internal class LocalObjectManager : BaseObjectTracker() {
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
-        objReference: WeakReference<Any>,
+        obj: Any,
         kind: ObjectKind
     ): ObjectEntry = LocalObjectManagerEntry(
         objNumber = objNumber,
         objHashCode = objHashCode,
         objDisplayNumber = objDisplayNumber,
-        objReference = objReference,
+        objReference = createWeakReference(obj),
         isLocal = when (kind) {
             // every newly registered object is considered local initially
             ObjectKind.NEW -> true

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -499,26 +499,28 @@ internal class LocalObjectManager : BaseObjectTracker() {
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
+        objKind: ObjectTracker.ObjectKind,
         objReference: WeakReference<Any>,
         var isLocal: Boolean,
-    ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
+    ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objKind, objReference)
 
     override fun createObjectEntry(
         objNumber: Int,
         objHashCode: Int,
         objDisplayNumber: Int,
         obj: Any,
-        kind: ObjectKind
+        kind: ObjectTracker.ObjectKind
     ): ObjectEntry = LocalObjectManagerEntry(
         objNumber = objNumber,
         objHashCode = objHashCode,
         objDisplayNumber = objDisplayNumber,
+        objKind = kind,
         objReference = createWeakReference(obj),
         isLocal = when (kind) {
             // every newly registered object is considered local initially
-            ObjectKind.NEW -> true
+            ObjectTracker.ObjectKind.NEW -> true
             // external objects are considered non-local since we don't have information about them
-            ObjectKind.EXTERNAL -> false
+            ObjectTracker.ObjectKind.EXTERNAL -> false
         }
     )
 

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/MemoryModelTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/MemoryModelTest.kt
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.*
 
 import org.jetbrains.kotlinx.lincheck.strategy.managed.eventstructure.*
 import org.jetbrains.lincheck.datastructures.scenario
-import org.junit.Ignore
 
 import org.junit.Test
 
@@ -102,72 +101,6 @@ class MemoryModelTest {
             (r1 to r2)
         }
     }
-
-    @Test
-    fun testHashMap() {
-        class Foo {
-            var x = AtomicInteger(0)
-            fun one() {
-                 val map = mutableMapOf<Int, Int>()
-                map[0] = x.get()
-            }
-
-            fun two() {
-                val flarb = Object()
-                x.set(1)
-            }
-        }
-
-        val testScenario = scenario {
-            parallel {
-                thread {
-                    actor(Foo::one)
-                }
-                thread {
-                    actor(Foo::two)
-                }
-            }
-        }
-
-        val outcomes: Set<Unit> = setOf(Unit)
-        litmusTest(Foo::class.java, testScenario, outcomes) { results ->
-            Unit
-        }
-    }
-
-    @Test
-    fun testIf() {
-        class Foo {
-            var x = AtomicInteger(0)
-            fun one() {
-                x.get() == 0
-                val blarb = Object()
-            }
-
-            fun two() {
-                val flarb = Object()
-                x.set(1)
-            }
-        }
-
-        val testScenario = scenario {
-            parallel {
-                thread {
-                    actor(Foo::one)
-                }
-                thread {
-                    actor(Foo::two)
-                }
-            }
-        }
-
-        val outcomes: Set<Unit> = setOf(Unit)
-        litmusTest(Foo::class.java, testScenario, outcomes) { results ->
-            Unit
-        }
-
-    }
-
 }
 
 internal class SharedMemory(size: Int = 16) {

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/MemoryModelTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/MemoryModelTest.kt
@@ -103,6 +103,71 @@ class MemoryModelTest {
         }
     }
 
+    @Test
+    fun testHashMap() {
+        class Foo {
+            var x = AtomicInteger(0)
+            fun one() {
+                 val map = mutableMapOf<Int, Int>()
+                map[0] = x.get()
+            }
+
+            fun two() {
+                val flarb = Object()
+                x.set(1)
+            }
+        }
+
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+
+        val outcomes: Set<Unit> = setOf(Unit)
+        litmusTest(Foo::class.java, testScenario, outcomes) { results ->
+            Unit
+        }
+    }
+
+    @Test
+    fun testIf() {
+        class Foo {
+            var x = AtomicInteger(0)
+            fun one() {
+                x.get() == 0
+                val blarb = Object()
+            }
+
+            fun two() {
+                val flarb = Object()
+                x.set(1)
+            }
+        }
+
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+
+        val outcomes: Set<Unit> = setOf(Unit)
+        litmusTest(Foo::class.java, testScenario, outcomes) { results ->
+            Unit
+        }
+
+    }
+
 }
 
 internal class SharedMemory(size: Int = 16) {

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -1134,4 +1134,83 @@ class PrimitivesTest {
         }
     }
 
+
+    @Test
+    fun testObjectsObjectsIDsDoNotBreakOnBackwardRevisit() {
+        // This test is specifically made to make break during backward revisit of allocated objects
+        // We had a bug in the object tracker where the replay order of the events affected the ObjectIDs of the replayed objects
+        // In the initial invocation, we first assigned objectID 1 to Bar(1) and 2 to Bar(2)
+        // In the next invocation we do a backward revisit from x.set(1) to x.get()
+        // This means that we first replay Bar(2) and the x.set(1) and go to actually run x.get() and Bar(1).
+        // During replay this meant that we wrongly gave Bar(2) the objectID of 1 (instead of the original 2 value)
+        class Bar(a: Int) {
+            val b = a
+            override fun toString(): String {
+                return "BAR:($b)"
+            }
+        }
+        class Foo {
+            var x = AtomicInteger(0)
+            @Volatile var y = Bar(0)
+            fun one() {
+                x.get() == 0
+                y = Bar(1)
+                val x = y
+            }
+            fun two() {
+                y = Bar(2)
+                x.set(1)
+            }
+        }
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+        val outcomes: Set<Unit> = setOf(Unit)
+        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            Unit
+        }
+    }
+
+
+
+    @Test
+    fun testStringsObjectsIDsDoNotBreakOnBackwardRevisit() {
+        // Same thing as the test above, but with strings, which work a bit differently
+        class Foo {
+            var x = AtomicInteger(0)
+            @Volatile var y = ""
+
+            fun one() {
+                x.get() == 0
+                y = "a"
+            }
+
+            fun two() {
+                y = "b"
+                x.set(1)
+            }
+
+        }
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+        val outcomes: Set<Unit> = setOf(Unit)
+        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            Unit
+        }
+    }
 }

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -1134,9 +1134,8 @@ class PrimitivesTest {
         }
     }
 
-
     @Test
-    fun testObjectsObjectsIDsDoNotBreakOnBackwardRevisit() {
+    fun testObjectIdsAreNotBrokenOnBackwardRevisit() {
         // This test is specifically made to make break during backward revisit of allocated objects
         // We had a bug in the object tracker where the replay order of the events affected the ObjectIDs of the replayed objects
         // In the initial invocation, we first assigned objectID 1 to Bar(1) and 2 to Bar(2)
@@ -1179,7 +1178,41 @@ class PrimitivesTest {
     }
 
     @Test
-    fun testDoNotGCExternalObjects() {
+    fun testStringsIdsAreNotBrokenOnBackwardRevisit() {
+        // Same thing as the test above, but with strings, which work a bit differently
+        class Foo {
+            var x = AtomicInteger(0)
+            @Volatile var y = ""
+
+            fun one() {
+                x.get() == 0
+                y = "a"
+            }
+
+            fun two() {
+                y = "b"
+                x.set(1)
+            }
+
+        }
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+        val outcomes: Set<Unit> = setOf(Unit)
+        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            Unit
+        }
+    }
+
+    @Test
+    fun testExternalObjectIdsAreNotBrokenOnGarbageCollection() {
         // This test tries to force the GC to collect the external Baz(0), which is left unused after each testInvocation
         // The ObjectTracker used to rely on a weak reference to the GC'd object, which would cause trouble
         class Baz(a: Int) {
@@ -1216,13 +1249,12 @@ class PrimitivesTest {
         litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
             val b1 = getValue<Int>(results.parallelResults[0][0]!!)
             System.gc() // Kindly suggest the GC to do its thing. Should make the test fail more consistently.
-            System.gc()
             return@litmusTest b1
         }
     }
 
     @Test
-    fun testObjectIdsStableCrazy() {
+    fun testObjectIdsAreNotBrokenOnReplays() {
         // This test tries various nesting levels to see if we can break the replay order of the object tracker
         // Kind of a throw stuff at the wall and see what sticks approach
         class Bar(a: AtomicInteger) {
@@ -1265,42 +1297,6 @@ class PrimitivesTest {
         litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
             val b1 = getValue<Int>(results.parallelResults[0][0]!!)
             return@litmusTest b1
-        }
-    }
-
-
-
-    @Test
-    fun testStringsObjectsIDsDoNotBreakOnBackwardRevisit() {
-        // Same thing as the test above, but with strings, which work a bit differently
-        class Foo {
-            var x = AtomicInteger(0)
-            @Volatile var y = ""
-
-            fun one() {
-                x.get() == 0
-                y = "a"
-            }
-
-            fun two() {
-                y = "b"
-                x.set(1)
-            }
-
-        }
-        val testScenario = scenario {
-            parallel {
-                thread {
-                    actor(Foo::one)
-                }
-                thread {
-                    actor(Foo::two)
-                }
-            }
-        }
-        val outcomes: Set<Unit> = setOf(Unit)
-        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
-            Unit
         }
     }
 }

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -1178,6 +1178,96 @@ class PrimitivesTest {
         }
     }
 
+    @Test
+    fun testDoNotGCExternalObjects() {
+        // This test tries to force the GC to collect the external Baz(0), which is left unused after each testInvocation
+        // The ObjectTracker used to rely on a weak reference to the GC'd object, which would cause trouble
+        class Baz(a: Int) {
+            @Volatile var b = a
+            override fun toString(): String {
+                return "BAZ:($b)"
+            }
+        }
+        class Foo {
+            // The Baz(0) here is an external object
+            // Since it is the intial value of a field of the test class
+            @Volatile var y = Baz(0)
+            fun one() : Int {
+                val res = y.b
+                return 0
+            }
+            fun two() {
+                y.b = 0
+                y.b = 1
+                y.b = 2
+            }
+        }
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+        val outcomes: Set<Int> = setOf(0)
+        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            val b1 = getValue<Int>(results.parallelResults[0][0]!!)
+            System.gc() // Kindly suggest the GC to do its thing. Should make the test fail more consistently.
+            System.gc()
+            return@litmusTest b1
+        }
+    }
+
+    @Test
+    fun testObjectIdsStableCrazy() {
+        // This test tries various nesting levels to see if we can break the replay order of the object tracker
+        // Kind of a throw stuff at the wall and see what sticks approach
+        class Bar(a: AtomicInteger) {
+            @Volatile
+            var b = a
+            override fun toString(): String {
+                return "BAR:($b)"
+            }
+        }
+        class Baz(a: Bar) {
+            @Volatile var b = a
+            override fun toString(): String {
+                return "BAZ:($b)"
+            }
+        }
+        class Foo {
+            @Volatile var y = Baz(Bar(AtomicInteger(0)))
+            fun one() : Int {
+                y.b = Bar(AtomicInteger(1))
+                val res = y.b.b.get()
+                return res
+            }
+            fun two() {
+                y.b = Bar(AtomicInteger(2))
+                y.b.b = AtomicInteger(3)
+                y.b.b.set(4)
+            }
+        }
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(Foo::one)
+                }
+                thread {
+                    actor(Foo::two)
+                }
+            }
+        }
+        val outcomes: Set<Int> = setOf(1,2,3,4)
+        litmusTest(Foo::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            val b1 = getValue<Int>(results.parallelResults[0][0]!!)
+            return@litmusTest b1
+        }
+    }
+
 
 
     @Test


### PR DESCRIPTION
The EventStrucutreObjectTracker was broken.
* When replaying events it did not assign ObjectIDs, consistently. In one invocation an object would have ObjectID 6, while in another it would have ObjectID 2, because the replay order changed.  
* It wrongly marked the test instance as an external object, while it should have been internal. This again messed up the ObjectIDs.
* External Object could get garbage collected between invocations, which could again break the ObjectTracker

Fixes:
* External objects are not removed between invocation from the object tracker. This way their ObjectIDs will be consistent
* Now when replaying events, if we allocate an internal object, we now give it an ObjectID from the replayed event instead of giving it a new one.
* We now hold a "hard" reference to external objects to prevent GC   