### PR TITLE
Park and Unpark thread waiting for awaitTurn.

### DIFF
--- a/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
@@ -76,7 +76,7 @@ class Spinner private constructor(
      * the spin-loop should perform before yielding to other threads.
      */
     fun pollYieldLimit(): Int =
-        1 + if (isSpinning) SPIN_CYCLES_LIMIT else 0
+        1 + if (isSpinning) spinLimit else 0
 
     /**
      * Determines the limit for the number of iterations
@@ -235,4 +235,4 @@ fun SpinnerGroup(nThreads: Int, spinLimit: Int = SPIN_CYCLES_LIMIT): List<Spinne
 
 //NOTE: Should be powers of 2
 const val SPIN_CYCLES_LIMIT: Int = 1_048_576 // 2^20
-const val SPIN_CYCLES_LIMITS_POLL_COUNT = 1024
+const val SPIN_CYCLES_LIMITS_POLL_COUNT = 1024 // 2^10

--- a/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
@@ -9,6 +9,7 @@
  */
 
 package org.jetbrains.lincheck.util
+import java.util.concurrent.locks.LockSupport
 
 /**
  * A spinner implements utility functions for spinning in a loop.
@@ -75,6 +76,13 @@ class Spinner private constructor(
      * the spin-loop should perform before yielding to other threads.
      */
     fun pollYieldLimit(): Int =
+        1 + if (isSpinning) PARK_CYCLES_LIMIT else 0
+
+    /**
+     * Determines the limit for the number of iterations
+     * the spin-loop should perform before parking the current thread
+     */
+    fun pollParkLimit(): Int =
         1 + if (isSpinning) spinLimit else 0
 
     /**
@@ -110,6 +118,28 @@ class Spinner private constructor(
             }
             if (counter % pollCount == 0) {
                 limit = pollYieldLimit()
+            }
+        }
+    }
+
+    /**
+     * Waits in the spin-loop until the given condition is true
+     * with periodical yielding to other threads.
+     *
+     * @param condition A lambda function that determines the condition to wait for.
+     *   The function should return true when the condition is satisfied, and false otherwise.
+     */
+    inline fun spinWaitUntilOrPark(condition: () -> Boolean) {
+        var counter = 0
+        var limit = pollParkLimit()
+        val pollCount = PARK_CYCLES_LIMIT
+        while (!condition()) {
+            counter++
+            if (counter % limit == 0) {
+                LockSupport.park()
+            }
+            if (counter % pollCount == 0) {
+                limit = pollParkLimit()
             }
         }
     }
@@ -205,4 +235,5 @@ fun SpinnerGroup(nThreads: Int, spinLimit: Int = SPIN_CYCLES_LIMIT): List<Spinne
 
 //NOTE: Should be powers of 2
 const val SPIN_CYCLES_LIMIT: Int = 1_048_576 // 2^20
-const val SPIN_CYCLES_LIMITS_POLL_COUNT = 1024 // 2^10
+const val PARK_CYCLES_LIMIT: Int = 1024  // 2^10
+const val SPIN_CYCLES_LIMITS_POLL_COUNT = 1024

--- a/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
+++ b/common/src/main/org/jetbrains/lincheck/util/Spinner.kt
@@ -76,7 +76,7 @@ class Spinner private constructor(
      * the spin-loop should perform before yielding to other threads.
      */
     fun pollYieldLimit(): Int =
-        1 + if (isSpinning) PARK_CYCLES_LIMIT else 0
+        1 + if (isSpinning) SPIN_CYCLES_LIMIT else 0
 
     /**
      * Determines the limit for the number of iterations
@@ -124,7 +124,7 @@ class Spinner private constructor(
 
     /**
      * Waits in the spin-loop until the given condition is true
-     * with periodical yielding to other threads.
+     * and periodically parks thread after spinning for too long.
      *
      * @param condition A lambda function that determines the condition to wait for.
      *   The function should return true when the condition is satisfied, and false otherwise.
@@ -132,7 +132,7 @@ class Spinner private constructor(
     inline fun spinWaitUntilOrPark(condition: () -> Boolean) {
         var counter = 0
         var limit = pollParkLimit()
-        val pollCount = PARK_CYCLES_LIMIT
+        val pollCount = SPIN_CYCLES_LIMITS_POLL_COUNT
         while (!condition()) {
             counter++
             if (counter % limit == 0) {
@@ -235,5 +235,4 @@ fun SpinnerGroup(nThreads: Int, spinLimit: Int = SPIN_CYCLES_LIMIT): List<Spinne
 
 //NOTE: Should be powers of 2
 const val SPIN_CYCLES_LIMIT: Int = 1_048_576 // 2^20
-const val PARK_CYCLES_LIMIT: Int = 1024  // 2^10
 const val SPIN_CYCLES_LIMITS_POLL_COUNT = 1024

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/Runner.kt
@@ -116,6 +116,9 @@ internal abstract class AbstractActiveThreadPoolRunner : Runner {
  * see: https://github.com/JetBrains/lincheck/issues/1008 for details.
  */
 fun Strategy.spinLimit() : Int = when (this) {
-    is ManagedStrategy -> 128          // 2^7
-    else               -> 1_048_576    // 2^20
+    is ManagedStrategy -> MANAGED_STRATEGY_SPIN_LIMIT
+    else               -> DEFAULT_STRATEGY_SPIN_LIMIT
 }
+
+val MANAGED_STRATEGY_SPIN_LIMIT = 128 // 2^7
+val DEFAULT_STRATEGY_SPIN_LIMIT = 1_048_576 // 2^20

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -15,6 +15,7 @@ import sun.nio.ch.lincheck.ThreadDescriptor
 import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.lincheck.util.Spinner
 import java.util.Collections
+import java.util.concurrent.locks.LockSupport
 
 /**
  * Enumeration representing the various states of a thread.
@@ -335,6 +336,8 @@ open class ThreadScheduler {
     fun abortThread(threadId: ThreadId) {
         threads[threadId].apply {
             state = ThreadState.ABORTED
+            val thread = descriptor.thread
+            LockSupport.unpark(thread)
         }
     }
 
@@ -348,6 +351,7 @@ open class ThreadScheduler {
             if (thread.state == ThreadState.FINISHED)
                 continue
             thread.state = ThreadState.ABORTED
+            LockSupport.unpark(thread.descriptor.thread)
         }
     }
 
@@ -362,6 +366,7 @@ open class ThreadScheduler {
             if (thread.state == ThreadState.FINISHED || thread.id == currentThreadId)
                 continue
             thread.state = ThreadState.ABORTED
+            LockSupport.unpark(thread.descriptor.thread)
         }
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -336,8 +336,7 @@ open class ThreadScheduler {
     fun abortThread(threadId: ThreadId) {
         threads[threadId].apply {
             state = ThreadState.ABORTED
-            val thread = descriptor.thread
-            LockSupport.unpark(thread)
+            LockSupport.unpark(descriptor.thread)
         }
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/ThreadScheduler.kt
@@ -10,6 +10,7 @@
 
 package org.jetbrains.kotlinx.lincheck.strategy
 
+import org.jetbrains.kotlinx.lincheck.runner.DEFAULT_STRATEGY_SPIN_LIMIT
 import sun.nio.ch.lincheck.TestThread
 import sun.nio.ch.lincheck.ThreadDescriptor
 import org.jetbrains.kotlinx.lincheck.util.*
@@ -102,16 +103,17 @@ open class ThreadScheduler {
         val id: ThreadId,
         val descriptor: ThreadDescriptor,
         val scheduler: ThreadScheduler,
+        spinLimit: Int,
     ) {
         @Volatile var state: ThreadState = ThreadState.INITIALIZED
 
         @Volatile var blockingReason: BlockingReason? = null
 
-        val spinner: Spinner = Spinner { scheduler.threads.size }
+        val spinner: Spinner = Spinner(spinLimit = spinLimit) { scheduler.threads.size }
     }
 
     protected open fun createThreadData(id: ThreadId, descriptor: ThreadDescriptor): ThreadData {
-        return ThreadData(id, descriptor, this)
+        return ThreadData(id, descriptor, this, DEFAULT_STRATEGY_SPIN_LIMIT)
     }
 
     /**

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
@@ -13,6 +13,7 @@ package org.jetbrains.kotlinx.lincheck.strategy.managed
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.lincheck.util.LincheckAnalysisAbortedError
+import java.util.concurrent.locks.LockSupport
 
 
 /**
@@ -57,6 +58,8 @@ class ManagedThreadScheduler : ThreadScheduler() {
      */
     fun scheduleThread(threadId: Int) {
         scheduledThreadId = threadId
+        val thread = getThread(threadId)
+        LockSupport.unpark(thread)
     }
 
     /**
@@ -88,7 +91,13 @@ class ManagedThreadScheduler : ThreadScheduler() {
             if (threadData.state == ThreadState.ABORTED) {
                 raiseThreadAbortError()
             }
-            scheduledThreadId == threadId
+
+            if(scheduledThreadId == threadId) {
+                return@spinWaitUntil true
+            }
+
+            LockSupport.park()
+            false
         }
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
@@ -87,17 +87,11 @@ class ManagedThreadScheduler : ThreadScheduler() {
     fun awaitTurn(threadId: ThreadId) {
         check(threadId == getCurrentThreadId())
         val threadData = threads[threadId]!!
-        threadData.spinner.spinWaitUntil {
+        threadData.spinner.spinWaitUntilOrPark {
             if (threadData.state == ThreadState.ABORTED) {
                 raiseThreadAbortError()
             }
-
-            if(scheduledThreadId == threadId) {
-                return@spinWaitUntil true
-            }
-
-            LockSupport.park()
-            false
+            scheduledThreadId == threadId
         }
     }
 

--- a/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
+++ b/lincheck/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedThreadScheduler.kt
@@ -10,9 +10,11 @@
 
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
+import org.jetbrains.kotlinx.lincheck.runner.MANAGED_STRATEGY_SPIN_LIMIT
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.util.*
 import org.jetbrains.lincheck.util.LincheckAnalysisAbortedError
+import sun.nio.ch.lincheck.ThreadDescriptor
 import java.util.concurrent.locks.LockSupport
 
 
@@ -93,6 +95,12 @@ class ManagedThreadScheduler : ThreadScheduler() {
             }
             scheduledThreadId == threadId
         }
+    }
+
+    // Override, so we can set the spinLimit of the spinners to something smaller
+    // Note: that preferably the spin limit here should match the spin limit for Strategy.spinLimit
+    override fun createThreadData(id: ThreadId, descriptor: ThreadDescriptor): ThreadData {
+        return ThreadData(id, descriptor, this, MANAGED_STRATEGY_SPIN_LIMIT)
     }
 
     private fun raiseThreadAbortError(): Nothing {


### PR DESCRIPTION
In order to clean up the profiling trace, we now park/unpark the thread in awaitTurn of threadScheduler. Maybe add an option to disable this like in the profiling case?