### PR TITLE
Using structural equality to support immutable objects in `ObjectTracker`

### DIFF
--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -479,12 +479,12 @@ open class BaseObjectTracker(
     }
 
     fun compareObjects(left: Any?, right: Any?): Boolean {
-        if(left.isImmutable) return left == right
+        if (left.isImmutable && right.isImmutable) return left == right
         else return left === right
     }
 
     private fun getObjectHashCode(obj: Any?): Int {
-        if(obj.isImmutable) return obj.hashCode()
+        if (obj.isImmutable) return obj.hashCode()
         else return System.identityHashCode(obj)
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -475,6 +475,17 @@ open class BaseObjectTracker(
         return perClassObjectNumeration.update(objClassKey, default = offset) { it + 1 }
     }
 
+    fun compareObjects(left: Any?, right: Any?): Boolean {
+        if(left.isImmutable) return left == right
+        else return left === right
+    }
+
+    private fun getObjectHashCode(obj: Any?): Int {
+        if(obj.isImmutable) return obj.hashCode()
+        else return System.identityHashCode(obj)
+    }
+
+
     override fun registerThread(threadId: Int, thread: Thread) {
         registerObjectIfAbsent(thread)
     }
@@ -490,12 +501,11 @@ open class BaseObjectTracker(
         registerObject(ObjectTracker.ObjectKind.EXTERNAL, obj)
 
     private fun registerObject(kind: ObjectTracker.ObjectKind, obj: Any): ObjectEntry {
-        check(!obj.isPrimitive)
         check(obj.isImmutable implies shouldTrackImmutableValues)
         cleanup()
         val entry = createObjectEntry(
             objNumber = ++objectCounter,
-            objHashCode = System.identityHashCode(obj),
+            objHashCode = getObjectHashCode(obj),
             objDisplayNumber = computeObjectDisplayNumber(obj),
             obj = obj,
             kind = kind,
@@ -538,9 +548,9 @@ open class BaseObjectTracker(
     }
 
     override operator fun get(obj: Any?): ObjectEntry? {
-        val objHashCode = System.identityHashCode(obj)
+        val objHashCode = getObjectHashCode(obj)
         val entries = getEntries(objHashCode) ?: return null
-        return entries.find { it.objectWeakReference.get() === obj }
+        return entries.find { compareObjects(it.objectWeakReference.get(), obj) }
     }
 
     override fun enumerateObjectEntries(): Sequence<ObjectEntry> =

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -32,10 +32,12 @@ import kotlin.reflect.KClass
  *
  * The unique object id is a 64-bit integer number, constructed from
  * the object's serial number and its identity hash code.
+ * In the case of immutable objects it hashCode is used instead.
  *
  * The registered objects are associated with the registry entries [ObjectEntry],
- * keeping object's serial number, its identity hash code, a weak reference to the object,
- * and, potentially, other meta-data (defined by the concrete implementations of the interface).
+ * keeping object's serial number, its identity/regular hash code, a weak reference to the object,
+ * an optional strong reference to prevent garbage collection,
+ * and potentially, other meta-data (defined by the concrete implementations of the interface).
  *
  * The tracker allows retrieving the registry entry either by the object reference itself or by unique object id.
  * In this way, the tracker allows to:
@@ -183,6 +185,7 @@ typealias ObjectNumber = Int
  *
  * @property objectNumber A unique serial number for the object.
  * @property objectHashCode The identity hash code of the object.
+ *   If the object is immutable, then its regular hash code is used instead.
  * @property objectDisplayNumber The number used in string representation of the object.
  * @property objectWeakReference A weak reference to the associated object.
  * @property objectKind Whether the object is an external or a new object

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ObjectTracker.kt
@@ -31,8 +31,8 @@ import kotlin.reflect.KClass
  * providing a persistent objects numeration between different re-runs of the same program execution.
  *
  * The unique object id is a 64-bit integer number, constructed from
- * the object's serial number and its identity hash code.
- * In the case of immutable objects it hashCode is used instead.
+* the object's serial number and its identity hash code 
+* (or regular `hashCode` in case of immutable objects).
  *
  * The registered objects are associated with the registry entries [ObjectEntry],
  * keeping object's serial number, its identity/regular hash code, a weak reference to the object,

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/eventstructure/EventStructureObjectTracker.kt
@@ -66,7 +66,7 @@ internal class EventStructureObjectTracker(private val eventStructure: EventStru
         this.initEvent = initEvent
     }
 
-    //NOTE: as in the oringinal ObjectRegistry, if an external object is already registered
+    //NOTE: as in the original ObjectRegistry, if an external object is already registered,
     // we do not register it again.
     // This is because the external object may already exist, which messes up the objectIDs
     override fun registerExternalObject(obj: Any): ObjectEntry =

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -1492,4 +1492,37 @@ class PrimitivesTest {
         }
     }
 
+
+
+    @Test
+    fun testBoxedPrimitives() {
+        class TestClass {
+            var x: Any? = null;
+
+            fun thread0(): Any? {
+                x = 42_000_000
+                return x
+            }
+            fun thread1() {
+                x = "foo"
+            }
+        }
+
+        val testScenario = scenario {
+            parallel {
+                thread {
+                    actor(TestClass::thread0)
+                }
+                thread {
+                    actor(TestClass::thread1)
+                }
+            }
+        }
+
+        val outcomes: Set<Any?> = setOf(42_000_000, "foo")
+        litmusTest(TestClass::class.java, testScenario, outcomes, UNKNOWN) { results ->
+            val b1 = getValue<Any?>(results.parallelResults[0][0]!!)
+            return@litmusTest b1
+        }
+    }
 }

--- a/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
+++ b/lincheck/src/jvm/test/org/jetbrains/kotlinx/lincheck_test/strategy/eventstructure/PrimitivesTest.kt
@@ -1437,9 +1437,6 @@ class PrimitivesTest {
             }
         }
 
-        // TODO: investigate why this test fails on JDK 8
-        Assume.assumeFalse(jdkVersion == JdkVersion.JDK_8)
-
         val outcomes: Set<Unit> = setOf(Unit)
         litmusTest(TestClass::class.java, testScenario, outcomes, UNKNOWN) { _ -> }
     }


### PR DESCRIPTION
This aims to fix the issue where objectTracker cannot handle boxed primitives for fields of type any. @eupp
