### PR TITLE
Fix bug with incorrect double KClass<*> extraction

### DIFF
--- a/trace/src/main/org/jetbrains/lincheck/trace/SerializationStream.kt
+++ b/trace/src/main/org/jetbrains/lincheck/trace/SerializationStream.kt
@@ -399,7 +399,7 @@ class FileStreamingTraceCollecting(
     }
 
     private fun getDescriptorBitmap(descriptorClass: KClass<*>): AtomicBitmap? {
-        return when (descriptorClass::class) {
+        return when (descriptorClass) {
             ClassDescriptor::class -> seenClassDescriptors
             MethodDescriptor::class -> seenMethodDescriptors
             FieldDescriptor::class -> seenFieldDescriptors


### PR DESCRIPTION
Cherry-picked from #999 