### PR TITLE
Fix boxed primitive type `ValueID` representation

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/descriptors/Types.kt
+++ b/common/src/main/org/jetbrains/lincheck/descriptors/Types.kt
@@ -116,14 +116,14 @@ object Types {
     val SHORT_TYPE: ShortType = ShortType()
     val CHAR_TYPE: CharType = CharType()
 
-    val INT_TYPE_BOXED: ObjectType = ObjectType("java.lang.Integer")
-    val LONG_TYPE_BOXED: ObjectType = ObjectType("java.lang.Long")
-    val DOUBLE_TYPE_BOXED: ObjectType = ObjectType("java.lang.Double")
-    val FLOAT_TYPE_BOXED: ObjectType = ObjectType("java.lang.Float")
-    val BOOLEAN_TYPE_BOXED: ObjectType = ObjectType("java.lang.Boolean")
-    val BYTE_TYPE_BOXED: ObjectType = ObjectType("java.lang.Byte")
-    val SHORT_TYPE_BOXED: ObjectType = ObjectType("java.lang.Short")
-    val CHAR_TYPE_BOXED: ObjectType = ObjectType("java.lang.Character")
+    val INT_TYPE_BOXED: ObjectType = ObjectType("java/lang/Integer")
+    val LONG_TYPE_BOXED: ObjectType = ObjectType("java/lang/Long")
+    val DOUBLE_TYPE_BOXED: ObjectType = ObjectType("java/lang/Double")
+    val FLOAT_TYPE_BOXED: ObjectType = ObjectType("java/lang/Float")
+    val BOOLEAN_TYPE_BOXED: ObjectType = ObjectType("java/lang/Boolean")
+    val BYTE_TYPE_BOXED: ObjectType = ObjectType("java/lang/Byte")
+    val SHORT_TYPE_BOXED: ObjectType = ObjectType("java/lang/Short")
+    val CHAR_TYPE_BOXED: ObjectType = ObjectType("java/lang/Character")
 
     val OBJECT_TYPE: ObjectType = ObjectType(Object::class.java.name)
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -58,7 +58,7 @@ interface ObjectTracker {
      * @param objNumber the object number to retrieve the corresponding entry for.
      * @return the corresponding [ObjectEntry], or null if no entry is associated with the given object number.
      */
-    fun lookupByNumber(objNumber: Int): ObjectEntry?
+    fun lookupByNumber(objNumber: Long): ObjectEntry?
 
     /**
      * Retrieves the registry entry associated with the given object id.
@@ -167,18 +167,18 @@ typealias ObjectID = Long
 /**
  * A type alias for representing a unique serial number of registered objects.
  */
-typealias ObjectNumber = Int
+typealias ObjectNumber = Long
 
 /**
  * Represents an entry for the tracked object.
  *
- * @property objectNumber A unique serial number for the object.
- * @property objectHashCode The identity hash code of the object.
+ * @property objectNumber A unique serial number for the object. Needs to be at most 33 bits
+ * @property objectHashCode The identity hash code of the object. Needs to be at most 31 bits.
  * @property objectDisplayNumber The number used in string representation of the object.
  * @property objectReference A weak reference to the associated object.
  */
 open class ObjectEntry(
-    val objectNumber: Int,
+    val objectNumber: Long,
     val objectHashCode: Int,
     val objectDisplayNumber: Int,
     val objectReference: WeakReference<Any>,
@@ -188,17 +188,17 @@ open class ObjectEntry(
  * A unique identifier of an object.
  *
  * The identifier is a 64-bit integer number, formed by combining its serial number and hash code.
- * The serial number [ObjectEntry.objectNumber] is stored in the higher 32-bits of the id, while
- * the identity hash code [ObjectEntry.objectHashCode] is stored in the lower 32-bits.
+ * The serial number [ObjectEntry.objectNumber] is stored in the higher 33-bits of the id, while
+ * the identity hash code [ObjectEntry.objectHashCode] is stored in the lower 31-bits.
  */
 val ObjectEntry.objectID: ObjectID get() =
-    (objectNumber.toLong() shl 32) + objectHashCode.toLong()
+    (objectNumber shl 31) + (objectHashCode.toLong() shr 1)
 
 /**
  * Extracts and returns the object number from the given object id.
  */
-fun ObjectID.getObjectNumber(): Int =
-    (this ushr 32).toInt()
+fun ObjectID.getObjectNumber(): Long =
+    (this ushr 31)
 
 /**
  * Extracts and returns the identity hash code of the object from the given object id.
@@ -206,7 +206,7 @@ fun ObjectID.getObjectNumber(): Int =
  * @return The integer hash code derived from the ObjectID.
  */
 fun ObjectID.getObjectHashCode(): Int =
-    this.toInt()
+    this.toInt() and ((1 shl 31) - 1)
 
 /**
  * Retrieves the unique serial object number for the given object.
@@ -215,7 +215,7 @@ fun ObjectID.getObjectHashCode(): Int =
  * @return the unique object number if the object is registered in the tracker,
  *   or -1 if no entry is associated with the given object.
  */
-fun ObjectTracker.getObjectNumber(obj: Any): Int =
+fun ObjectTracker.getObjectNumber(obj: Any): Long =
     get(obj)?.objectNumber ?: -1
 
 /**
@@ -418,11 +418,11 @@ open class BaseObjectTracker(
     open val shouldTrackImmutableValues: Boolean = false
 
     // counter of all registered objects
-    private var objectCounter = 0
+    private var objectCounter: Long = 0
 
     // index of all registered objects
     protected val objectIndex = HashMap<IdentityHashCode, MutableList<ObjectEntry>>()
-    protected val objectNumberIndex = HashMap<Int, ObjectEntry>();
+    protected val objectNumberIndex = HashMap<Long, ObjectEntry>();
 
     // reference queue keeping track of garbage-collected objects
     private val referenceQueue = ReferenceQueue<Any>()
@@ -445,7 +445,7 @@ open class BaseObjectTracker(
      * with additional meta-data.
      */
     protected open fun createObjectEntry(
-        objNumber: Int,
+        objNumber: Long,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
@@ -512,7 +512,7 @@ open class BaseObjectTracker(
         return entries
     }
 
-    override fun lookupByNumber(objNumber: Int): ObjectEntry? {
+    override fun lookupByNumber(objNumber: Long): ObjectEntry? {
         return objectNumberIndex[objNumber]
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/OpaqueValue.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/OpaqueValue.kt
@@ -110,8 +110,8 @@ fun Any?.toOpaqueString(): String {
 typealias ValueID = Long
 
 // TODO: override `toString` ?
-internal const val STATIC_OBJECT_NUMBER = -1
-internal const val NULL_OBJECT_NUMBER = 0
+internal const val STATIC_OBJECT_NUMBER: Long = -1
+internal const val NULL_OBJECT_NUMBER: Long = Int.MIN_VALUE.toLong() - 1
 
 internal fun Int.convert(type: Types.Type): Number = when (type) {
     Types.LONG_TYPE -> toLong()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructure.kt
@@ -334,7 +334,7 @@ internal class EventStructure(
             return null
         val allocation = eventStructureObjectTracker.getAllocation(label.objectID)
         val source = (label as? WriteAccessLabel)?.writeValue?.let {
-            eventStructureObjectTracker.getAllocation(it.toInt())
+            eventStructureObjectTracker.getAllocation(it)
         }
         val event = AtomicThreadEventImpl(
             label = label,

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -33,7 +33,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     override val shouldTrackImmutableValues: Boolean = true
 
     private class EventStructureObjectEntry(
-        objNumber: Int,
+        objNumber: Long,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
@@ -49,7 +49,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     }
 
     override fun createObjectEntry(
-        objNumber: Int,
+        objNumber: Long,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
@@ -103,7 +103,7 @@ internal fun EventStructureObjectTracker.getValue(type: Types.Type, id: ValueID)
 }
 
 internal fun EventStructureObjectTracker.getOrRegisterValueID(type: Types.Type, value: OpaqueValue?): ValueID {
-    if (value == null) return NULL_OBJECT_NUMBER.toLong()
+    if (value == null) return NULL_OBJECT_NUMBER
     return when (type) {
         Types.LONG_TYPE       -> (value.unwrap() as Long)
         Types.INT_TYPE        -> (value.unwrap() as Int).toLong()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -43,6 +43,39 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
 
     private var initEvent: AtomicThreadEvent? = null
 
+    private var longObjectCounter = NULL_OBJECT_NUMBER - 1
+    private var longObjectToIDMap: MutableMap<Long, ObjectNumber> = mutableMapOf()
+    private var idTolongObjectMap: MutableMap<ObjectNumber, Long> = mutableMapOf()
+
+    fun getBoxedLongId(obj: Long): ObjectNumber? {
+        check(obj <= NULL_OBJECT_NUMBER)
+        return longObjectToIDMap.get(obj)
+    }
+
+    fun registerBoxedLong(obj: Long): ObjectNumber {
+        check(obj <= NULL_OBJECT_NUMBER)
+        check(longObjectCounter != Long.MIN_VALUE)
+        val id = --longObjectCounter
+        idTolongObjectMap[id] = obj
+        longObjectToIDMap[obj] = id
+        return id
+    }
+
+    fun getOrRegisterBoxedLongId(obj: Long?): ObjectNumber {
+        check(obj != null)
+        if(obj <= NULL_OBJECT_NUMBER) {
+            return getBoxedLongId(obj) ?: registerBoxedLong(obj)
+        } else {
+            return obj
+        }
+    }
+
+    fun getBoxedLong(obj: ObjectNumber): Long? {
+        if(obj == NULL_OBJECT_NUMBER) { return null }
+        else if(obj < NULL_OBJECT_NUMBER) { return idTolongObjectMap[obj] }
+        else { return obj }
+    }
+
     fun initialize(initEvent: AtomicThreadEvent) {
         require(initEvent.label is InitializationLabel)
         this.initEvent = initEvent
@@ -80,11 +113,20 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
     }
 }
 
+// TODO: can we remove this method and just use getOrRegisterValueID, and make Type optional
 internal fun EventStructureObjectTracker.registerValueIfAbsent(obj: OpaqueValue?): ObjectNumber =
     when {
         obj == null -> NULL_OBJECT_NUMBER
         else -> registerObjectIfAbsent(obj.unwrap()).objectNumber
     }
+
+internal fun<T: Any> boxedValueIdToOpaqueValue(id: ValueID, conv: (Long) -> T): OpaqueValue? {
+    if (id == NULL_OBJECT_NUMBER) {
+        return null
+    } else {
+        return conv(id).opaque()
+    }
+}
 
 internal fun EventStructureObjectTracker.getValue(type: Types.Type, id: ValueID): OpaqueValue? = when (type) {
     Types.LONG_TYPE       -> id.opaque()
@@ -93,13 +135,13 @@ internal fun EventStructureObjectTracker.getValue(type: Types.Type, id: ValueID)
     Types.SHORT_TYPE      -> id.toShort().opaque()
     Types.CHAR_TYPE       -> id.toInt().toChar().opaque()
     Types.BOOLEAN_TYPE    -> id.toInt().toBoolean().opaque()
-    Types.LONG_TYPE_BOXED     -> id.opaque()
-    Types.INT_TYPE_BOXED      -> id.toInt().opaque()
-    Types.BYTE_TYPE_BOXED     -> id.toByte().opaque()
-    Types.SHORT_TYPE_BOXED    -> id.toShort().opaque()
-    Types.CHAR_TYPE_BOXED     -> id.toInt().toChar().opaque()
-    Types.BOOLEAN_TYPE_BOXED  -> id.toInt().toBoolean().opaque()
-    else                -> getObject(id.toInt())
+    Types.LONG_TYPE_BOXED     -> getBoxedLong(id)?.opaque()
+    Types.INT_TYPE_BOXED      -> boxedValueIdToOpaqueValue(id) { it.toInt() }
+    Types.BYTE_TYPE_BOXED     -> boxedValueIdToOpaqueValue(id) { it.toByte() }
+    Types.SHORT_TYPE_BOXED    -> boxedValueIdToOpaqueValue(id) { it.toShort() }
+    Types.CHAR_TYPE_BOXED     -> boxedValueIdToOpaqueValue(id) { it.toInt() }
+    Types.BOOLEAN_TYPE_BOXED  -> boxedValueIdToOpaqueValue(id) { it.toInt() }
+    else                -> getObject(id)
 }
 
 internal fun EventStructureObjectTracker.getOrRegisterValueID(type: Types.Type, value: OpaqueValue?): ValueID {
@@ -118,7 +160,7 @@ internal fun EventStructureObjectTracker.getOrRegisterValueID(type: Types.Type, 
         Types.BOOLEAN_TYPE    ->
             (value.unwrap() as? Boolean)?.toInt()?.toLong() ?:
             (value.unwrap() as Byte).toBoolean().toInt().toLong()
-        Types.LONG_TYPE_BOXED     -> (value.unwrap() as Long)
+        Types.LONG_TYPE_BOXED     -> getOrRegisterBoxedLongId(value.unwrap() as Long)
         Types.INT_TYPE_BOXED      -> (value.unwrap() as Int).toLong()
         Types.BYTE_TYPE_BOXED     -> (value.unwrap() as Byte).toLong()
         Types.SHORT_TYPE_BOXED    -> (value.unwrap() as Short).toLong()

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingStrategy.kt
@@ -496,7 +496,7 @@ internal class LocalObjectManager : BaseObjectTracker() {
      * tracks the thread-locality of objects via the designated flag.
      */
     private class LocalObjectManagerEntry(
-        objNumber: Int,
+        objNumber: Long,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,
@@ -504,7 +504,7 @@ internal class LocalObjectManager : BaseObjectTracker() {
     ) : ObjectEntry(objNumber, objHashCode, objDisplayNumber, objReference)
 
     override fun createObjectEntry(
-        objNumber: Int,
+        objNumber: Long,
         objHashCode: Int,
         objDisplayNumber: Int,
         objReference: WeakReference<Any>,

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.lincheck.execution.*
 import java.util.concurrent.atomic.*
 import java.util.concurrent.locks.LockSupport.*
 import kotlinx.coroutines.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.NULL_OBJECT_NUMBER
 import org.jetbrains.kotlinx.lincheck.util.CancelledResult
 import org.jetbrains.kotlinx.lincheck.util.SuspendedResult
 import org.jetbrains.lincheck.datastructures.Operation
@@ -1131,6 +1132,74 @@ class PrimitivesTest {
             val b1 = getValue<Boolean>(results.parallelResults[1][0]!!)
             val b2 = getValue<Boolean>(results.parallelResults[2][0]!!)
             Triple(r, b1, b2)
+        }
+    }
+
+    @Test
+    fun testBoxedIntegersNullValues() {
+        class TestClass {
+            var x: Int? = null
+
+            fun one(): Int? {
+                return x
+            }
+
+            fun two(): Int? {
+                x = 1
+                return x
+            }
+        }
+
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(TestClass::one)
+                }
+                thread {
+                    actor(TestClass::two)
+                }
+            }
+        }
+
+        val outcomes: Set<Pair<Int?, Int?>> = setOf((null to 1), (1 to 1))
+        litmusTest(TestClass::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            val b1 = getValue<Int?>(results.parallelResults[0][0]!!)
+            val b2 = getValue<Int?>(results.parallelResults[1][0]!!)
+            return@litmusTest b1 to b2
+        }
+    }
+
+    @Test
+    fun testBoxedLongNullValues() {
+        class TestClass {
+            var x: Long? = null
+
+            fun one(): Long? {
+                return x
+            }
+
+            fun two(): Long? {
+                x = NULL_OBJECT_NUMBER
+                return x
+            }
+        }
+
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(TestClass::one)
+                }
+                thread {
+                    actor(TestClass::two)
+                }
+            }
+        }
+
+        val outcomes: Set<Pair<Long?, Long?>> = setOf((null to NULL_OBJECT_NUMBER), (NULL_OBJECT_NUMBER to NULL_OBJECT_NUMBER))
+        litmusTest(TestClass::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            val b1 = getValue<Long?>(results.parallelResults[0][0]!!)
+            val b2 = getValue<Long?>(results.parallelResults[1][0]!!)
+            return@litmusTest b1 to b2
         }
     }
 


### PR DESCRIPTION
This is a bit of an experimental fix to how we handle boxed primitive types and null values.
Previously we had a `NULL_OBJECT_NUMBER` that was equal to 0.
This was not optimal for boxed primitive types as they did not go through the object tracker, but instead their object number was derived from the value of the primitive itself. So int the case where we have a variable of type `Int?' we could not distinguish from `null` and `0`.  

The first fix here is to make the `NULL_OBJECT_NUMBER` equal to `Int.MIN_VALUE - 1`. The object number needs to be preferably negative as to not collide with the incrementing object numbers in the regular object tracker. It also needs to be some value that is outside the range of an int, in order to avoid collisions.

However there persists one issue with boxed longs. To resolve that I have a **highly experimental** suggestion, to just track some subset of Longs which includes `NULL_OBJECT_NUMBER`, i.e `<= NULL_OBJECT_NUMBER` inside the object tracker. 

Sadly the object tracker uses `identityHashCode` for to compare object, which is not what we want for Longs. We want the same long values to be identified by value and not by reference in order to have stable objects ids. So I just made a separate tracker just for the above-mentioned subset of longs. 